### PR TITLE
Replatform project to .NET monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Build outputs
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Node
+node_modules/
+dist/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Installer artifacts
+publish/
+artifacts/
+*.zip
+*.pkg
+
+# Secrets
+*.pfx
+appsettings.Local.json
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# HwInventory
+# HW Inventory Platform (Monorepo Skeleton)
+
+This repository provides a .NET 8 and React monorepo scaffold for the HW Inventory platform described in the consolidated specification. The previous Python prototype has been replaced with the target architecture so that future iterations can focus on completing feature depth rather than replatforming.
+
+## Structure
+
+```
+/attachments      Supporting templates and artefacts (placeholders)
+/db               Database migrations and seed data (to be completed)
+/docs             Product documentation (manual, release notes, etc.)
+/scripts          Deployment helpers (IIS installer placeholder)
+/src
+  /api            ASP.NET Core solution (Domain, Application, Infrastructure, Api)
+  /web            React admin application (to be implemented)
+```
+
+### API Solution
+
+The API solution (`src/api/HWInventory.sln`) includes four projects:
+
+* **HWInventory.Domain** – entity definitions for servers, network devices, workstations, audit, RBAC, connectors, labels, and settings.
+* **HWInventory.Application** – shared abstractions (e.g., `IAppDbContext`), paging helpers, and DTOs for application services.
+* **HWInventory.Infrastructure** – EF Core `DbContext`, entity configurations, DI helpers, and initial seed data.
+* **HWInventory.Api** – ASP.NET Core Web API exposing the required endpoints (`/api/servers`, `/api/network-devices`, `/api/workstations`, `/api/dictionaries`, `/api/audit`, `/api/modules`, `/api/dashboard/summary`, `/api/labels/*`).
+
+The API boots with EF Core InMemory by default (until a SQL Server connection string is supplied) and seeds baseline dictionaries, roles, and feature modules. Controllers implement CRUD, soft-retire/restore flows, module toggling, dashboard summaries, and basic label rendering with QuestPDF.
+
+### Remaining Work
+
+The skeleton is intentionally incomplete compared to the full specification. Major follow-up tasks include:
+
+* Implementing authentication/authorization (JWT, policies, 2FA, LDAP/OIDC integration).
+* Finishing audit logging, handover workflows (PDF/email), background jobs, imports/exports, and report scheduling.
+* Completing the React admin (`src/web`) with Vite + Tailwind, dark/light theming, and wizard UX.
+* Creating production-ready installer/build scripts, All-in-One packaging, migrations, and CI pipelines.
+* Finalising documentation, attachments, and smoke tests.
+
+## Getting Started
+
+1. Ensure the .NET 8 SDK is installed.
+2. Restore dependencies and build the solution:
+   ```bash
+   cd src/api
+   dotnet restore
+   dotnet build
+   dotnet run --project src/HWInventory.Api/HWInventory.Api.csproj
+   ```
+3. Browse Swagger UI at `https://localhost:5001/swagger` (or configured URL).
+
+> **Note:** In this environment the .NET SDK and third-party packages (e.g., QuestPDF) are not pre-installed. The project files are provided so that the solution restores and builds once the SDK is available.
+
+## Licensing
+
+QuestPDF is licensed under the Polyform Noncommercial license. Evaluate licensing implications before production use.

--- a/attachments/README.md
+++ b/attachments/README.md
@@ -1,0 +1,3 @@
+# Attachments Placeholder
+
+This folder will host import/export templates, label samples (ZPL/PDF/PNG), email templates, BPMN diagrams, and other artefacts referenced in the delivery checklist. Populate as the corresponding features are implemented.

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,0 +1,3 @@
+# EF Core Migrations Placeholder
+
+Add generated migrations in this directory when scaffolding begins. Each migration should align with SemVer releases and the deployment scripts.

--- a/db/seed/README.md
+++ b/db/seed/README.md
@@ -1,0 +1,3 @@
+# Database Seed Data Placeholder
+
+EF Core seed data currently resides in `HWInventory.Infrastructure`. When full migrations are created, move static CSV/JSON seeds into this directory to be packaged with the installer and All-in-One distribution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# HW Inventory – Architecture Skeleton (v1)
+
+This document captures the initial .NET-based architecture that replaces the earlier Python FastAPI prototype. The structure aligns with the Codex implementation brief and provides a foundation for subsequent feature work.
+
+## Projects Overview
+
+* **HWInventory.Domain** – Entities and enums representing inventory assets, audit logs, RBAC objects, connectors, label templates, and settings. Entities derive from `AuditableEntity` to support audit metadata and soft-state transitions.
+* **HWInventory.Application** – Shared contracts (e.g., `IAppDbContext`), paging helpers, and filter descriptors. Application services can depend on these abstractions without referencing ASP.NET Core directly.
+* **HWInventory.Infrastructure** – EF Core persistence layer with entity configurations, SQL Server/InMemory providers, DI extensions, and seeded baseline data (roles, dictionaries, feature modules).
+* **HWInventory.Api** – ASP.NET Core Web API hosting controllers, swagger, health endpoints, and label rendering helpers (QuestPDF). The API exposes CRUD for servers, network devices, workstations, dictionaries, audit, modules, dashboard summary, and label templates/print jobs.
+
+## Persistence
+
+* EF Core `AppDbContext` manages inventory tables and owned collections for VLAN/IP assignments.
+* Seed data creates baseline dictionaries (environment, WSUS priority, OS, server roles, workstation types, VLAN, locations) and feature modules (labels, reports, Zabbix).
+* Database provider defaults to InMemory when no connection string is configured; relational providers trigger migrations when available.
+
+## API Highlights
+
+* Controllers implement pagination with `X-Total-Count` and RFC5988 `Link` headers (limited to simple next/prev semantics for now).
+* Servers/NetworkDevices/Workstations expose CRUD + retire/restore flows to mirror the specification.
+* Workstation handover endpoint updates ownership/location metadata (email/PDF automation to be delivered later).
+* Modules API toggles feature flags to support optional components (labels, reports, Zabbix, etc.).
+* Dashboard summary aggregates counts and latest audit entries.
+* Labels controller manages templates, renders sample PDF previews via QuestPDF, and captures print job requests (persisted for auditing/queue processing).
+
+## Next Steps
+
+* Introduce authentication/authorization middleware, policy-based enforcement, and LDAP/OIDC connectors.
+* Replace placeholder installer with IIS-aware deployment automation and All-in-One packaging scripts.
+* Expand audit logging to capture diffs and export audit events.
+* Implement background job processing for print jobs, report schedules, and import/export pipelines.
+* Build the React admin UI with module toggles, settings wizard, and dark/light theming.

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,0 +1,8 @@
+param(
+    [string]$PublishPath = "publish",
+    [string]$SiteName = "HWInventory",
+    [string]$AppPoolName = "HWInventoryPool"
+)
+
+Write-Host "[HWInventory] Preparing IIS deployment at $PublishPath" -ForegroundColor Cyan
+Write-Host "This is a placeholder installer script. Implement IIS provisioning, folder permissions, and appsettings patching here." -ForegroundColor Yellow

--- a/src/api/HWInventory.sln
+++ b/src/api/HWInventory.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Api", "src/HWInventory.Api/HWInventory.Api.csproj", "{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Application", "src/HWInventory.Application/HWInventory.Application.csproj", "{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Domain", "src/HWInventory.Domain/HWInventory.Domain.csproj", "{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Infrastructure", "src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj", "{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.Build.0 = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.Build.0 = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.Build.0 = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
@@ -1,0 +1,17 @@
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[ApiController]
+[Produces("application/json")]
+[Route("api/[controller]")]
+public abstract class ApiControllerBase : ControllerBase
+{
+    protected ApiControllerBase(IAppDbContext dbContext)
+    {
+        DbContext = dbContext;
+    }
+
+    protected IAppDbContext DbContext { get; }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuditController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuditController.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/audit")]
+public class AuditController : ApiControllerBase
+{
+    public AuditController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<AuditLog>>> GetAsync([FromQuery] string? entityType, [FromQuery] string? user, [FromQuery] string? action)
+    {
+        var query = DbContext.AuditLogs.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(entityType))
+        {
+            query = query.Where(x => x.EntityType == entityType);
+        }
+        if (!string.IsNullOrWhiteSpace(user))
+        {
+            query = query.Where(x => x.PerformedBy == user);
+        }
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            query = query.Where(x => x.Action == action);
+        }
+
+        var items = await query.OrderByDescending(x => x.PerformedAtUtc).Take(500).ToListAsync();
+        return Ok(items);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dashboard")]
+public class DashboardController : ApiControllerBase
+{
+    public DashboardController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet("summary")]
+    public async Task<ActionResult<DashboardSummaryResponse>> GetSummaryAsync()
+    {
+        var servers = await DbContext.Servers.CountAsync();
+        var network = await DbContext.NetworkDevices.CountAsync();
+        var workstations = await DbContext.Workstations.CountAsync();
+        var latestChanges = await DbContext.AuditLogs.AsNoTracking()
+            .OrderByDescending(x => x.PerformedAtUtc)
+            .Take(10)
+            .Select(x => new AuditEntryDto(x.EntityType, x.Action, x.PerformedBy, x.PerformedAtUtc))
+            .ToListAsync();
+
+        return Ok(new DashboardSummaryResponse(servers, network, workstations, latestChanges));
+    }
+
+    public record DashboardSummaryResponse(int Servers, int NetworkDevices, int Workstations, IReadOnlyCollection<AuditEntryDto> LatestChanges);
+
+    public record AuditEntryDto(string EntityType, string Action, string PerformedBy, DateTime PerformedAtUtc);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dictionaries")]
+public class DictionariesController : ApiControllerBase
+{
+    public DictionariesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<DictionaryEntry>>> GetAsync([FromQuery] string? type)
+    {
+        var query = DbContext.DictionaryEntries.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            query = query.Where(x => x.DictType == type);
+        }
+
+        var result = await query.OrderBy(x => x.DictType).ThenBy(x => x.Order).ThenBy(x => x.Value).ToListAsync();
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> GetByIdAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entry is null ? NotFound() : Ok(entry);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DictionaryEntry>> CreateAsync([FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = new DictionaryEntry
+        {
+            DictType = request.DictType,
+            Key = request.Key,
+            Value = request.Value,
+            Description = request.Description,
+            Order = request.Order,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system"
+        };
+
+        DbContext.DictionaryEntries.Add(entry);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entry.Id }, entry);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> UpdateAsync(Guid id, [FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        entry.DictType = request.DictType;
+        entry.Key = request.Key;
+        entry.Value = request.Value;
+        entry.Description = request.Description;
+        entry.Order = request.Order;
+        entry.ModifiedAtUtc = DateTime.UtcNow;
+        entry.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(entry);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.DictionaryEntries.Remove(entry);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
@@ -1,0 +1,151 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/labels")]
+public class LabelsController : ApiControllerBase
+{
+    public LabelsController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet("templates")]
+    public async Task<ActionResult<IEnumerable<LabelTemplate>>> GetTemplatesAsync()
+    {
+        var templates = await DbContext.LabelTemplates.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(templates);
+    }
+
+    [HttpPost("templates")]
+    public async Task<ActionResult<LabelTemplate>> CreateTemplateAsync([FromBody] LabelTemplate request)
+    {
+        request.Id = Guid.NewGuid();
+        request.CreatedAtUtc = DateTime.UtcNow;
+        request.CreatedBy = User.Identity?.Name ?? "system";
+        DbContext.LabelTemplates.Add(request);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetTemplateByIdAsync), new { id = request.Id }, request);
+    }
+
+    [HttpGet("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> GetTemplateByIdAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return template is null ? NotFound() : Ok(template);
+    }
+
+    [HttpPut("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> UpdateTemplateAsync(Guid id, [FromBody] LabelTemplate request)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        template.Name = request.Name;
+        template.Code = request.Code;
+        template.Format = request.Format;
+        template.Payload = request.Payload;
+        template.Description = request.Description;
+        template.ModifiedAtUtc = DateTime.UtcNow;
+        template.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(template);
+    }
+
+    [HttpDelete("templates/{id:guid}")]
+    public async Task<IActionResult> DeleteTemplateAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.LabelTemplates.Remove(template);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("templates/{id:guid}/render/pdf")]
+    public async Task<IActionResult> RenderPdfAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(10);
+                page.Content().Element(c => c
+                    .Padding(10)
+                    .Border(1)
+                    .Column(col =>
+                    {
+                        col.Item().Text(template.Name).SemiBold().FontSize(18);
+                        col.Item().Text($"Code: {template.Code}");
+                        col.Item().Text("Sample payload preview");
+                        col.Item().Text(template.Payload);
+                    }));
+            });
+        });
+
+        var stream = new MemoryStream();
+        document.GeneratePdf(stream);
+        stream.Position = 0;
+        return File(stream, "application/pdf", $"{template.Code}.pdf");
+    }
+
+    [HttpPost("print-jobs")]
+    public async Task<ActionResult<LabelPrintJob>> CreatePrintJobAsync([FromBody] CreatePrintJobRequest request)
+    {
+        var job = new LabelPrintJob
+        {
+            Target = request.Target,
+            Format = request.Format,
+            Status = "Queued",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system",
+            Items = request.Items.Select(item => new LabelPrintJobItem
+            {
+                AssetId = item.AssetId,
+                AssetType = item.AssetType,
+                Copies = item.Copies
+            }).ToList()
+        };
+
+        DbContext.LabelPrintJobs.Add(job);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetPrintJobByIdAsync), new { id = job.Id }, job);
+    }
+
+    [HttpGet("print-jobs")]
+    public async Task<ActionResult<IEnumerable<LabelPrintJob>>> GetPrintJobsAsync()
+    {
+        var jobs = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items)
+            .OrderByDescending(x => x.CreatedAtUtc).Take(100).ToListAsync();
+        return Ok(jobs);
+    }
+
+    [HttpGet("print-jobs/{id:guid}")]
+    public async Task<ActionResult<LabelPrintJob>> GetPrintJobByIdAsync(Guid id)
+    {
+        var job = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items).FirstOrDefaultAsync(x => x.Id == id);
+        return job is null ? NotFound() : Ok(job);
+    }
+
+    public record CreatePrintJobRequest(string Target, string Format, IReadOnlyCollection<PrintJobItemDto> Items);
+
+    public record PrintJobItemDto(Guid AssetId, string AssetType, int Copies);
+}

--- a/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/modules")]
+public class ModulesController : ApiControllerBase
+{
+    public ModulesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<FeatureModule>>> GetAsync()
+    {
+        var modules = await DbContext.FeatureModules.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(modules);
+    }
+
+    [HttpPost("{key}/toggle")]
+    public async Task<IActionResult> ToggleAsync(string key, [FromQuery] bool? enabled, [FromBody] FeatureModuleToggleRequest? body)
+    {
+        var module = await DbContext.FeatureModules.FirstOrDefaultAsync(x => x.Key == key);
+        if (module is null)
+        {
+            return NotFound();
+        }
+
+        var newState = enabled ?? body?.Enabled ?? !module.Enabled;
+        module.Enabled = newState;
+        module.ModifiedAtUtc = DateTime.UtcNow;
+        module.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(module);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
@@ -1,0 +1,177 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/network-devices")]
+public class NetworkDevicesController : ApiControllerBase
+{
+    public NetworkDevicesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<PagedResult<NetworkDevice>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.NetworkDevices.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("network-devices", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<NetworkDevice>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<NetworkDevice>> GetByIdAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entity is null ? NotFound() : Ok(entity);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<NetworkDevice>> CreateAsync([FromBody] NetworkDeviceRequestDto request)
+    {
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.NetworkDevices.Add(entity);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<NetworkDevice>> UpdateAsync(Guid id, [FromBody] NetworkDeviceRequestDto request)
+    {
+        var entity = await DbContext.NetworkDevices.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    public async Task<IActionResult> RetireAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.NetworkDevices.Remove(entity);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private static NetworkDevice Map(NetworkDeviceRequestDto request)
+    {
+        return new NetworkDevice
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            DeviceTypeId = request.DeviceTypeId,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(NetworkDevice entity, NetworkDeviceRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.DeviceTypeId = request.DeviceTypeId;
+        entity.Manufacturer = request.Manufacturer;
+        entity.Model = request.Model;
+        entity.LocationId = request.LocationId;
+        entity.RackPosition = request.RackPosition;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.SupportUntil = request.SupportUntil;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ServersController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ServersController.cs
@@ -1,0 +1,199 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+public class ServersController : ApiControllerBase
+{
+    public ServersController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<PagedResult<Server>>> GetServersAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.Servers.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = GeneratePaginationLinksStatic("servers", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Server>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Server>> GetServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return server is null ? NotFound() : Ok(server);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Server>> CreateServerAsync([FromBody] ServerRequestDto request)
+    {
+        var server = MapServer(request);
+        server.CreatedAtUtc = DateTime.UtcNow;
+        server.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Servers.Add(server);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetServerAsync), new { id = server.Id }, server);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<Server>> UpdateServerAsync(Guid id, [FromBody] ServerRequestDto request)
+    {
+        var server = await DbContext.Servers.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        UpdateServer(server, request);
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(server);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    public async Task<IActionResult> RetireServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        server.Status = EntityStatus.Retired;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        server.Status = EntityStatus.Active;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.Servers.Remove(server);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    internal static string GeneratePaginationLinksStatic(string route, int page, int size, int total)
+    {
+        var links = new List<string>();
+        var lastPage = (int)Math.Ceiling(total / (double)size);
+        if (page > 1)
+        {
+            links.Add($"</api/{route}?page=1&size={size}>; rel=\"first\"");
+            links.Add($"</api/{route}?page={page - 1}&size={size}>; rel=\"prev\"");
+        }
+        if (page < lastPage)
+        {
+            links.Add($"</api/{route}?page={page + 1}&size={size}>; rel=\"next\"");
+            links.Add($"</api/{route}?page={lastPage}&size={size}>; rel=\"last\"");
+        }
+        return string.Join(", ", links);
+    }
+
+    private static Server MapServer(ServerRequestDto request)
+    {
+        return new Server
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            EnvironmentId = request.EnvironmentId,
+            WsusPriorityId = request.WsusPriorityId,
+            OperatingSystemId = request.OperatingSystemId,
+            ServerRoleId = request.ServerRoleId,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments
+                .Select(x => new NetworkEndpoint { Label = x.Label, VlanId = x.VlanId, IpAddress = x.IpAddress })
+                .ToList()
+        };
+    }
+
+    private static void UpdateServer(Server server, ServerRequestDto request)
+    {
+        server.Name = request.Name;
+        server.InventoryNumber = request.InventoryNumber;
+        server.Manufacturer = request.Manufacturer;
+        server.Model = request.Model;
+        server.EnvironmentId = request.EnvironmentId;
+        server.WsusPriorityId = request.WsusPriorityId;
+        server.OperatingSystemId = request.OperatingSystemId;
+        server.ServerRoleId = request.ServerRoleId;
+        server.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        server.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        server.LocationId = request.LocationId;
+        server.RackPosition = request.RackPosition;
+        server.PurchasedAt = request.PurchasedAt;
+        server.SupportUntil = request.SupportUntil;
+        server.Notes = request.Notes;
+
+        server.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            server.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
@@ -1,0 +1,222 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/workstations")]
+public class WorkstationsController : ApiControllerBase
+{
+    public WorkstationsController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<PagedResult<Workstation>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.Workstations.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("workstations", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Workstation>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Workstation>> GetByIdAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entity is null ? NotFound() : Ok(entity);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Workstation>> CreateAsync([FromBody] WorkstationRequestDto request)
+    {
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Workstations.Add(entity);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<Workstation>> UpdateAsync(Guid id, [FromBody] WorkstationRequestDto request)
+    {
+        var entity = await DbContext.Workstations.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/handover")]
+    public async Task<ActionResult> HandoverAsync(Guid id, [FromBody] HandoverRequest request)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.OwnerId = request.NewOwnerId;
+        entity.OwnerDisplayName = request.NewOwnerDisplayName;
+        entity.OwnerDepartment = request.NewOwnerDepartment;
+        entity.LocationId = request.NewLocationId;
+        entity.LocationNote = request.NewLocationNote;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    public async Task<IActionResult> RetireAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    public async Task<IActionResult> RestoreAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.Workstations.Remove(entity);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private static Workstation Map(WorkstationRequestDto request)
+    {
+        return new Workstation
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            OperatingSystemId = request.OperatingSystemId,
+            WorkstationTypeId = request.WorkstationTypeId,
+            OwnerId = request.OwnerId,
+            OwnerDisplayName = request.OwnerDisplayName,
+            OwnerDepartment = request.OwnerDepartment,
+            LocationId = request.LocationId,
+            LocationNote = request.LocationNote,
+            Cpu = request.Cpu,
+            Ram = request.Ram,
+            Storage = request.Storage,
+            MacAddress = request.MacAddress,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(Workstation entity, WorkstationRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.OperatingSystemId = request.OperatingSystemId;
+        entity.WorkstationTypeId = request.WorkstationTypeId;
+        entity.OwnerId = request.OwnerId;
+        entity.OwnerDisplayName = request.OwnerDisplayName;
+        entity.OwnerDepartment = request.OwnerDepartment;
+        entity.LocationId = request.LocationId;
+        entity.LocationNote = request.LocationNote;
+        entity.Cpu = request.Cpu;
+        entity.Ram = request.Ram;
+        entity.Storage = request.Storage;
+        entity.MacAddress = request.MacAddress;
+        entity.PurchasedAt = request.PurchasedAt;
+        entity.SupportUntil = request.SupportUntil;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+
+    public record HandoverRequest(
+        Guid? NewOwnerId,
+        string? NewOwnerDisplayName,
+        string? NewOwnerDepartment,
+        Guid NewLocationId,
+        string? NewLocationNote,
+        Guid? NewAdminId,
+        IReadOnlyCollection<string>? Emails,
+        string? Comment);
+}

--- a/src/api/src/HWInventory.Api/HWInventory.Api.csproj
+++ b/src/api/src/HWInventory.Api/HWInventory.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Infrastructure/HWInventory.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Api.Models;
+
+public record DictionaryEntryRequestDto(
+    string DictType,
+    string Key,
+    string Value,
+    string? Description,
+    int Order);

--- a/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
+++ b/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record FeatureModuleToggleRequest(bool Enabled);

--- a/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkDeviceRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid DeviceTypeId,
+    string Manufacturer,
+    string Model,
+    Guid LocationId,
+    string? RackPosition,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkEndpointDto(string Label, Guid? VlanId, string? IpAddress);

--- a/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Api.Models;
+
+public record ServerRequestDto(
+    string Name,
+    string InventoryNumber,
+    string Manufacturer,
+    string Model,
+    Guid EnvironmentId,
+    Guid WsusPriorityId,
+    Guid OperatingSystemId,
+    Guid ServerRoleId,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    Guid LocationId,
+    string? RackPosition,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
@@ -1,0 +1,22 @@
+namespace HWInventory.Api.Models;
+
+public record WorkstationRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid OperatingSystemId,
+    Guid WorkstationTypeId,
+    Guid? OwnerId,
+    string? OwnerDisplayName,
+    string? OwnerDepartment,
+    Guid LocationId,
+    string? LocationNote,
+    string Cpu,
+    string Ram,
+    string Storage,
+    string MacAddress,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Program.cs
+++ b/src/api/src/HWInventory.Api/Program.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using HWInventory.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using QuestPDF.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+QuestPDF.Settings.License = LicenseType.Community;
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status400BadRequest));
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status404NotFound));
+}).AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("default", policy =>
+    {
+        policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin();
+    });
+});
+
+var app = builder.Build();
+
+await app.InitializeDatabaseAsync();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("default");
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
+
+await app.RunAsync();

--- a/src/api/src/HWInventory.Api/appsettings.Development.json
+++ b/src/api/src/HWInventory.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/api/src/HWInventory.Api/appsettings.json
+++ b/src/api/src/HWInventory.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
@@ -1,0 +1,21 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IAppDbContext
+{
+    DbSet<Server> Servers { get; }
+    DbSet<NetworkDevice> NetworkDevices { get; }
+    DbSet<Workstation> Workstations { get; }
+    DbSet<DictionaryEntry> DictionaryEntries { get; }
+    DbSet<AuditLog> AuditLogs { get; }
+    DbSet<LabelTemplate> LabelTemplates { get; }
+    DbSet<LabelPrintJob> LabelPrintJobs { get; }
+    DbSet<AppUser> Users { get; }
+    DbSet<AppRole> Roles { get; }
+    DbSet<FeatureModule> FeatureModules { get; }
+    DbSet<AppSetting> Settings { get; }
+    DbSet<ConnectorProfile> ConnectorProfiles { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
+++ b/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Common;
+
+public class FilterDescriptor
+{
+    public string Field { get; init; } = string.Empty;
+    public string Operator { get; init; } = string.Empty;
+    public string? Value { get; init; }
+}

--- a/src/api/src/HWInventory.Application/Common/PagedResult.cs
+++ b/src/api/src/HWInventory.Application/Common/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Application.Common;
+
+public class PagedResult<T>
+{
+    public IReadOnlyCollection<T> Items { get; init; } = Array.Empty<T>();
+    public int TotalCount { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/api/src/HWInventory.Application/HWInventory.Application.csproj
+++ b/src/api/src/HWInventory.Application/HWInventory.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Entities/AppRole.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppRole.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppRole : BaseEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public ICollection<AppUserRole> UserRoles { get; set; } = new List<AppUserRole>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppSetting : AuditableEntity
+{
+    public string Section { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public bool IsSecret { get; set; }
+    public bool IsMasked => IsSecret && !string.IsNullOrEmpty(Value);
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppUser.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppUser.cs
@@ -1,0 +1,14 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppUser : AuditableEntity
+{
+    public string UserName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool IsDomainAccount { get; set; }
+    public bool TwoFactorEnabled { get; set; }
+    public bool TwoFactorRequired { get; set; }
+    public string? Department { get; set; }
+    public ICollection<AppUserRole> UserRoles { get; set; } = new List<AppUserRole>();
+    public ICollection<DataScope> DataScopes { get; set; } = new List<DataScope>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppUserRole.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppUserRole.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppUserRole
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid AppRoleId { get; set; }
+    public AppRole AppRole { get; set; } = default!;
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Domain.Entities;
+
+public class AuditLog : BaseEntity
+{
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string PerformedBy { get; set; } = string.Empty;
+    public string? Roles { get; set; }
+    public DateTime PerformedAtUtc { get; set; }
+    public string? ChangeSummary { get; set; }
+    public string? ChangedFieldsJson { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+}

--- a/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Domain.Entities;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
@@ -1,0 +1,12 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorProfile : AuditableEntity
+{
+    public string Type { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public bool Enabled { get; set; }
+    public string? ConfigurationJson { get; set; }
+    public string? HealthStatus { get; set; }
+    public DateTime? LastTestedAtUtc { get; set; }
+    public ICollection<ConnectorSecret> Secrets { get; set; } = new List<ConnectorSecret>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorSecret : BaseEntity
+{
+    public Guid ConnectorProfileId { get; set; }
+    public ConnectorProfile ConnectorProfile { get; set; } = default!;
+    public string Key { get; set; } = string.Empty;
+    public string SecretReference { get; set; } = string.Empty;
+    public DateTime? RotatedAtUtc { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/DataScope.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DataScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class DataScope : BaseEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid? DepartmentId { get; set; }
+    public Guid? LocationId { get; set; }
+    public string ScopeType { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class DictionaryEntry : AuditableEntity
+{
+    public string DictType { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int Order { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
+++ b/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class FeatureModule : AuditableEntity
+{
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool Enabled { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJob : AuditableEntity
+{
+    public string Target { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string Status { get; set; } = "Pending";
+    public string? ArtifactPath { get; set; }
+    public ICollection<LabelPrintJobItem> Items { get; set; } = new List<LabelPrintJobItem>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJobItem : BaseEntity
+{
+    public Guid LabelPrintJobId { get; set; }
+    public Guid AssetId { get; set; }
+    public string AssetType { get; set; } = string.Empty;
+    public int Copies { get; set; } = 1;
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelTemplate : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Format { get; set; } = "ZPL";
+    public string Payload { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
+++ b/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class NetworkDevice : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid DeviceTypeId { get; set; }
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/Server.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Server.cs
@@ -1,0 +1,24 @@
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Server : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid EnvironmentId { get; set; }
+    public Guid WsusPriorityId { get; set; }
+    public Guid OperatingSystemId { get; set; }
+    public Guid ServerRoleId { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/Workstation.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Workstation.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Workstation : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid OperatingSystemId { get; set; }
+    public Guid WorkstationTypeId { get; set; }
+    public Guid? OwnerId { get; set; }
+    public string? OwnerDisplayName { get; set; }
+    public string? OwnerDepartment { get; set; }
+    public Guid LocationId { get; set; }
+    public string? LocationNote { get; set; }
+    public string Cpu { get; set; } = string.Empty;
+    public string Ram { get; set; } = string.Empty;
+    public string Storage { get; set; } = string.Empty;
+    public string MacAddress { get; set; } = string.Empty;
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum EntityStatus
+{
+    Active = 1,
+    Retired = 2
+}

--- a/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
+++ b/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
@@ -1,0 +1,11 @@
+namespace HWInventory.Domain.Enums;
+
+public static class SystemRoleNames
+{
+    public const string SuperAdmin = "SuperAdmin";
+    public const string ServerAdmin = "SRV Administrator";
+    public const string NetworkAdmin = "NET Administrator";
+    public const string AppAdmin = "Aplikační admin";
+    public const string Helpdesk = "Helpdesk";
+    public const string HelpdeskRead = "Helpdesk Read";
+}

--- a/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
+++ b/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
+++ b/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.ValueObjects;
+
+public class NetworkEndpoint
+{
+    public string Label { get; set; } = string.Empty;
+    public Guid? VlanId { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
+++ b/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,27 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HWInventory.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase("hwinventory"));
+        }
+        else
+        {
+            services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
+        }
+
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+
+        return services;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
+++ b/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
+++ b/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
@@ -1,0 +1,27 @@
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace HWInventory.Infrastructure;
+
+public static class HostExtensions
+{
+    public static async Task<IHost> InitializeDatabaseAsync(this IHost host, CancellationToken cancellationToken = default)
+    {
+        using var scope = host.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        if (context.Database.IsRelational())
+        {
+            await context.Database.MigrateAsync(cancellationToken);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        await SeedData.InitializeAsync(context, cancellationToken);
+        return host;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,31 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext, IAppDbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Server> Servers => Set<Server>();
+    public DbSet<NetworkDevice> NetworkDevices => Set<NetworkDevice>();
+    public DbSet<Workstation> Workstations => Set<Workstation>();
+    public DbSet<DictionaryEntry> DictionaryEntries => Set<DictionaryEntry>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<LabelTemplate> LabelTemplates => Set<LabelTemplate>();
+    public DbSet<LabelPrintJob> LabelPrintJobs => Set<LabelPrintJob>();
+    public DbSet<AppUser> Users => Set<AppUser>();
+    public DbSet<AppRole> Roles => Set<AppRole>();
+    public DbSet<FeatureModule> FeatureModules => Set<FeatureModule>();
+    public DbSet<AppSetting> Settings => Set<AppSetting>();
+    public DbSet<ConnectorProfile> ConnectorProfiles => Set<ConnectorProfile>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppRoleConfiguration : IEntityTypeConfiguration<AppRole>
+{
+    public void Configure(EntityTypeBuilder<AppRole> builder)
+    {
+        builder.ToTable("Roles");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppSettingConfiguration : IEntityTypeConfiguration<AppSetting>
+{
+    public void Configure(EntityTypeBuilder<AppSetting> builder)
+    {
+        builder.ToTable("AppSettings");
+        builder.Property(x => x.Section).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
@@ -1,0 +1,22 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.ToTable("Users");
+        builder.Property(x => x.UserName).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.DisplayName).HasMaxLength(200);
+        builder.Property(x => x.Email).HasMaxLength(320);
+        builder.HasMany(x => x.UserRoles)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+        builder.HasMany(x => x.DataScopes)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserRoleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserRoleConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppUserRoleConfiguration : IEntityTypeConfiguration<AppUserRole>
+{
+    public void Configure(EntityTypeBuilder<AppUserRole> builder)
+    {
+        builder.ToTable("UserRoles");
+        builder.HasKey(x => new { x.AppUserId, x.AppRoleId });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+{
+    public void Configure(EntityTypeBuilder<AuditLog> builder)
+    {
+        builder.ToTable("AuditLogs");
+        builder.Property(x => x.EntityType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Action).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.PerformedBy).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorProfileConfiguration : IEntityTypeConfiguration<ConnectorProfile>
+{
+    public void Configure(EntityTypeBuilder<ConnectorProfile> builder)
+    {
+        builder.ToTable("ConnectorProfiles");
+        builder.Property(x => x.Type).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Alias).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.HealthStatus).HasMaxLength(50);
+        builder.HasMany(x => x.Secrets)
+            .WithOne(x => x.ConnectorProfile)
+            .HasForeignKey(x => x.ConnectorProfileId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorSecretConfiguration : IEntityTypeConfiguration<ConnectorSecret>
+{
+    public void Configure(EntityTypeBuilder<ConnectorSecret> builder)
+    {
+        builder.ToTable("ConnectorSecrets");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.SecretReference).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DataScopeConfiguration : IEntityTypeConfiguration<DataScope>
+{
+    public void Configure(EntityTypeBuilder<DataScope> builder)
+    {
+        builder.ToTable("DataScopes");
+        builder.Property(x => x.ScopeType).HasMaxLength(100).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DictionaryEntryConfiguration : IEntityTypeConfiguration<DictionaryEntry>
+{
+    public void Configure(EntityTypeBuilder<DictionaryEntry> builder)
+    {
+        builder.ToTable("DictionaryEntries");
+        builder.Property(x => x.DictType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class FeatureModuleConfiguration : IEntityTypeConfiguration<FeatureModule>
+{
+    public void Configure(EntityTypeBuilder<FeatureModule> builder)
+    {
+        builder.ToTable("FeatureModules");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobConfiguration : IEntityTypeConfiguration<LabelPrintJob>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJob> builder)
+    {
+        builder.ToTable("LabelPrintJobs");
+        builder.Property(x => x.Target).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.Status).HasMaxLength(50).IsRequired();
+        builder.HasMany(x => x.Items)
+            .WithOne()
+            .HasForeignKey(x => x.LabelPrintJobId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobItemConfiguration : IEntityTypeConfiguration<LabelPrintJobItem>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJobItem> builder)
+    {
+        builder.ToTable("LabelPrintJobItems");
+        builder.Property(x => x.AssetType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Copies).HasDefaultValue(1);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelTemplateConfiguration : IEntityTypeConfiguration<LabelTemplate>
+{
+    public void Configure(EntityTypeBuilder<LabelTemplate> builder)
+    {
+        builder.ToTable("LabelTemplates");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Code).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).HasDefaultValue("ZPL");
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class NetworkDeviceConfiguration : IEntityTypeConfiguration<NetworkDevice>
+{
+    public void Configure(EntityTypeBuilder<NetworkDevice> builder)
+    {
+        builder.ToTable("NetworkDevices");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("NetworkDeviceAssignments");
+            nb.WithOwner().HasForeignKey("NetworkDeviceId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ServerConfiguration : IEntityTypeConfiguration<Server>
+{
+    public void Configure(EntityTypeBuilder<Server> builder)
+    {
+        builder.ToTable("Servers");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("ServerNetworkAssignments");
+            nb.WithOwner().HasForeignKey("ServerId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
@@ -1,0 +1,28 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class WorkstationConfiguration : IEntityTypeConfiguration<Workstation>
+{
+    public void Configure(EntityTypeBuilder<Workstation> builder)
+    {
+        builder.ToTable("Workstations");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Cpu).HasMaxLength(200);
+        builder.Property(x => x.Ram).HasMaxLength(100);
+        builder.Property(x => x.Storage).HasMaxLength(200);
+        builder.Property(x => x.MacAddress).HasMaxLength(100).IsRequired();
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("WorkstationNetworkAssignments");
+            nb.WithOwner().HasForeignKey("WorkstationId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
@@ -1,0 +1,72 @@
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public static class SeedData
+{
+    private static readonly (string Dict, string Key, string Value)[] DictionarySeeds =
+    {
+        ("Environment", "PROD", "Production"),
+        ("Environment", "TEST", "Testing"),
+        ("Environment", "DEV", "Development"),
+        ("WsusPriority", "HIGH", "Vysoká"),
+        ("WsusPriority", "NORMAL", "Standard"),
+        ("OperatingSystem", "WIN2022", "Windows Server 2022"),
+        ("OperatingSystem", "WIN11", "Windows 11"),
+        ("ServerRole", "APP", "Application Server"),
+        ("ServerRole", "DB", "Database Server"),
+        ("WorkstationType", "PC", "Desktop"),
+        ("WorkstationType", "LAPTOP", "Notebook"),
+        ("Location", "HQ-1F", "HQ 1st Floor"),
+        ("Location", "HQ-2F", "HQ 2nd Floor"),
+        ("VLAN", "VLAN10", "Production 10"),
+        ("VLAN", "VLAN20", "DMZ 20"),
+    };
+
+    public static async Task InitializeAsync(AppDbContext context, CancellationToken cancellationToken = default)
+    {
+        await context.Database.EnsureCreatedAsync(cancellationToken);
+
+        if (!await context.Roles.AnyAsync(cancellationToken))
+        {
+            context.Roles.AddRange(new[]
+            {
+                new AppRole { Name = SystemRoleNames.SuperAdmin },
+                new AppRole { Name = SystemRoleNames.ServerAdmin },
+                new AppRole { Name = SystemRoleNames.NetworkAdmin },
+                new AppRole { Name = SystemRoleNames.AppAdmin },
+                new AppRole { Name = SystemRoleNames.Helpdesk },
+                new AppRole { Name = SystemRoleNames.HelpdeskRead }
+            });
+        }
+
+        foreach (var seed in DictionarySeeds)
+        {
+            if (!await context.DictionaryEntries.AnyAsync(x => x.DictType == seed.Dict && x.Key == seed.Key, cancellationToken))
+            {
+                context.DictionaryEntries.Add(new DictionaryEntry
+                {
+                    DictType = seed.Dict,
+                    Key = seed.Key,
+                    Value = seed.Value,
+                    CreatedAtUtc = DateTime.UtcNow,
+                    CreatedBy = "seed"
+                });
+            }
+        }
+
+        if (!await context.FeatureModules.AnyAsync(cancellationToken))
+        {
+            context.FeatureModules.AddRange(new[]
+            {
+                new FeatureModule { Key = "labels", Name = "Labels & Printing", Enabled = true, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "reports", Name = "Reports & Schedules", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "zabbix", Name = "Zabbix Metrics", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" }
+            });
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,0 +1,10 @@
+# HW Inventory Admin UI (Placeholder)
+
+The React + Vite + Tailwind admin application will live in this directory. Upcoming milestones:
+
+1. Scaffold Vite project structure with routing, layout shell, and Tailwind theme tokens.
+2. Implement authentication shell (login, MFA prompt) integrated with the API once auth is available.
+3. Build pages for dashboard, servers, network, workstations, dictionaries, audit, labels, modules, and settings (including the onboarding wizard).
+4. Connect to API endpoints, implement pagination/filtering, and render label previews.
+
+Until the UI is generated the directory contains documentation placeholders only.


### PR DESCRIPTION
## Summary
- replace the previous Python FastAPI prototype with a .NET 8 monorepo structure containing Domain, Application, Infrastructure, and API projects
- scaffold EF Core persistence with seeded dictionaries/roles, feature modules, and CRUD controllers for servers, network devices, workstations, dictionaries, audit, dashboard, modules, and labels
- add QuestPDF-powered label template rendering, initial print job persistence, deployment placeholder scripts, and updated documentation describing the new architecture and next steps

## Testing
- not run (dotnet SDK and package restore unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e519d659008324a7e28854833a88fb