### PR TITLE
Add authorization policies and secure API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Build outputs
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Node
+node_modules/
+dist/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Installer artifacts
+publish/
+artifacts/
+*.zip
+*.pkg
+
+# Secrets
+*.pfx
+appsettings.Local.json
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# HwInventory
+# HW Inventory Platform (Monorepo Skeleton)
+
+This repository provides a .NET 8 and React monorepo scaffold for the HW Inventory platform described in the consolidated specification. The previous Python prototype has been replaced with the target architecture so that future iterations can focus on completing feature depth rather than replatforming.
+
+> **Status:** the solution is **not** production-ready. The current codebase now boots with SQL Server, ASP.NET Core Identity (including TOTP 2FA scaffolding), baseline policy-based RBAC guard rails, persistent audit logging, Quartz.NET job scheduling, a label rendering engine, and a React admin shell with dark/light theming. However, the majority of domain workflows (handover, imports/exports, backups, updates, connectors, RBAC scoping, onboarding wizard, etc.) are still outstanding—see [`docs/implementation-plan.md`](docs/implementation-plan.md) for the full backlog.
+
+## Structure
+
+```
+/attachments      Supporting templates and artefacts (placeholders)
+/db               Database migrations and seed data (to be completed)
+/docs             Product documentation (manual, release notes, etc.)
+/scripts          Deployment helpers (IIS installer placeholder)
+/src
+  /api            ASP.NET Core solution (Domain, Application, Infrastructure, Api)
+  /web            React admin shell (Vite + Tailwind, dark/light theme toggle)
+```
+
+### API Solution
+
+The API solution (`src/api/HWInventory.sln`) includes four projects:
+
+* **HWInventory.Domain** – entity definitions for servers, network devices, workstations, audit, RBAC, connectors, labels, and settings.
+* **HWInventory.Application** – shared abstractions (e.g., `IAppDbContext`), paging helpers, and DTOs for application services.
+* **HWInventory.Infrastructure** – EF Core `DbContext`, SQL Server migrations, Identity integration, Quartz.NET job wiring, label rendering services, and initial seed data.
+* **HWInventory.Api** – ASP.NET Core Web API exposing the required endpoints (`/api/servers`, `/api/network-devices`, `/api/workstations`, `/api/dictionaries`, `/api/audit`, `/api/modules`, `/api/dashboard/summary`, `/api/labels/*`, `/api/auth/*`).
+
+The API defaults to SQL Server (LocalDB for development, configurable via `appsettings.json`), runs migrations on startup, and seeds baseline dictionaries, roles, and feature modules. Controllers implement CRUD, soft-retire/restore flows, module toggling, dashboard summaries, label rendering (QuestPDF + ZPL), and `/api/auth` endpoints for profile introspection plus TOTP enrollment. Background processing is orchestrated through Quartz.NET (`LabelPrintJobProcessor`).
+
+### Remaining Work
+
+The skeleton is intentionally incomplete compared to the full specification. Major follow-up tasks include (see the implementation plan for detail):
+
+* Hardening authentication/authorization (SSPR, LDAP/OIDC integration, scoped data filters, CAPTCHA, session management) with auditable scope controls.
+* Migrating to SQL Server with EF Core migrations, seeders, background jobs, and persistent audit logging.
+* Building the React admin (`src/web`) with onboarding wizard, dark/light theming, feature pages, and contextual help.
+* Delivering domain workflows: workstation handover PDFs/e-mails, label management and printing, imports/exports with jobs, reports & schedules, connectors catalogue, backups/restores, updates, observability, Help Center.
+* Completing packaging: installer scripts, All-in-One builder, GitHub Actions, documentation set (manual, release notes, deployment guide), and smoke tests.
+
+### Suggested execution order
+
+If you are planning the next development iteration, tackle the milestones in this order (summarised from the implementation plan):
+
+1. **Foundations & persistence** – move to SQL Server, produce migrations, seed data, configuration options, and job scheduling infrastructure.
+2. **Identity & security** – wire up Identity, 2FA, SSPR, CAPTCHA, scoped RBAC, and the onboarding wizard steps that exercise SMTP/LDAP connectivity.
+3. **Inventory workflows** – finish CRUD, audit diffing, VLAN/IP enforcement, handover PDFs/e-mails, labels, imports/exports, and async jobs.
+4. **Operations & integrations** – connectors catalogue, Updates, Backup & Restore, Reports & Schedules, Observability dashboards.
+5. **Frontend completion** – full React admin, theming, contextual help/manual integration, UI automation tests.
+6. **Packaging & release** – installers, builder scripts, GitHub Actions, All-in-One ZIP with SHA256, documentation, and smoke/regression test suites.
+
+## Getting Started
+
+1. Ensure the .NET 8 SDK is installed.
+2. Restore dependencies and build the solution:
+   ```bash
+   cd src/api
+   dotnet restore
+   dotnet build
+   dotnet run --project src/HWInventory.Api/HWInventory.Api.csproj
+   ```
+3. Browse Swagger UI at `https://localhost:5001/swagger` (or configured URL).
+
+> **Note:** In this environment the .NET SDK and third-party packages (e.g., QuestPDF) are not pre-installed. The project files are provided so that the solution restores and builds once the SDK is available.
+
+## Licensing
+
+QuestPDF is licensed under the Polyform Noncommercial license. Evaluate licensing implications before production use.

--- a/attachments/README.md
+++ b/attachments/README.md
@@ -1,0 +1,3 @@
+# Attachments Placeholder
+
+This folder will host import/export templates, label samples (ZPL/PDF/PNG), email templates, BPMN diagrams, and other artefacts referenced in the delivery checklist. Populate as the corresponding features are implemented.

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,0 +1,3 @@
+# EF Core Migrations Placeholder
+
+Runtime migrations now live under `src/api/src/HWInventory.Infrastructure/Migrations` so that they compile with the API solution. Use this folder to store exported SQL scripts (if required for DBA review) or versioned documentation about migration batches that accompany the packaged releases.

--- a/db/seed/README.md
+++ b/db/seed/README.md
@@ -1,0 +1,3 @@
+# Database Seed Data Placeholder
+
+EF Core seed data currently resides in `HWInventory.Infrastructure`. When full migrations are created, move static CSV/JSON seeds into this directory to be packaged with the installer and All-in-One distribution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# HW Inventory – Architecture Skeleton (v1)
+
+This document captures the initial .NET-based architecture that replaces the earlier Python FastAPI prototype. The structure aligns with the Codex implementation brief and provides a foundation for subsequent feature work.
+
+## Projects Overview
+
+* **HWInventory.Domain** – Entities and enums representing inventory assets, audit logs, RBAC objects, connectors, label templates, and settings. Entities derive from `AuditableEntity` to support audit metadata and soft-state transitions.
+* **HWInventory.Application** – Shared contracts (e.g., `IAppDbContext`), paging helpers, and filter descriptors. Application services can depend on these abstractions without referencing ASP.NET Core directly.
+* **HWInventory.Infrastructure** – EF Core persistence layer with entity configurations, SQL Server/InMemory providers, DI extensions, and seeded baseline data (roles, dictionaries, feature modules).
+* **HWInventory.Api** – ASP.NET Core Web API hosting controllers, swagger, health endpoints, and label rendering helpers (QuestPDF). The API exposes CRUD for servers, network devices, workstations, dictionaries, audit, modules, dashboard summary, and label templates/print jobs.
+
+## Persistence
+
+* EF Core `AppDbContext` manages inventory tables and owned collections for VLAN/IP assignments.
+* Seed data creates baseline dictionaries (environment, WSUS priority, OS, server roles, workstation types, VLAN, locations) and feature modules (labels, reports, Zabbix).
+* Database provider defaults to InMemory when no connection string is configured; relational providers trigger migrations when available.
+
+## API Highlights
+
+* Controllers implement pagination with `X-Total-Count` and RFC5988 `Link` headers (limited to simple next/prev semantics for now).
+* Servers/NetworkDevices/Workstations expose CRUD + retire/restore flows to mirror the specification.
+* Workstation handover endpoint updates ownership/location metadata (email/PDF automation to be delivered later).
+* Modules API toggles feature flags to support optional components (labels, reports, Zabbix, etc.).
+* Dashboard summary aggregates counts and latest audit entries.
+* Labels controller manages templates, renders sample PDF previews via QuestPDF, and captures print job requests (persisted for auditing/queue processing).
+
+## Next Steps
+
+* Introduce authentication/authorization middleware, policy-based enforcement, and LDAP/OIDC connectors.
+* Replace placeholder installer with IIS-aware deployment automation and All-in-One packaging scripts.
+* Expand audit logging to capture diffs and export audit events.
+* Implement background job processing for print jobs, report schedules, and import/export pipelines.
+* Build the React admin UI with module toggles, settings wizard, and dark/light theming.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,155 @@
+# HW Inventory Platform – Implementation Plan
+
+This document enumerates the outstanding work required to transform the current monorepo skeleton into a production-ready release that satisfies the full specification from the "HW Inventory – Zadání pro Codex" document. Items are grouped by thematic area and capture dependencies where relevant.
+
+## 1. Platform Foundations
+- **Adopt SQL Server persistence**
+  - Replace the InMemory provider with SQL Server across all environments.
+  - Create comprehensive EF Core migrations for the domain model (servers, network devices, workstations, dictionaries, users/roles, audit, connectors, labels, jobs, reports, backups, updates, settings, modules, etc.).
+  - Seed baseline dictionaries, RBAC roles, feature modules, connectors, and system settings with idempotent scripts.
+- **Configuration model**
+  - Introduce strongly-typed options for App Configuration, Security & Auth, LDAP, SMTP, Connectors, Reports, Import/Export, Maintenance, Observability, Advanced, About/Support, Handover, Updates, Backup & Restore.
+  - Ensure secrets are stored encrypted (DPAPI on Windows / AES-256 elsewhere) and surfaced in the UI as "set/unset" flags with reset flows.
+- **Background job infrastructure**
+  - Integrate Quartz.NET (or Hangfire if selected) for scheduled jobs (LDAP sync, reports, backups, exports, print jobs, maintenance, observability health checks).
+  - Design persistence tables for job definitions, executions, locks, and audit.
+
+## 2. Security, Identity, and RBAC
+- **Identity provider**
+  - Implement ASP.NET Core Identity with support for local accounts and Active Directory/LDAP linked identities.
+  - Add password policies (complexity, expiry, history) and lockout rules in line with the specification.
+- **Authentication mechanisms**
+  - Enable cookie-based sessions for the admin UI plus JWT/OIDC for API access as needed.
+  - Support external SSO/OIDC providers with configurable discovery and claim mapping.
+- **Two-factor authentication (2FA)**
+  - Provide TOTP (OtpNet) and e-mail OTP methods with enforced enrollment for Super Admin.
+  - Implement per-role/group policy enforcement, overrides, reset flows, backup codes, and audit trails.
+- **Self-service password reset (SSPR)**
+  - Build secure token issuance with optional SMS OTP via the SMS connector, CAPTCHA enforcement, rate limiting, and audit logging.
+- **Session management**
+  - Expose active sessions, remote logout, automatic invalidation after password changes, and inactivity timeouts.
+- **RBAC policies**
+  - Materialize policies (Servers.*, Network.*, Workstations.*, Dicts.*, Audit.Read, Settings.*) and map LDAP groups to roles with an auditable ruleset.
+  - Implement data scoping per department/location across queries, exports, dashboards, and print jobs.
+
+## 3. Domain Features
+- **Inventory management**
+  - Complete CRUD flows, retire/restore, hard delete (with password confirmation), comments, audit history, Excel import/export, PDF/CSV exports.
+  - Enforce VLAN/IP pairing logic, status management, and scoped administration for Aplikační admin role.
+- **Workstation handover**
+  - Implement mandatory old/new location capture, PDF generation via QuestPDF, templated e-mails with dynamic recipients, CC/BCC, attachments, and audit entries.
+- **Labels & printing**
+  - Finalize label template editor (JSON schema), Code128/EAN-13/QR rendering, ZPL and PDF outputs, batch printing, print job queue with destinations (download, named printer, raw socket 9100), audit, and artefact retention policies.
+- **Dictionaries**
+  - Build full CRUD with import/export (CSV/XLSX), duplicate detection, referential integrity, VLAN metadata requirements, and audit.
+- **Audit logging**
+  - Persist JSON diffs for all entity operations, support filtering (entity, user, action, timeframe), highlight deletes/restores, and include export functionality that logs access.
+- **Reports & schedules**
+  - Provide report definitions with filters (e.g., retired devices, aging assets, expiring warranties), scheduling (daily/weekly/monthly), async execution with e-mail delivery, and history tracking.
+- **Import/Export jobs**
+  - Implement dry-run validation, async processing with progress tracking, per-user concurrency limits, expiring download links, deduplicated notifications, and audit.
+- **Backup & restore**
+  - Build UI/API for scoped backups (full/partial), AES-256 encryption with password confirmation, scheduling, integrity checks, optional e-mail delivery, restore flows with confirmations, history, and incremental options.
+- **Updates module**
+  - Support upload of update packages (ZIP/PKG), validation, optional backup, maintenance mode, file replacement, migration execution, log viewing, audit, and rollback to previous version.
+- **Connectors catalogue**
+  - CRUD for connector profiles (Database, External SQL, SMTP, SMS, LDAP, OIDC, Webhooks, SFTP/FTPS, Storage, Printing, Observability, Zabbix), test connections with readable errors, secret rotation, retry/backoff, periodic health checks, status dashboard.
+- **Observability**
+  - Expose structured logging, /health, /metrics, OpenTelemetry exporter configuration, correlation IDs in responses, diagnostics export for support.
+
+## 4. Frontend (React + Vite + Tailwind)
+- **App shell**
+  - Implement authentication views, onboarding wizard (9 steps), dark/light theme toggle persisted in localStorage, responsive layout, accessibility considerations.
+- **Feature pages**
+  - Evidence pages for servers, network devices, workstations with tables, filters, scoped data, multi-select actions (batch export, print, retire).
+  - Audit explorer with filtering, highlighting, diff viewer, export.
+  - Labels & printing section with template editor, preview, batch printing workflow, job status list.
+  - Settings subsections (App Configuration, Security & Auth, LDAP/AD Sync, Email, Dictionaries, Roles & Users, Labels & Printing, Reports & Schedules, Import/Export, Maintenance, Observability, Advanced, About & Support, Handover, Updates, Backup & Restore).
+  - Modules page with toggles (GET/POST /api/modules).
+  - Dashboard with counts, recent changes, quick actions.
+  - Help Center integration (embedded manual viewer, contextual "?" tooltips linking to manual chapters).
+- **API integration**
+  - Provide strongly-typed clients (OpenAPI generated or hand-written) with pagination, filters, and consistent error handling.
+  - Implement optimistic UI updates where appropriate and handle async job polling.
+
+## 5. Packaging & Deployment
+- **Installer & builder scripts**
+  - Complete PowerShell installer (installer.ps1) to set up IIS App Pool, file permissions, environment configuration, and health checks.
+  - Provide merge/all-in-one builder supporting MERGE/ALLINONE modes with logging, phase detection, regex fixes, wizard verification, and optional installer automation.
+- **CI/CD**
+  - Author GitHub Actions workflows for build, test (API + web), publish artefacts, generate All-in-One ZIP with SHA256 manifest, and smoke tests.
+- **All-in-One artefact**
+  - Package publish output, API contracts, migrations, installer, documentation, attachments, observability examples, release notes, checksums.
+- **Documentation**
+  - Produce manual.pdf, release notes template updates, user guide, deployment guide, troubleshooting, rollback instructions.
+
+## 6. Testing & Quality
+- **Automated tests**
+  - Unit, integration, and end-to-end tests covering domain logic, API endpoints, RBAC enforcement, background jobs, printing workflows, import/export, backups, updates.
+  - UI tests (Playwright) for key flows including onboarding wizard, settings updates, inventory CRUD, label printing, report scheduling.
+- **Smoke tests**
+  - Scripts verifying /health, login + 2FA, CRUD basics, label rendering, SMTP/LDAP tests post-deployment.
+- **Performance & security**
+  - Add rate limiting, CAPTCHA for login/SSPR, vulnerability scanning, dependency checks, and penetration testing considerations.
+
+## 7. Inputs Required From Stakeholders
+The following information is necessary to implement environment-specific integrations safely:
+1. **SMTP relay details** – host, port, TLS requirements, credentials, from/reply-to policy.
+2. **LDAP/AD topology** – hostnames, base DNs, group naming conventions for role mapping, attribute mapping preferences.
+3. **SMS provider selection** – preferred vendor (Twilio/Vonage/SMPP/HTTP gateway), sender ID policy, compliance requirements.
+4. **Storage locations** – UNC paths or S3 buckets for artefacts, backups, and exports.
+5. **Printing infrastructure** – target printer names or IPs for raw 9100 jobs, supported label sizes/DPI.
+6. **Branding assets** – organization name, logos, color palette, default e-mail templates (CZ/EN), handover PDF branding.
+7. **Security policies** – password complexity rules, session timeout standards, audit retention periods, captcha provider (if any).
+8. **Reporting requirements** – exact report recipients, schedules, filtering thresholds (e.g., warranty expiry days).
+9. **Observability endpoints** – OTEL collector URLs, authentication tokens, log retention policies.
+10. **Support contacts** – helpdesk URLs, diagnostic package recipients, escalation procedures.
+
+Documenting these inputs early will unblock the configuration-driven portions of the build and reduce rework during implementation.
+
+## 8. Recommended execution order
+To turn the blueprint into a production-ready release, iterate through the following milestone-oriented phases. Each phase is
+designed to produce a demonstrable increment that can be validated with automated smoke tests and short stakeholder reviews.
+
+1. **Foundations & Persistence**
+   - Switch to SQL Server, ship the initial migration bundle, and stand up seed data for dictionaries, roles, modules, and feature
+     flags.
+   - Harden the configuration system, secrets storage, and background job infrastructure so subsequent features can rely on
+     durable state and scheduling.
+2. **Identity, RBAC, and Security**
+   - Light up ASP.NET Core Identity, session management, 2FA (TOTP/e-mail), SSPR, CAPTCHA, and policy-based authorization with
+     scoped data filters.
+   - Deliver the first pass of the onboarding wizard to exercise authentication, SMTP test, and LDAP dry-run flows end to end.
+3. **Core Inventory Workflows**
+   - Complete server/network/workstation CRUD, retire/restore, comments, audit diffing, VLAN/IP enforcement, and scoped admin
+     behaviour.
+   - Implement handover PDFs/e-mail notifications, label management with ZPL/PDF rendering, and export/import jobs with dry-run.
+4. **Operations & Integrations**
+   - Finish connectors (SMTP, SMS, LDAP/OIDC, Webhooks, SFTP/FTPS, Storage, Printing, Observability) with health reporting and
+     secret rotation.
+   - Build the Updates, Backup & Restore, Reports & Schedules, and Observability modules plus dashboard widgets.
+5. **Frontend completion & UX polish**
+   - Deliver the full React/Vite admin app, dark/light theming, contextual help, manual viewer, and feature-specific pages.
+   - Add Playwright tests and align UI copy with terminology in the specification.
+6. **Packaging, CI/CD, and Release Enablement**
+   - Finalize PowerShell installers, builder/merger scripts, All-in-One ZIP with SHA256, GitHub Actions pipelines, release notes,
+     manual PDFs, and smoke tests ready for acceptance.
+
+## 9. Immediate actions possible without stakeholder input
+While waiting for environment-specific details, the following engineering work can start immediately inside the repository:
+
+- Replace EF Core InMemory with SQL Server LocalDB/SQL Express configuration and generate baseline migrations.
+- Implement ASP.NET Core Identity with built-in local authentication, password policies, and TOTP 2FA using OtpNet.
+- Create the base React/Vite project, navigation shell, authentication views, and dark/light theme toggle tied to localStorage.
+- Build audit logging infrastructure (entity change diffing, history endpoints) and wire it into existing CRUD handlers.
+- Implement label template storage, QuestPDF previews, and ZPL generation utilities with unit tests.
+- Set up Quartz.NET with tables for scheduled jobs and stub processors for LDAP sync, report scheduling, export, and backup jobs.
+- Draft PowerShell installer scaffolding to create IIS App Pool/sites and prepare configuration placeholders.
+
+These deliverables unblock downstream work and prove the end-to-end tooling without requiring external credentials.
+
+## 10. Items waiting on stakeholder input
+Once the engineering baseline above is in place, integrate the environment-specific values listed in Section 7. A consolidated
+tracking table should be maintained in the project wiki (or issue tracker) so that each dependency is assigned an owner and due
+date. During implementation, guard production-only settings behind feature flags and provide sensible development defaults to
+keep local environments functional while inputs are pending.

--- a/docs/status-report.md
+++ b/docs/status-report.md
@@ -1,0 +1,19 @@
+# HW Inventory Platform – Current Status
+
+_Last updated: 2025-10-07T18:44:56Z_
+
+## Implemented Capabilities
+- Monorepo scaffold targeting .NET 8 (API) and React/Vite (admin UI shell) with Tailwind-based dark/light theming.
+- ASP.NET Core backend structured into Domain, Application, Infrastructure, and Api layers with SQL Server persistence, Entity Framework Core migrations, and seeded baseline dictionaries, feature modules, and RBAC role definitions.
+- Identity foundation using ASP.NET Core Identity with TOTP 2FA helpers, policy-based authorization tied to the mandated RBAC roles, audit log entities that capture change diffs, and Quartz.NET background job wiring (initial label print processor).
+- Label rendering services that produce QuestPDF previews and ZPL output, plus REST endpoints for inventory CRUD (servers, network devices, workstations), dictionaries, modules, dashboard summary, audit exploration, and TOTP enrollment.
+- PowerShell installer scaffold that provisions IIS resources and patches connection strings, alongside documentation describing the remaining backlog and execution plan.
+
+## Outstanding Work (High-Level)
+- Harden authentication & RBAC: scoped authorization policies, LDAP/AD integration, SSO/OIDC, SSPR with CAPTCHA/SMS, session management, and audit coverage for all security changes.
+- Complete domain workflows: workstation handover PDF/e-mail process, import/export with dry-run and async jobs, reporting & schedules, connectors catalogue, backup/restore, updates module, observability endpoints, and full audit diff surfacing.
+- Build the full React admin experience: onboarding wizard, inventory tables with filters/batch actions, settings subsections, label template editor, reports dashboards, help center/manual integration, and modules toggles.
+- Deliver packaging & ops tooling: All-in-One builder, CI/CD pipelines, release notes/manual PDFs, smoke/regression tests, and artefact bundling with checksums.
+- Gather stakeholder inputs for SMTP, LDAP, SMS, storage, printing, branding, security policies, reporting thresholds, observability, and support contacts to configure environment-specific connectors.
+
+See [`docs/implementation-plan.md`](implementation-plan.md) for the detailed backlog and sequencing guidance.

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,0 +1,76 @@
+param(
+    [string]$PublishPath = "publish",
+    [string]$SiteName = "HWInventory",
+    [string]$AppPoolName = "HWInventoryPool",
+    [string]$AppPoolIdentity = "ApplicationPoolIdentity",
+    [string]$SqlConnectionString = "Server=localhost;Database=HWInventory;Trusted_Connection=True;TrustServerCertificate=True",
+    [switch]$SkipIisProvisioning
+)
+
+Import-Module WebAdministration -ErrorAction Stop
+
+function Ensure-Directory {
+    param([string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        Write-Host "[HWInventory] Creating directory $Path" -ForegroundColor Green
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function Update-AppSettings {
+    param([string]$ConfigPath, [string]$ConnectionString)
+
+    $json = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+    if (-not $json.ConnectionStrings) {
+        $json | Add-Member -NotePropertyName ConnectionStrings -NotePropertyValue @{ }
+    }
+
+    $json.ConnectionStrings.DefaultConnection = $ConnectionString
+    $json | ConvertTo-Json -Depth 6 | Out-File $ConfigPath -Encoding UTF8
+    Write-Host "[HWInventory] Updated $ConfigPath with SQL Server connection string" -ForegroundColor Green
+}
+
+function Grant-AppPermissions {
+    param([string]$Path, [string]$Identity)
+
+    Write-Host "[HWInventory] Granting Modify permissions to $Identity on $Path" -ForegroundColor Green
+    icacls $Path /grant "$Identity":(OI)(CI)M | Out-Null
+}
+
+Ensure-Directory -Path $PublishPath
+Ensure-Directory -Path (Join-Path $PublishPath "logs")
+
+$webConfigPath = Join-Path $PublishPath "appsettings.Production.json"
+if (-not (Test-Path $webConfigPath)) {
+    $webConfigPath = Join-Path $PublishPath "appsettings.json"
+}
+
+if (Test-Path $webConfigPath) {
+    Update-AppSettings -ConfigPath $webConfigPath -ConnectionString $SqlConnectionString
+} else {
+    Write-Warning "[HWInventory] Unable to locate appsettings file in $PublishPath. Please update the connection string manually."
+}
+
+if (-not $SkipIisProvisioning) {
+    Write-Host "[HWInventory] Configuring IIS application pool $AppPoolName" -ForegroundColor Cyan
+
+    if (-not (Get-Item "IIS:\AppPools\$AppPoolName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\AppPools\$AppPoolName" -Force | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name managedRuntimeVersion -Value ""
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name processModel.identityType -Value $AppPoolIdentity
+
+    Write-Host "[HWInventory] Ensuring IIS site $SiteName" -ForegroundColor Cyan
+    if (-not (Get-Item "IIS:\Sites\$SiteName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\Sites\$SiteName" -Bindings @{ protocol = "http"; bindingInformation = "*:8080:" } -PhysicalPath $PublishPath | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\Sites\$SiteName" -Name applicationPool -Value $AppPoolName
+
+    Grant-AppPermissions -Path $PublishPath -Identity "IIS AppPool\$AppPoolName"
+    Grant-AppPermissions -Path (Join-Path $PublishPath "logs") -Identity "IIS AppPool\$AppPoolName"
+}
+
+Write-Host "[HWInventory] Deployment artifacts staged successfully. Run dotnet ef database update or start the web application to apply migrations." -ForegroundColor Cyan

--- a/src/api/HWInventory.sln
+++ b/src/api/HWInventory.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Api", "src/HWInventory.Api/HWInventory.Api.csproj", "{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Application", "src/HWInventory.Application/HWInventory.Application.csproj", "{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Domain", "src/HWInventory.Domain/HWInventory.Domain.csproj", "{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Infrastructure", "src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj", "{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.Build.0 = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.Build.0 = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.Build.0 = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
@@ -1,0 +1,19 @@
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Produces("application/json")]
+[Route("api/[controller]")]
+public abstract class ApiControllerBase : ControllerBase
+{
+    protected ApiControllerBase(IAppDbContext dbContext)
+    {
+        DbContext = dbContext;
+    }
+
+    protected IAppDbContext DbContext { get; }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuditController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuditController.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/audit")]
+[Authorize(Policy = AuthorizationPolicies.AuditRead)]
+public class AuditController : ApiControllerBase
+{
+    public AuditController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<AuditLog>>> GetAsync([FromQuery] string? entityType, [FromQuery] string? user, [FromQuery] string? action)
+    {
+        var query = DbContext.AuditLogs.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(entityType))
+        {
+            query = query.Where(x => x.EntityType == entityType);
+        }
+        if (!string.IsNullOrWhiteSpace(user))
+        {
+            query = query.Where(x => x.PerformedBy == user);
+        }
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            query = query.Where(x => x.Action == action);
+        }
+
+        var items = await query.OrderByDescending(x => x.PerformedAtUtc).Take(500).ToListAsync();
+        return Ok(items);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuthController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuthController.cs
@@ -1,0 +1,108 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/auth")]
+[ApiController]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+    private readonly ITotpService _totpService;
+
+    public AuthController(UserManager<AppUser> userManager, SignInManager<AppUser> signInManager, ITotpService totpService)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _totpService = totpService;
+    }
+
+    [HttpGet("me")]
+    [Authorize]
+    public async Task<ActionResult<object>> GetProfileAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return Ok(new
+        {
+            user.Id,
+            user.UserName,
+            user.DisplayName,
+            user.Email,
+            Roles = roles,
+            TwoFactorEnabled = user.TwoFactorEnabled,
+            TwoFactorRequired = user.TwoFactorRequired
+        });
+    }
+
+    [HttpPost("totp/setup")]
+    [Authorize]
+    public async Task<ActionResult<object>> BeginTotpSetupAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            user.AuthenticatorKey = _totpService.GenerateSecretKey();
+            await _userManager.UpdateAsync(user);
+        }
+
+        var code = _totpService.GenerateCode(user.AuthenticatorKey);
+        return Ok(new
+        {
+            SecretKey = user.AuthenticatorKey,
+            VerificationCode = code
+        });
+    }
+
+    [HttpPost("totp/verify")]
+    [Authorize]
+    public async Task<ActionResult> CompleteTotpSetupAsync([FromBody] TotpVerificationRequest request)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "TOTP secret not initialized",
+                Detail = "Call /api/auth/totp/setup before attempting verification."
+            });
+        }
+
+        if (!_totpService.ValidateCode(user.AuthenticatorKey, request.Code))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid verification code",
+                Detail = "The provided TOTP code could not be validated."
+            });
+        }
+
+        user.TwoFactorEnabled = true;
+        await _userManager.UpdateAsync(user);
+        await _userManager.SetTwoFactorEnabledAsync(user, true);
+        await _signInManager.RefreshSignInAsync(user);
+
+        return NoContent();
+    }
+
+    public record TotpVerificationRequest(string Code);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dashboard")]
+[Authorize(Policy = AuthorizationPolicies.DashboardView)]
+public class DashboardController : ApiControllerBase
+{
+    public DashboardController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet("summary")]
+    public async Task<ActionResult<DashboardSummaryResponse>> GetSummaryAsync()
+    {
+        var servers = await DbContext.Servers.CountAsync();
+        var network = await DbContext.NetworkDevices.CountAsync();
+        var workstations = await DbContext.Workstations.CountAsync();
+        var latestChanges = await DbContext.AuditLogs.AsNoTracking()
+            .OrderByDescending(x => x.PerformedAtUtc)
+            .Take(10)
+            .Select(x => new AuditEntryDto(x.EntityType, x.Action, x.PerformedBy, x.PerformedAtUtc))
+            .ToListAsync();
+
+        return Ok(new DashboardSummaryResponse(servers, network, workstations, latestChanges));
+    }
+
+    public record DashboardSummaryResponse(int Servers, int NetworkDevices, int Workstations, IReadOnlyCollection<AuditEntryDto> LatestChanges);
+
+    public record AuditEntryDto(string EntityType, string Action, string PerformedBy, DateTime PerformedAtUtc);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dictionaries")]
+[Authorize(Policy = AuthorizationPolicies.DictionariesManage)]
+public class DictionariesController : ApiControllerBase
+{
+    public DictionariesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<DictionaryEntry>>> GetAsync([FromQuery] string? type)
+    {
+        var query = DbContext.DictionaryEntries.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            query = query.Where(x => x.DictType == type);
+        }
+
+        var result = await query.OrderBy(x => x.DictType).ThenBy(x => x.Order).ThenBy(x => x.Value).ToListAsync();
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> GetByIdAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entry is null ? NotFound() : Ok(entry);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DictionaryEntry>> CreateAsync([FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = new DictionaryEntry
+        {
+            DictType = request.DictType,
+            Key = request.Key,
+            Value = request.Value,
+            Description = request.Description,
+            Order = request.Order,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system"
+        };
+
+        DbContext.DictionaryEntries.Add(entry);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entry.Id }, entry);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> UpdateAsync(Guid id, [FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        entry.DictType = request.DictType;
+        entry.Key = request.Key;
+        entry.Value = request.Value;
+        entry.Description = request.Description;
+        entry.Order = request.Order;
+        entry.ModifiedAtUtc = DateTime.UtcNow;
+        entry.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(entry);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.DictionaryEntries.Remove(entry);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/labels")]
+[Authorize(Policy = AuthorizationPolicies.LabelsManage)]
+public class LabelsController : ApiControllerBase
+{
+    private readonly ILabelRenderingService _labelRenderingService;
+
+    public LabelsController(IAppDbContext dbContext, ILabelRenderingService labelRenderingService) : base(dbContext)
+    {
+        _labelRenderingService = labelRenderingService;
+    }
+
+    [HttpGet("templates")]
+    public async Task<ActionResult<IEnumerable<LabelTemplate>>> GetTemplatesAsync()
+    {
+        var templates = await DbContext.LabelTemplates.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(templates);
+    }
+
+    [HttpPost("templates")]
+    public async Task<ActionResult<LabelTemplate>> CreateTemplateAsync([FromBody] LabelTemplate request)
+    {
+        request.Id = Guid.NewGuid();
+        request.CreatedAtUtc = DateTime.UtcNow;
+        request.CreatedBy = User.Identity?.Name ?? "system";
+        DbContext.LabelTemplates.Add(request);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetTemplateByIdAsync), new { id = request.Id }, request);
+    }
+
+    [HttpGet("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> GetTemplateByIdAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return template is null ? NotFound() : Ok(template);
+    }
+
+    [HttpPut("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> UpdateTemplateAsync(Guid id, [FromBody] LabelTemplate request)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        template.Name = request.Name;
+        template.Code = request.Code;
+        template.Format = request.Format;
+        template.Payload = request.Payload;
+        template.Description = request.Description;
+        template.ModifiedAtUtc = DateTime.UtcNow;
+        template.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(template);
+    }
+
+    [HttpDelete("templates/{id:guid}")]
+    public async Task<IActionResult> DeleteTemplateAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.LabelTemplates.Remove(template);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("templates/{id:guid}/render/pdf")]
+    public async Task<IActionResult> RenderPdfAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var pdf = _labelRenderingService.RenderPdf(template, data);
+        return File(pdf, "application/pdf", $"{template.Code}.pdf");
+    }
+
+    [HttpPost("templates/{id:guid}/render/zpl")]
+    public async Task<IActionResult> RenderZplAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var zpl = _labelRenderingService.RenderZpl(template, data);
+        return Ok(new { zpl });
+    }
+
+    [HttpPost("print-jobs")]
+    public async Task<ActionResult<LabelPrintJob>> CreatePrintJobAsync([FromBody] CreatePrintJobRequest request)
+    {
+        var job = new LabelPrintJob
+        {
+            Target = request.Target,
+            Format = request.Format,
+            JobStatus = "Queued",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system",
+            Items = request.Items.Select(item => new LabelPrintJobItem
+            {
+                AssetId = item.AssetId,
+                AssetType = item.AssetType,
+                Copies = item.Copies
+            }).ToList()
+        };
+
+        DbContext.LabelPrintJobs.Add(job);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetPrintJobByIdAsync), new { id = job.Id }, job);
+    }
+
+    [HttpGet("print-jobs")]
+    public async Task<ActionResult<IEnumerable<LabelPrintJob>>> GetPrintJobsAsync()
+    {
+        var jobs = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items)
+            .OrderByDescending(x => x.CreatedAtUtc).Take(100).ToListAsync();
+        return Ok(jobs);
+    }
+
+    [HttpGet("print-jobs/{id:guid}")]
+    public async Task<ActionResult<LabelPrintJob>> GetPrintJobByIdAsync(Guid id)
+    {
+        var job = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items).FirstOrDefaultAsync(x => x.Id == id);
+        return job is null ? NotFound() : Ok(job);
+    }
+
+    public record CreatePrintJobRequest(string Target, string Format, IReadOnlyCollection<PrintJobItemDto> Items);
+
+    public record PrintJobItemDto(Guid AssetId, string AssetType, int Copies);
+
+    public record LabelRenderRequest(Dictionary<string, string>? Data);
+}

--- a/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/modules")]
+[Authorize(Policy = AuthorizationPolicies.ModulesManage)]
+public class ModulesController : ApiControllerBase
+{
+    public ModulesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<FeatureModule>>> GetAsync()
+    {
+        var modules = await DbContext.FeatureModules.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(modules);
+    }
+
+    [HttpPost("{key}/toggle")]
+    public async Task<IActionResult> ToggleAsync(string key, [FromQuery] bool? enabled, [FromBody] FeatureModuleToggleRequest? body)
+    {
+        var module = await DbContext.FeatureModules.FirstOrDefaultAsync(x => x.Key == key);
+        if (module is null)
+        {
+            return NotFound();
+        }
+
+        var newState = enabled ?? body?.Enabled ?? !module.Enabled;
+        module.Enabled = newState;
+        module.ModifiedAtUtc = DateTime.UtcNow;
+        module.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(module);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
@@ -1,0 +1,186 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/network-devices")]
+public class NetworkDevicesController : ApiControllerBase
+{
+    public NetworkDevicesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<PagedResult<NetworkDevice>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.NetworkDevices.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("network-devices", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<NetworkDevice>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<NetworkDevice>> GetByIdAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entity is null ? NotFound() : Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> CreateAsync([FromBody] NetworkDeviceRequestDto request)
+    {
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.NetworkDevices.Add(entity);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> UpdateAsync(Guid id, [FromBody] NetworkDeviceRequestDto request)
+    {
+        var entity = await DbContext.NetworkDevices.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RetireAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.NetworkDevices.Remove(entity);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private static NetworkDevice Map(NetworkDeviceRequestDto request)
+    {
+        return new NetworkDevice
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            DeviceTypeId = request.DeviceTypeId,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(NetworkDevice entity, NetworkDeviceRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.DeviceTypeId = request.DeviceTypeId;
+        entity.Manufacturer = request.Manufacturer;
+        entity.Model = request.Model;
+        entity.LocationId = request.LocationId;
+        entity.RackPosition = request.RackPosition;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.SupportUntil = request.SupportUntil;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ServersController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ServersController.cs
@@ -1,0 +1,208 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+public class ServersController : ApiControllerBase
+{
+    public ServersController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<PagedResult<Server>>> GetServersAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.Servers.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = GeneratePaginationLinksStatic("servers", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Server>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<Server>> GetServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return server is null ? NotFound() : Ok(server);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> CreateServerAsync([FromBody] ServerRequestDto request)
+    {
+        var server = MapServer(request);
+        server.CreatedAtUtc = DateTime.UtcNow;
+        server.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Servers.Add(server);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetServerAsync), new { id = server.Id }, server);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> UpdateServerAsync(Guid id, [FromBody] ServerRequestDto request)
+    {
+        var server = await DbContext.Servers.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        UpdateServer(server, request);
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(server);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RetireServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        server.Status = EntityStatus.Retired;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RestoreServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        server.Status = EntityStatus.Active;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> DeleteServerAsync(Guid id)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.Servers.Remove(server);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    internal static string GeneratePaginationLinksStatic(string route, int page, int size, int total)
+    {
+        var links = new List<string>();
+        var lastPage = (int)Math.Ceiling(total / (double)size);
+        if (page > 1)
+        {
+            links.Add($"</api/{route}?page=1&size={size}>; rel=\"first\"");
+            links.Add($"</api/{route}?page={page - 1}&size={size}>; rel=\"prev\"");
+        }
+        if (page < lastPage)
+        {
+            links.Add($"</api/{route}?page={page + 1}&size={size}>; rel=\"next\"");
+            links.Add($"</api/{route}?page={lastPage}&size={size}>; rel=\"last\"");
+        }
+        return string.Join(", ", links);
+    }
+
+    private static Server MapServer(ServerRequestDto request)
+    {
+        return new Server
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            EnvironmentId = request.EnvironmentId,
+            WsusPriorityId = request.WsusPriorityId,
+            OperatingSystemId = request.OperatingSystemId,
+            ServerRoleId = request.ServerRoleId,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments
+                .Select(x => new NetworkEndpoint { Label = x.Label, VlanId = x.VlanId, IpAddress = x.IpAddress })
+                .ToList()
+        };
+    }
+
+    private static void UpdateServer(Server server, ServerRequestDto request)
+    {
+        server.Name = request.Name;
+        server.InventoryNumber = request.InventoryNumber;
+        server.Manufacturer = request.Manufacturer;
+        server.Model = request.Model;
+        server.EnvironmentId = request.EnvironmentId;
+        server.WsusPriorityId = request.WsusPriorityId;
+        server.OperatingSystemId = request.OperatingSystemId;
+        server.ServerRoleId = request.ServerRoleId;
+        server.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        server.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        server.LocationId = request.LocationId;
+        server.RackPosition = request.RackPosition;
+        server.PurchasedAt = request.PurchasedAt;
+        server.SupportUntil = request.SupportUntil;
+        server.Notes = request.Notes;
+
+        server.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            server.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
@@ -1,0 +1,232 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/workstations")]
+public class WorkstationsController : ApiControllerBase
+{
+    public WorkstationsController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<PagedResult<Workstation>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var query = DbContext.Workstations.AsNoTracking().OrderBy(x => x.Name);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync();
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("workstations", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Workstation>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<Workstation>> GetByIdAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entity is null ? NotFound() : Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> CreateAsync([FromBody] WorkstationRequestDto request)
+    {
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Workstations.Add(entity);
+        await DbContext.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> UpdateAsync(Guid id, [FromBody] WorkstationRequestDto request)
+    {
+        var entity = await DbContext.Workstations.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/handover")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult> HandoverAsync(Guid id, [FromBody] HandoverRequest request)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.OwnerId = request.NewOwnerId;
+        entity.OwnerDisplayName = request.NewOwnerDisplayName;
+        entity.OwnerDepartment = request.NewOwnerDepartment;
+        entity.LocationId = request.NewLocationId;
+        entity.LocationNote = request.NewLocationNote;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RetireAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.Workstations.Remove(entity);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private static Workstation Map(WorkstationRequestDto request)
+    {
+        return new Workstation
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            OperatingSystemId = request.OperatingSystemId,
+            WorkstationTypeId = request.WorkstationTypeId,
+            OwnerId = request.OwnerId,
+            OwnerDisplayName = request.OwnerDisplayName,
+            OwnerDepartment = request.OwnerDepartment,
+            LocationId = request.LocationId,
+            LocationNote = request.LocationNote,
+            Cpu = request.Cpu,
+            Ram = request.Ram,
+            Storage = request.Storage,
+            MacAddress = request.MacAddress,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(Workstation entity, WorkstationRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.OperatingSystemId = request.OperatingSystemId;
+        entity.WorkstationTypeId = request.WorkstationTypeId;
+        entity.OwnerId = request.OwnerId;
+        entity.OwnerDisplayName = request.OwnerDisplayName;
+        entity.OwnerDepartment = request.OwnerDepartment;
+        entity.LocationId = request.LocationId;
+        entity.LocationNote = request.LocationNote;
+        entity.Cpu = request.Cpu;
+        entity.Ram = request.Ram;
+        entity.Storage = request.Storage;
+        entity.MacAddress = request.MacAddress;
+        entity.PurchasedAt = request.PurchasedAt;
+        entity.SupportUntil = request.SupportUntil;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+
+    public record HandoverRequest(
+        Guid? NewOwnerId,
+        string? NewOwnerDisplayName,
+        string? NewOwnerDepartment,
+        Guid NewLocationId,
+        string? NewLocationNote,
+        Guid? NewAdminId,
+        IReadOnlyCollection<string>? Emails,
+        string? Comment);
+}

--- a/src/api/src/HWInventory.Api/HWInventory.Api.csproj
+++ b/src/api/src/HWInventory.Api/HWInventory.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Infrastructure/HWInventory.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Api.Models;
+
+public record DictionaryEntryRequestDto(
+    string DictType,
+    string Key,
+    string Value,
+    string? Description,
+    int Order);

--- a/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
+++ b/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record FeatureModuleToggleRequest(bool Enabled);

--- a/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkDeviceRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid DeviceTypeId,
+    string Manufacturer,
+    string Model,
+    Guid LocationId,
+    string? RackPosition,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkEndpointDto(string Label, Guid? VlanId, string? IpAddress);

--- a/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Api.Models;
+
+public record ServerRequestDto(
+    string Name,
+    string InventoryNumber,
+    string Manufacturer,
+    string Model,
+    Guid EnvironmentId,
+    Guid WsusPriorityId,
+    Guid OperatingSystemId,
+    Guid ServerRoleId,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    Guid LocationId,
+    string? RackPosition,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
@@ -1,0 +1,22 @@
+namespace HWInventory.Api.Models;
+
+public record WorkstationRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid OperatingSystemId,
+    Guid WorkstationTypeId,
+    Guid? OwnerId,
+    string? OwnerDisplayName,
+    string? OwnerDepartment,
+    Guid LocationId,
+    string? LocationNote,
+    string Cpu,
+    string Ram,
+    string Storage,
+    string MacAddress,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Program.cs
+++ b/src/api/src/HWInventory.Api/Program.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using HWInventory.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using QuestPDF.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+QuestPDF.Settings.License = LicenseType.Community;
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status400BadRequest));
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status404NotFound));
+}).AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("default", policy =>
+    {
+        policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin();
+    });
+});
+
+var app = builder.Build();
+
+await app.InitializeDatabaseAsync();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("default");
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
+
+await app.RunAsync();

--- a/src/api/src/HWInventory.Api/appsettings.Development.json
+++ b/src/api/src/HWInventory.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/api/src/HWInventory.Api/appsettings.json
+++ b/src/api/src/HWInventory.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
@@ -1,0 +1,21 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IAppDbContext
+{
+    DbSet<Server> Servers { get; }
+    DbSet<NetworkDevice> NetworkDevices { get; }
+    DbSet<Workstation> Workstations { get; }
+    DbSet<DictionaryEntry> DictionaryEntries { get; }
+    DbSet<AuditLog> AuditLogs { get; }
+    DbSet<LabelTemplate> LabelTemplates { get; }
+    DbSet<LabelPrintJob> LabelPrintJobs { get; }
+    DbSet<AppUser> Users { get; }
+    DbSet<AppRole> Roles { get; }
+    DbSet<FeatureModule> FeatureModules { get; }
+    DbSet<AppSetting> Settings { get; }
+    DbSet<ConnectorProfile> ConnectorProfiles { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
@@ -1,0 +1,9 @@
+using HWInventory.Domain.Entities;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ILabelRenderingService
+{
+    string RenderZpl(LabelTemplate template, IDictionary<string, string> data);
+    byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ITotpService
+{
+    string GenerateSecretKey();
+    string GenerateCode(string secretKey);
+    bool ValidateCode(string secretKey, string code);
+}

--- a/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
+++ b/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Common;
+
+public class FilterDescriptor
+{
+    public string Field { get; init; } = string.Empty;
+    public string Operator { get; init; } = string.Empty;
+    public string? Value { get; init; }
+}

--- a/src/api/src/HWInventory.Application/Common/PagedResult.cs
+++ b/src/api/src/HWInventory.Application/Common/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Application.Common;
+
+public class PagedResult<T>
+{
+    public IReadOnlyCollection<T> Items { get; init; } = Array.Empty<T>();
+    public int TotalCount { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/api/src/HWInventory.Application/HWInventory.Application.csproj
+++ b/src/api/src/HWInventory.Application/HWInventory.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Entities/AppRole.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppRole.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppRole : IdentityRole<Guid>
+{
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppSetting : AuditableEntity
+{
+    public string Section { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public bool IsSecret { get; set; }
+    public bool IsMasked => IsSecret && !string.IsNullOrEmpty(Value);
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppUser.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppUser.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppUser : IdentityUser<Guid>
+{
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsDomainAccount { get; set; }
+    public bool TwoFactorRequired { get; set; }
+    public string? Department { get; set; }
+    public string? AuthenticatorKey { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+    public ICollection<DataScope> DataScopes { get; set; } = new List<DataScope>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Domain.Entities;
+
+public class AuditLog : BaseEntity
+{
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string PerformedBy { get; set; } = string.Empty;
+    public string? Roles { get; set; }
+    public DateTime PerformedAtUtc { get; set; }
+    public string? ChangeSummary { get; set; }
+    public string? ChangedFieldsJson { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+}

--- a/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Domain.Entities;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
@@ -1,0 +1,12 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorProfile : AuditableEntity
+{
+    public string Type { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public bool Enabled { get; set; }
+    public string? ConfigurationJson { get; set; }
+    public string? HealthStatus { get; set; }
+    public DateTime? LastTestedAtUtc { get; set; }
+    public ICollection<ConnectorSecret> Secrets { get; set; } = new List<ConnectorSecret>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorSecret : BaseEntity
+{
+    public Guid ConnectorProfileId { get; set; }
+    public ConnectorProfile ConnectorProfile { get; set; } = default!;
+    public string Key { get; set; } = string.Empty;
+    public string SecretReference { get; set; } = string.Empty;
+    public DateTime? RotatedAtUtc { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/DataScope.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DataScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class DataScope : BaseEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid? DepartmentId { get; set; }
+    public Guid? LocationId { get; set; }
+    public string ScopeType { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class DictionaryEntry : AuditableEntity
+{
+    public string DictType { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int Order { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
+++ b/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class FeatureModule : AuditableEntity
+{
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool Enabled { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJob : AuditableEntity
+{
+    public string Target { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string JobStatus { get; set; } = "Pending";
+    public string? ArtifactPath { get; set; }
+    public ICollection<LabelPrintJobItem> Items { get; set; } = new List<LabelPrintJobItem>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJobItem : BaseEntity
+{
+    public Guid LabelPrintJobId { get; set; }
+    public Guid AssetId { get; set; }
+    public string AssetType { get; set; } = string.Empty;
+    public int Copies { get; set; } = 1;
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelTemplate : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Format { get; set; } = "ZPL";
+    public string Payload { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
+++ b/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class NetworkDevice : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid DeviceTypeId { get; set; }
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/Server.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Server.cs
@@ -1,0 +1,24 @@
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Server : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid EnvironmentId { get; set; }
+    public Guid WsusPriorityId { get; set; }
+    public Guid OperatingSystemId { get; set; }
+    public Guid ServerRoleId { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/Workstation.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Workstation.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Workstation : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid OperatingSystemId { get; set; }
+    public Guid WorkstationTypeId { get; set; }
+    public Guid? OwnerId { get; set; }
+    public string? OwnerDisplayName { get; set; }
+    public string? OwnerDepartment { get; set; }
+    public Guid LocationId { get; set; }
+    public string? LocationNote { get; set; }
+    public string Cpu { get; set; } = string.Empty;
+    public string Ram { get; set; } = string.Empty;
+    public string Storage { get; set; } = string.Empty;
+    public string MacAddress { get; set; } = string.Empty;
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum EntityStatus
+{
+    Active = 1,
+    Retired = 2
+}

--- a/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
+++ b/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
@@ -1,0 +1,11 @@
+namespace HWInventory.Domain.Enums;
+
+public static class SystemRoleNames
+{
+    public const string SuperAdmin = "SuperAdmin";
+    public const string ServerAdmin = "SRV Administrator";
+    public const string NetworkAdmin = "NET Administrator";
+    public const string AppAdmin = "Aplikační admin";
+    public const string Helpdesk = "Helpdesk";
+    public const string HelpdeskRead = "Helpdesk Read";
+}

--- a/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
+++ b/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
+++ b/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Domain.Security;
+
+public static class AuthorizationPolicies
+{
+    public const string ServersRead = "Servers.Read";
+    public const string ServersManage = "Servers.Manage";
+
+    public const string NetworkRead = "Network.Read";
+    public const string NetworkManage = "Network.Manage";
+
+    public const string WorkstationsRead = "Workstations.Read";
+    public const string WorkstationsManage = "Workstations.Manage";
+
+    public const string DictionariesManage = "Dictionaries.Manage";
+    public const string AuditRead = "Audit.Read";
+    public const string LabelsManage = "Labels.Manage";
+    public const string ModulesManage = "Modules.Manage";
+    public const string DashboardView = "Dashboard.View";
+}

--- a/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
+++ b/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.ValueObjects;
+
+public class NetworkEndpoint
+{
+    public string Label { get; set; } = string.Empty;
+    public Guid? VlanId { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
+++ b/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,138 @@
+using System;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Infrastructure.Jobs;
+using HWInventory.Infrastructure.Labels;
+using HWInventory.Infrastructure.Persistence;
+using HWInventory.Infrastructure.Security;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+
+namespace HWInventory.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True";
+        }
+
+        services.AddDbContext<AppDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.EnableRetryOnFailure();
+                sql.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName);
+            });
+        });
+
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+        services.AddHttpContextAccessor();
+
+        var identityBuilder = services.AddIdentityCore<AppUser>(options =>
+        {
+            options.Password.RequireDigit = true;
+            options.Password.RequireLowercase = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequireNonAlphanumeric = true;
+            options.Password.RequiredLength = 12;
+            options.SignIn.RequireConfirmedAccount = false;
+            options.User.RequireUniqueEmail = true;
+            options.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
+        });
+
+        identityBuilder = new IdentityBuilder(identityBuilder.UserType, typeof(AppRole), identityBuilder.Services);
+        identityBuilder.AddRoles<AppRole>();
+        identityBuilder.AddEntityFrameworkStores<AppDbContext>();
+        identityBuilder.AddDefaultTokenProviders();
+        identityBuilder.AddSignInManager();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
+        }).AddIdentityCookies();
+
+        services.ConfigureApplicationCookie(options =>
+        {
+            options.Cookie.Name = "HWInventory.Auth";
+            options.SlidingExpiration = true;
+            options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+            options.LoginPath = "/signin";
+            options.LogoutPath = "/signout";
+        });
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(AuthorizationPolicies.ServersRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.AppAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.ServersManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk, SystemRoleNames.HelpdeskRead));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.DictionariesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.AuditRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.LabelsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.ModulesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.DashboardView, policy =>
+                policy.RequireRole(
+                    SystemRoleNames.SuperAdmin,
+                    SystemRoleNames.ServerAdmin,
+                    SystemRoleNames.NetworkAdmin,
+                    SystemRoleNames.AppAdmin,
+                    SystemRoleNames.Helpdesk,
+                    SystemRoleNames.HelpdeskRead));
+        });
+
+        services.AddScoped<ITotpService, TotpService>();
+        services.AddScoped<ILabelRenderingService, LabelRenderingService>();
+
+        services.AddQuartz(q =>
+        {
+            q.UseMicrosoftDependencyInjectionJobFactory();
+            var jobKey = new JobKey("LabelPrintJobProcessor");
+            q.AddJob<LabelPrintJobProcessor>(options => options.WithIdentity(jobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity("LabelPrintJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).RepeatForever()));
+        });
+
+        services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        return services;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
+++ b/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Otp.NET" Version="1.3.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
+++ b/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
@@ -1,0 +1,28 @@
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace HWInventory.Infrastructure;
+
+public static class HostExtensions
+{
+    public static async Task<IHost> InitializeDatabaseAsync(this IHost host, CancellationToken cancellationToken = default)
+    {
+        using var scope = host.Services.CreateScope();
+        var serviceProvider = scope.ServiceProvider;
+        var context = serviceProvider.GetRequiredService<AppDbContext>();
+
+        if (context.Database.IsRelational())
+        {
+            await context.Database.MigrateAsync(cancellationToken);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        await SeedData.InitializeAsync(serviceProvider, cancellationToken);
+        return host;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.Jobs;
+
+public class LabelPrintJobProcessor : IJob
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly ILogger<LabelPrintJobProcessor> _logger;
+
+    public LabelPrintJobProcessor(IAppDbContext dbContext, ILogger<LabelPrintJobProcessor> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var queuedJobs = await _dbContext.LabelPrintJobs
+            .Where(job => job.JobStatus == "Queued")
+            .Include(job => job.Items)
+            .OrderBy(job => job.CreatedAtUtc)
+            .Take(10)
+            .ToListAsync(context.CancellationToken);
+
+        if (!queuedJobs.Any())
+        {
+            return;
+        }
+
+        foreach (var job in queuedJobs)
+        {
+            job.JobStatus = "Processed";
+            job.ModifiedAtUtc = DateTime.UtcNow;
+            job.ModifiedBy = "system-job";
+            _logger.LogInformation("Processed label print job {JobId} targeting {Target}", job.Id, job.Target);
+        }
+
+        await _dbContext.SaveChangesAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace HWInventory.Infrastructure.Labels;
+
+public class LabelRenderingService : ILabelRenderingService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public string RenderZpl(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var builder = new StringBuilder();
+        builder.AppendLine("^XA");
+        builder.AppendLine("^CI28");
+        builder.AppendLine($"^PW{ToDots(model.WidthMm, model.Dpi)}");
+        builder.AppendLine($"^LL{ToDots(model.HeightMm, model.Dpi)}");
+
+        foreach (var element in model.Elements)
+        {
+            var x = ToDots(element.X, model.Dpi);
+            var y = ToDots(element.Y, model.Dpi);
+            var value = ResolveValue(element, data);
+
+            switch (element.Type)
+            {
+                case LabelElementType.Text:
+                    builder.AppendLine($"^FO{x},{y}^A0N,{element.FontSize},{element.FontSize}^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Barcode128:
+                    builder.AppendLine($"^FO{x},{y}^BCN,{ToDots(element.HeightMm, model.Dpi)},Y,N,N^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Qr:
+                    builder.AppendLine($"^FO{x},{y}^BQN,2,10^FDLA,{Escape(value)}^FS");
+                    break;
+            }
+        }
+
+        builder.AppendLine("^XZ");
+        return builder.ToString();
+    }
+
+    public byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(10);
+                page.Size(model.WidthMm * 2.83465f, model.HeightMm * 2.83465f);
+                page.Content().Canvas((canvas, size) =>
+                {
+                    foreach (var element in model.Elements)
+                    {
+                        var value = ResolveValue(element, data);
+                        var x = element.X * 2.83465f;
+                        var y = element.Y * 2.83465f;
+
+                        switch (element.Type)
+                        {
+                            case LabelElementType.Text:
+                                canvas.DrawText(value, TextStyle.Default.FontSize(element.FontSize), new Position(x, y));
+                                break;
+                            case LabelElementType.Barcode128:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[Code128] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                            case LabelElementType.Qr:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[QR] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                        }
+                    }
+                });
+            });
+        });
+
+        using var stream = new MemoryStream();
+        document.GeneratePdf(stream);
+        return stream.ToArray();
+    }
+
+    private static LabelTemplateModel ParsePayload(LabelTemplate template)
+    {
+        if (string.IsNullOrWhiteSpace(template.Payload))
+        {
+            throw new InvalidOperationException("Label template payload cannot be empty");
+        }
+
+        var model = JsonSerializer.Deserialize<LabelTemplateModel>(template.Payload, SerializerOptions);
+        if (model is null)
+        {
+            throw new InvalidOperationException("Label template payload is invalid");
+        }
+
+        return model;
+    }
+
+    private static string ResolveValue(LabelElement element, IDictionary<string, string> data)
+    {
+        if (!string.IsNullOrWhiteSpace(element.StaticValue))
+        {
+            return element.StaticValue!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(element.DataKey) && data.TryGetValue(element.DataKey!, out var value))
+        {
+            return value;
+        }
+
+        return string.Empty;
+    }
+
+    private static string Escape(string value) => value
+        .Replace("^", " ")
+        .Replace("~", " ");
+
+    private static int ToDots(float millimeters, int dpi)
+        => (int)Math.Round(millimeters / 25.4f * dpi);
+
+    private class LabelTemplateModel
+    {
+        public int Dpi { get; set; } = 203;
+        public float WidthMm { get; set; } = 50;
+        public float HeightMm { get; set; } = 30;
+        public IList<LabelElement> Elements { get; set; } = new List<LabelElement>();
+    }
+
+    private class LabelElement
+    {
+        public LabelElementType Type { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float WidthMm { get; set; } = 30;
+        public float HeightMm { get; set; } = 10;
+        public int FontSize { get; set; } = 12;
+        public string? StaticValue { get; set; }
+        public string? DataKey { get; set; }
+    }
+
+    private enum LabelElementType
+    {
+        Text,
+        Barcode128,
+        Qr
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,658 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: string.Empty),
+                    IsDomainAccount = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorRequired = table.Column<bool>(type: "bit", nullable: false),
+                    Department = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AuthenticatorKey = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: "system"),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AppSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Section = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    EntityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Action = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    PerformedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Roles = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    PerformedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ChangeSummary = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    ChangedFieldsJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    UserAgent = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Alias = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    HealthStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Configuration = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DictionaryEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DictType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DictionaryEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FeatureModules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FeatureModules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Target = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    JobStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ArtifactPath = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDevices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    DeviceTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDevices", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Servers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    EnvironmentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WsusPriorityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerRoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Servers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Workstations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OwnerId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    OwnerDisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    OwnerDepartment = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LocationNote = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Cpu = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Ram = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Storage = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    MacAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Workstations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorSecrets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ConnectorProfileId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    SecretReference = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorSecrets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConnectorSecrets_ConnectorProfiles_ConnectorProfileId",
+                        column: x => x.ConnectorProfileId,
+                        principalTable: "ConnectorProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataScopes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DepartmentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    ScopeType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataScopes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DataScopes_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LabelPrintJobId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Copies = table.Column<int>(type: "int", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LabelPrintJobItems_LabelPrintJobs_LabelPrintJobId",
+                        column: x => x.LabelPrintJobId,
+                        principalTable: "LabelPrintJobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDeviceAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    NetworkDeviceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDeviceAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NetworkDeviceAssignments_NetworkDevices_NetworkDeviceId",
+                        column: x => x.NetworkDeviceId,
+                        principalTable: "NetworkDevices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServerNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServerNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServerNetworkAssignments_Servers_ServerId",
+                        column: x => x.ServerId,
+                        principalTable: "Servers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkstationNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkstationNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkstationNetworkAssignments_Workstations_WorkstationId",
+                        column: x => x.WorkstationId,
+                        principalTable: "Workstations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true,
+                filter: "[NormalizedName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true,
+                filter: "[NormalizedUserName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConnectorSecrets_ConnectorProfileId",
+                table: "ConnectorSecrets",
+                column: "ConnectorProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataScopes_AppUserId",
+                table: "DataScopes",
+                column: "AppUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LabelPrintJobItems_LabelPrintJobId",
+                table: "LabelPrintJobItems",
+                column: "LabelPrintJobId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NetworkDeviceAssignments_NetworkDeviceId",
+                table: "NetworkDeviceAssignments",
+                column: "NetworkDeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerNetworkAssignments_ServerId",
+                table: "ServerNetworkAssignments",
+                column: "ServerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkstationNetworkAssignments_WorkstationId",
+                table: "WorkstationNetworkAssignments",
+                column: "WorkstationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppSettings");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AuditLogs");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorSecrets");
+
+            migrationBuilder.DropTable(
+                name: "DataScopes");
+
+            migrationBuilder.DropTable(
+                name: "DictionaryEntries");
+
+            migrationBuilder.DropTable(
+                name: "FeatureModules");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobItems");
+
+            migrationBuilder.DropTable(
+                name: "LabelTemplates");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDeviceAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ServerNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "WorkstationNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorProfiles");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobs");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDevices");
+
+            migrationBuilder.DropTable(
+                name: "Servers");
+
+            migrationBuilder.DropTable(
+                name: "Workstations");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -1,0 +1,877 @@
+using System;
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    partial class AppDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppRole", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Description")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("Name")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedName").IsUnique().HasFilter("[NormalizedName] IS NOT NULL");
+
+                b.ToTable("AspNetRoles", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppSetting", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Section")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Value")
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AppSettings");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("AccessFailedCount")
+                    .HasColumnType("int");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue("system");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Department")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("AuthenticatorKey")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("DisplayName")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue(string.Empty);
+
+                b.Property<string>("Email")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<bool>("EmailConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("IsDomainAccount")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("LockoutEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<DateTimeOffset?>("LockoutEnd")
+                    .HasColumnType("datetimeoffset");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("NormalizedEmail")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedUserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("PasswordHash")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("PhoneNumber")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("PhoneNumberConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<string>("SecurityStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<bool>("TwoFactorEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("TwoFactorRequired")
+                    .HasColumnType("bit");
+
+                b.Property<string>("UserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedEmail");
+
+                b.HasIndex("NormalizedUserName").IsUnique().HasFilter("[NormalizedUserName] IS NOT NULL");
+
+                b.ToTable("AspNetUsers", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AuditLog", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Action")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ChangeSummary")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("ChangedFieldsJson")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid>("EntityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("EntityType")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("IpAddress")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<DateTime>("PerformedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("PerformedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Roles")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("UserAgent")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AuditLogs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Alias")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Configuration")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("HealthStatus")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("Type")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.ToTable("ConnectorProfiles");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ConnectorProfileId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("SecretReference")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ConnectorProfileId");
+
+                b.ToTable("ConnectorSecrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid?>("DepartmentId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid?>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ScopeType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId");
+
+                b.ToTable("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DictionaryEntry", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("DictType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Value")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("DictionaryEntries");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.FeatureModule", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("Enabled")
+                    .HasColumnType("bit");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("FeatureModules");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ArtifactPath")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("JobStatus")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Target")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelPrintJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AssetId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("AssetType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<int>("Copies")
+                    .HasColumnType("int")
+                    .HasDefaultValue(1);
+
+                b.Property<Guid>("LabelPrintJobId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("LabelPrintJobId");
+
+                b.ToTable("LabelPrintJobItems");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelTemplate", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Code")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Payload")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelTemplates");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("DeviceTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.HasKey("Id");
+
+                b.ToTable("NetworkDevices");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("EnvironmentId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ServerRoleId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WsusPriorityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Servers");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Cpu")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("LocationNote")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("MacAddress")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("OwnerId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("OwnerDepartment")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("OwnerDisplayName")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Ram")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Storage")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WorkstationTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Workstations");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.ConnectorProfile", "ConnectorProfile")
+                    .WithMany("Secrets")
+                    .HasForeignKey("ConnectorProfileId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("ConnectorProfile");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.AppUser", "AppUser")
+                    .WithMany("DataScopes")
+                    .HasForeignKey("AppUserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("AppUser");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.LabelPrintJob", null)
+                    .WithMany("Items")
+                    .HasForeignKey("LabelPrintJobId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("NetworkDeviceId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("NetworkDeviceId");
+
+                    b1.ToTable("NetworkDeviceAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("ServerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("ServerId");
+
+                    b1.ToTable("ServerNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("WorkstationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("WorkstationId");
+
+                    b1.ToTable("WorkstationNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Navigation("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Navigation("Secrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Navigation("Items");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,119 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public class AppDbContext : IdentityDbContext<AppUser, AppRole, Guid, IdentityUserClaim<Guid>, IdentityUserRole<Guid>, IdentityUserLogin<Guid>, IdentityRoleClaim<Guid>, IdentityUserToken<Guid>>, IAppDbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Server> Servers => Set<Server>();
+    public DbSet<NetworkDevice> NetworkDevices => Set<NetworkDevice>();
+    public DbSet<Workstation> Workstations => Set<Workstation>();
+    public DbSet<DictionaryEntry> DictionaryEntries => Set<DictionaryEntry>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<LabelTemplate> LabelTemplates => Set<LabelTemplate>();
+    public DbSet<LabelPrintJob> LabelPrintJobs => Set<LabelPrintJob>();
+    public new DbSet<AppUser> Users => Set<AppUser>();
+    public new DbSet<AppRole> Roles => Set<AppRole>();
+    public DbSet<FeatureModule> FeatureModules => Set<FeatureModule>();
+    public DbSet<AppSetting> Settings => Set<AppSetting>();
+    public DbSet<ConnectorProfile> ConnectorProfiles => Set<ConnectorProfile>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var auditLogs = BuildAuditEntries();
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        if (auditLogs.Count > 0)
+        {
+            AuditLogs.AddRange(auditLogs);
+            await base.SaveChangesAsync(cancellationToken);
+        }
+
+        return result;
+    }
+
+    private List<AuditLog> BuildAuditEntries()
+    {
+        var auditEntries = new List<AuditLog>();
+        var now = DateTime.UtcNow;
+
+        foreach (var entry in ChangeTracker.Entries<AuditableEntity>())
+        {
+            if (entry.State == EntityState.Detached || entry.State == EntityState.Unchanged)
+            {
+                continue;
+            }
+
+            var auditLog = new AuditLog
+            {
+                EntityType = entry.Entity.GetType().Name,
+                EntityId = entry.Entity.Id,
+                PerformedAtUtc = now,
+                PerformedBy = entry.Entity.ModifiedBy ?? entry.Entity.CreatedBy,
+                Roles = null
+            };
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    entry.Entity.CreatedAtUtc = now;
+                    auditLog.Action = "Create";
+                    auditLog.ChangeSummary = "Entity created";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.CurrentValues.ToObject());
+                    break;
+                case EntityState.Modified:
+                    entry.Entity.ModifiedAtUtc = now;
+                    auditLog.Action = "Update";
+                    auditLog.ChangeSummary = "Entity updated";
+                    auditLog.ChangedFieldsJson = SerializeChanges(entry);
+                    break;
+                case EntityState.Deleted:
+                    auditLog.Action = "Delete";
+                    auditLog.ChangeSummary = "Entity deleted";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.OriginalValues.ToObject());
+                    break;
+            }
+
+            auditEntries.Add(auditLog);
+        }
+
+        return auditEntries;
+    }
+
+    private static string SerializeChanges(EntityEntry entry)
+    {
+        var changes = new Dictionary<string, object?>();
+
+        foreach (var property in entry.Properties)
+        {
+            if (!property.IsModified)
+            {
+                continue;
+            }
+
+            changes[property.Metadata.Name] = new
+            {
+                Original = property.OriginalValue,
+                Current = property.CurrentValue
+            };
+        }
+
+        return JsonSerializer.Serialize(changes);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppRoleConfiguration : IEntityTypeConfiguration<AppRole>
+{
+    public void Configure(EntityTypeBuilder<AppRole> builder)
+    {
+        builder.ToTable("AspNetRoles");
+        builder.Property(x => x.Description).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppSettingConfiguration : IEntityTypeConfiguration<AppSetting>
+{
+    public void Configure(EntityTypeBuilder<AppSetting> builder)
+    {
+        builder.ToTable("AppSettings");
+        builder.Property(x => x.Section).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
@@ -1,0 +1,21 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.ToTable("AspNetUsers");
+        builder.Property(x => x.DisplayName).HasMaxLength(200);
+        builder.Property(x => x.Department).HasMaxLength(200);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.AuthenticatorKey).HasMaxLength(256);
+        builder.HasMany(x => x.DataScopes)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+{
+    public void Configure(EntityTypeBuilder<AuditLog> builder)
+    {
+        builder.ToTable("AuditLogs");
+        builder.Property(x => x.EntityType).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Action).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.PerformedBy).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Roles).HasMaxLength(200);
+        builder.Property(x => x.ChangeSummary).HasMaxLength(400);
+        builder.Property(x => x.IpAddress).HasMaxLength(50);
+        builder.Property(x => x.UserAgent).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorProfileConfiguration : IEntityTypeConfiguration<ConnectorProfile>
+{
+    public void Configure(EntityTypeBuilder<ConnectorProfile> builder)
+    {
+        builder.ToTable("ConnectorProfiles");
+        builder.Property(x => x.Type).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Alias).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.HealthStatus).HasMaxLength(50);
+        builder.HasMany(x => x.Secrets)
+            .WithOne(x => x.ConnectorProfile)
+            .HasForeignKey(x => x.ConnectorProfileId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorSecretConfiguration : IEntityTypeConfiguration<ConnectorSecret>
+{
+    public void Configure(EntityTypeBuilder<ConnectorSecret> builder)
+    {
+        builder.ToTable("ConnectorSecrets");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.SecretReference).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DataScopeConfiguration : IEntityTypeConfiguration<DataScope>
+{
+    public void Configure(EntityTypeBuilder<DataScope> builder)
+    {
+        builder.ToTable("DataScopes");
+        builder.Property(x => x.ScopeType).HasMaxLength(100).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DictionaryEntryConfiguration : IEntityTypeConfiguration<DictionaryEntry>
+{
+    public void Configure(EntityTypeBuilder<DictionaryEntry> builder)
+    {
+        builder.ToTable("DictionaryEntries");
+        builder.Property(x => x.DictType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class FeatureModuleConfiguration : IEntityTypeConfiguration<FeatureModule>
+{
+    public void Configure(EntityTypeBuilder<FeatureModule> builder)
+    {
+        builder.ToTable("FeatureModules");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobConfiguration : IEntityTypeConfiguration<LabelPrintJob>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJob> builder)
+    {
+        builder.ToTable("LabelPrintJobs");
+        builder.Property(x => x.Target).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.JobStatus).HasMaxLength(50).IsRequired();
+        builder.HasMany(x => x.Items)
+            .WithOne()
+            .HasForeignKey(x => x.LabelPrintJobId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobItemConfiguration : IEntityTypeConfiguration<LabelPrintJobItem>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJobItem> builder)
+    {
+        builder.ToTable("LabelPrintJobItems");
+        builder.Property(x => x.AssetType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Copies).HasDefaultValue(1);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelTemplateConfiguration : IEntityTypeConfiguration<LabelTemplate>
+{
+    public void Configure(EntityTypeBuilder<LabelTemplate> builder)
+    {
+        builder.ToTable("LabelTemplates");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Code).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).HasDefaultValue("ZPL");
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class NetworkDeviceConfiguration : IEntityTypeConfiguration<NetworkDevice>
+{
+    public void Configure(EntityTypeBuilder<NetworkDevice> builder)
+    {
+        builder.ToTable("NetworkDevices");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("NetworkDeviceAssignments");
+            nb.WithOwner().HasForeignKey("NetworkDeviceId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ServerConfiguration : IEntityTypeConfiguration<Server>
+{
+    public void Configure(EntityTypeBuilder<Server> builder)
+    {
+        builder.ToTable("Servers");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("ServerNetworkAssignments");
+            nb.WithOwner().HasForeignKey("ServerId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
@@ -1,0 +1,28 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class WorkstationConfiguration : IEntityTypeConfiguration<Workstation>
+{
+    public void Configure(EntityTypeBuilder<Workstation> builder)
+    {
+        builder.ToTable("Workstations");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Cpu).HasMaxLength(200);
+        builder.Property(x => x.Ram).HasMaxLength(100);
+        builder.Property(x => x.Storage).HasMaxLength(200);
+        builder.Property(x => x.MacAddress).HasMaxLength(100).IsRequired();
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("WorkstationNetworkAssignments");
+            nb.WithOwner().HasForeignKey("WorkstationId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
@@ -1,0 +1,81 @@
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public static class SeedData
+{
+    private static readonly (string Dict, string Key, string Value)[] DictionarySeeds =
+    {
+        ("Environment", "PROD", "Production"),
+        ("Environment", "TEST", "Testing"),
+        ("Environment", "DEV", "Development"),
+        ("WsusPriority", "HIGH", "Vysoká"),
+        ("WsusPriority", "NORMAL", "Standard"),
+        ("OperatingSystem", "WIN2022", "Windows Server 2022"),
+        ("OperatingSystem", "WIN11", "Windows 11"),
+        ("ServerRole", "APP", "Application Server"),
+        ("ServerRole", "DB", "Database Server"),
+        ("WorkstationType", "PC", "Desktop"),
+        ("WorkstationType", "LAPTOP", "Notebook"),
+        ("Location", "HQ-1F", "HQ 1st Floor"),
+        ("Location", "HQ-2F", "HQ 2nd Floor"),
+        ("VLAN", "VLAN10", "Production 10"),
+        ("VLAN", "VLAN20", "DMZ 20"),
+    };
+
+    public static async Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<AppRole>>();
+
+        if (!await roleManager.Roles.AnyAsync(cancellationToken))
+        {
+            var roles = new[]
+            {
+                new AppRole { Name = SystemRoleNames.SuperAdmin, NormalizedName = SystemRoleNames.SuperAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.ServerAdmin, NormalizedName = SystemRoleNames.ServerAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.NetworkAdmin, NormalizedName = SystemRoleNames.NetworkAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.AppAdmin, NormalizedName = SystemRoleNames.AppAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.Helpdesk, NormalizedName = SystemRoleNames.Helpdesk.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.HelpdeskRead, NormalizedName = SystemRoleNames.HelpdeskRead.ToUpperInvariant() }
+            };
+
+            foreach (var role in roles)
+            {
+                await roleManager.CreateAsync(role);
+            }
+        }
+
+        foreach (var seed in DictionarySeeds)
+        {
+            if (!await context.DictionaryEntries.AnyAsync(x => x.DictType == seed.Dict && x.Key == seed.Key, cancellationToken))
+            {
+                context.DictionaryEntries.Add(new DictionaryEntry
+                {
+                    DictType = seed.Dict,
+                    Key = seed.Key,
+                    Value = seed.Value,
+                    CreatedAtUtc = DateTime.UtcNow,
+                    CreatedBy = "seed"
+                });
+            }
+        }
+
+        if (!await context.FeatureModules.AnyAsync(cancellationToken))
+        {
+            context.FeatureModules.AddRange(new[]
+            {
+                new FeatureModule { Key = "labels", Name = "Labels & Printing", Enabled = true, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "reports", Name = "Reports & Schedules", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "zabbix", Name = "Zabbix Metrics", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" }
+            });
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
@@ -1,0 +1,34 @@
+using System.Security.Cryptography;
+using HWInventory.Application.Abstractions;
+using OtpNet;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class TotpService : ITotpService
+{
+    private const int SecretSize = 20;
+
+    public string GenerateSecretKey()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(SecretSize);
+        return Base32Encoding.ToString(bytes);
+    }
+
+    public string GenerateCode(string secretKey)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.ComputeTotp(DateTime.UtcNow);
+    }
+
+    public bool ValidateCode(string secretKey, string code)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.VerifyTotp(code, out _, VerificationWindow.RfcSpecifiedNetworkDelay);
+    }
+
+    private static Totp CreateTotp(string secretKey)
+    {
+        var key = Base32Encoding.ToBytes(secretKey);
+        return new Totp(key, mode: OtpHashMode.Sha1, step: 30, totpSize: 6);
+    }
+}

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,0 +1,10 @@
+# HW Inventory Admin UI (Placeholder)
+
+The React + Vite + Tailwind admin application will live in this directory. Upcoming milestones:
+
+1. Scaffold Vite project structure with routing, layout shell, and Tailwind theme tokens.
+2. Implement authentication shell (login, MFA prompt) integrated with the API once auth is available.
+3. Build pages for dashboard, servers, network, workstations, dictionaries, audit, labels, modules, and settings (including the onboarding wizard).
+4. Connect to API endpoints, implement pagination/filtering, and render label previews.
+
+Until the UI is generated the directory contains documentation placeholders only.

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HW Inventory Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "hw-inventory-admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.17.0",
+    "axios": "^1.6.0",
+    "clsx": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/web/postcss.config.cjs
+++ b/src/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,0 +1,72 @@
+import { Link, Outlet, Route, Routes } from 'react-router-dom';
+import { useTheme } from './hooks/useTheme';
+import { DashboardPage } from './pages/DashboardPage';
+import { PlaceholderPage } from './pages/PlaceholderPage';
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/servers', label: 'Servers' },
+  { to: '/network', label: 'Network' },
+  { to: '/workstations', label: 'Workstations' },
+  { to: '/audit', label: 'Audit' },
+  { to: '/labels', label: 'Labels' },
+  { to: '/settings', label: 'Settings' },
+  { to: '/modules', label: 'Modules' }
+];
+
+const Layout = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="min-h-screen bg-slate-100 dark:bg-slate-950">
+      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-white">HW Inventory</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Operations control center</p>
+          </div>
+          <button
+            onClick={toggleTheme}
+            className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium shadow-sm transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            type="button"
+          >
+            {theme === 'light' ? '🌙 Dark mode' : '☀️ Light mode'}
+          </button>
+        </div>
+        <nav className="bg-slate-50 dark:bg-slate-950">
+          <div className="mx-auto flex max-w-6xl flex-wrap gap-3 px-6 py-2 text-sm font-medium">
+            {navItems.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className="rounded px-3 py-1 text-slate-700 transition hover:bg-slate-200 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+const App = () => (
+  <Routes>
+    <Route path="/" element={<Layout />}>
+      <Route index element={<DashboardPage />} />
+      <Route path="servers" element={<PlaceholderPage title="Servers" description="Server inventory grid will appear here." />} />
+      <Route path="network" element={<PlaceholderPage title="Network devices" description="Network device management workspace." />} />
+      <Route path="workstations" element={<PlaceholderPage title="Workstations" description="Workstation lifecycle management UI." />} />
+      <Route path="audit" element={<PlaceholderPage title="Audit" description="Audit trail filters and export tools." />} />
+      <Route path="labels" element={<PlaceholderPage title="Labels" description="Label editor and batch printing." />} />
+      <Route path="settings" element={<PlaceholderPage title="Settings" description="Administrative configuration center." />} />
+      <Route path="modules" element={<PlaceholderPage title="Modules" description="Feature toggle management." />} />
+    </Route>
+  </Routes>
+);
+
+export default App;

--- a/src/web/src/hooks/useTheme.ts
+++ b/src/web/src/hooks/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../theme/ThemeProvider';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+};

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </ThemeProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/web/src/pages/DashboardPage.tsx
+++ b/src/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,29 @@
+export const DashboardPage = () => {
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Quick stats</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Connect the dashboard to /api/dashboard/summary to surface real-time insights across servers, network devices and workstations.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          {['Servers', 'Network devices', 'Workstations'].map((label) => (
+            <div key={label} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <p className="text-sm text-slate-500 dark:text-slate-400">{label}</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">0</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Getting started checklist</h3>
+        <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+          <li>1. Configure SQL Server connection and run the onboarding wizard.</li>
+          <li>2. Enable authentication providers and test 2FA enrollment.</li>
+          <li>3. Sync baseline dictionaries and import inventory data.</li>
+          <li>4. Review scheduled jobs, backup policies, and alerting connectors.</li>
+        </ul>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/PlaceholderPage.tsx
+++ b/src/web/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type PlaceholderPageProps = {
+  title: string;
+  description: string;
+};
+
+export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title, description }) => (
+  <div className="space-y-4 rounded-lg border border-dashed border-slate-300 bg-white p-6 text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+    <h2 className="text-xl font-semibold">{title}</h2>
+    <p>{description}</p>
+    <p className="text-sm text-slate-500 dark:text-slate-400">
+      Scaffold API clients with React Query to fetch data from the secured ASP.NET Core backend. This shell ensures the dark/light
+      theme toggle and navigation system are ready for the upcoming modules.
+    </p>
+  </div>
+);

--- a/src/web/src/styles.css
+++ b/src/web/src/styles.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 transition-colors duration-200;
+}
+
+[data-theme='dark'] body {
+  @apply bg-slate-900 text-slate-100;
+}

--- a/src/web/src/theme/ThemeProvider.tsx
+++ b/src/web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => undefined
+});
+
+const STORAGE_KEY = 'hw-inventory:theme';
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/src/web/tailwind.config.cjs
+++ b/src/web/tailwind.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          dark: '#1d4ed8'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/web/tsconfig.node.json
+++ b/src/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: false
+  },
+  preview: {
+    port: 4173
+  }
+});


### PR DESCRIPTION
## Summary
- add centralized authorization policy constants and register policy-to-role mappings during infrastructure setup
- secure inventory, settings, audit, modules, labels, and dashboard controllers with the new role-based policies and shared authentication requirement
- document the new RBAC guard rails in the README and status report

## Testing
- not run (dotnet SDK unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e519d659008324a7e28854833a88fb