### PR TITLE
Add security connectors and first-run security wizard step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Build outputs
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Node
+node_modules/
+dist/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Installer artifacts
+publish/
+artifacts/
+*.zip
+*.pkg
+
+# Secrets
+*.pfx
+appsettings.Local.json
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# HwInventory
+# HW Inventory Platform (Monorepo Skeleton)
+
+This repository provides a .NET 8 and React monorepo scaffold for the HW Inventory platform described in the consolidated specification. The previous Python prototype has been replaced with the target architecture so that future iterations can focus on completing feature depth rather than replatforming.
+
+> **Status:** the solution is **not** production-ready. The current codebase now boots with SQL Server, ASP.NET Core Identity (including TOTP 2FA scaffolding), baseline policy-based RBAC guard rails with per-user location/department scoping, persistent audit logging, Quartz.NET job scheduling, a label rendering engine, and a React admin shell with dark/light theming. Security integrations now cover LDAP/AD test/dry-run endpoints, dynamic OIDC configuration, configurable password policies, CAPTCHA and SMS connector management, AD group-to-role mappings, middleware-backed session tracking with remote logout APIs, plus a dedicated React „Security Settings“ page that spravuje OIDC/LDAP/SSPR/CAPTCHA/SMS/politiky hesel, ukazuje auditní diffy a v režimu administrace nabízí správu aktivních relací. Součástí je také první iterace průvodce prvním spuštěním, která agreguje bezpečnostní kroky. However, the majority of domain workflows (handover, imports/exports, backups, updates, extended connectors, remaining onboarding steps, etc.) are still outstanding—see [`docs/implementation-plan.md`](docs/implementation-plan.md) for the full backlog.
+
+## Structure
+
+```
+/attachments      Supporting templates and artefacts (placeholders)
+/db               Database migrations and seed data (to be completed)
+/docs             Product documentation (manual, release notes, etc.)
+/scripts          Deployment helpers (IIS installer placeholder)
+/src
+  /api            ASP.NET Core solution (Domain, Application, Infrastructure, Api)
+  /web            React admin shell (Vite + Tailwind, dark/light theme toggle)
+```
+
+### API Solution
+
+The API solution (`src/api/HWInventory.sln`) includes four projects:
+
+* **HWInventory.Domain** – entity definitions for servers, network devices, workstations, audit, RBAC, connectors, labels, and settings.
+* **HWInventory.Application** – shared abstractions (e.g., `IAppDbContext`), paging helpers, and DTOs for application services.
+* **HWInventory.Infrastructure** – EF Core `DbContext`, SQL Server migrations, Identity integration, Quartz.NET job wiring, label rendering services, and initial seed data.
+* **HWInventory.Api** – ASP.NET Core Web API exposing the required endpoints (`/api/servers`, `/api/network-devices`, `/api/workstations`, `/api/dictionaries`, `/api/audit`, `/api/modules`, `/api/dashboard/summary`, `/api/labels/*`, `/api/auth/*`).
+
+The API defaults to SQL Server (LocalDB for development, configurable via `appsettings.json`), runs migrations on startup, and seeds baseline dictionaries, roles, and feature modules. Controllers implement CRUD, soft-retire/restore flows, module toggling, dashboard summaries, label rendering (QuestPDF + ZPL), and `/api/auth` endpoints for profile introspection plus TOTP enrollment. Background processing is orchestrated through Quartz.NET (`LabelPrintJobProcessor`).
+
+### Remaining Work
+
+The skeleton is intentionally incomplete compared to the full specification. Major follow-up tasks include (see the implementation plan for detail):
+
+* Rozšířit bezpečnostní governance: napojit bezpečnostní kroky na zbytek onboarding wizardu, dokončit SSO/OIDC hardening, session dashboards a bezpečnostní reporting, a provázat politiky hesel s runtime enforcementem v Identity.
+* Building the React admin (`src/web`) with onboarding wizard, dark/light theming, feature pages, and contextual help.
+* Delivering domain workflows: workstation handover PDFs/e-mails, label management and printing, imports/exports with jobs, reports & schedules, connectors catalogue, backups/restores, updates, observability, Help Center.
+* Completing packaging: installer scripts, All-in-One builder, GitHub Actions, documentation set (manual, release notes, deployment guide), and smoke tests.
+
+### Suggested execution order
+
+If you are planning the next development iteration, tackle the milestones in this order (summarised from the implementation plan):
+
+1. **Foundations & persistence** – move to SQL Server, produce migrations, seed data, configuration options, and job scheduling infrastructure.
+2. **Identity & security** – wire up Identity, 2FA, SSPR, CAPTCHA, scoped RBAC, and the onboarding wizard steps that exercise SMTP/LDAP connectivity.
+3. **Inventory workflows** – finish CRUD, audit diffing, VLAN/IP enforcement, handover PDFs/e-mails, labels, imports/exports, and async jobs.
+4. **Operations & integrations** – connectors catalogue, Updates, Backup & Restore, Reports & Schedules, Observability dashboards.
+5. **Frontend completion** – full React admin, theming, contextual help/manual integration, UI automation tests.
+6. **Packaging & release** – installers, builder scripts, GitHub Actions, All-in-One ZIP with SHA256, documentation, and smoke/regression test suites.
+
+## Getting Started
+
+1. Ensure the .NET 8 SDK is installed.
+2. Restore dependencies and build the solution:
+   ```bash
+   cd src/api
+   dotnet restore
+   dotnet build
+   dotnet run --project src/HWInventory.Api/HWInventory.Api.csproj
+   ```
+3. Browse Swagger UI at `https://localhost:5001/swagger` (or configured URL).
+
+> **Note:** In this environment the .NET SDK and third-party packages (e.g., QuestPDF) are not pre-installed. The project files are provided so that the solution restores and builds once the SDK is available.
+
+## Licensing
+
+QuestPDF is licensed under the Polyform Noncommercial license. Evaluate licensing implications before production use.

--- a/attachments/README.md
+++ b/attachments/README.md
@@ -1,0 +1,3 @@
+# Attachments Placeholder
+
+This folder will host import/export templates, label samples (ZPL/PDF/PNG), email templates, BPMN diagrams, and other artefacts referenced in the delivery checklist. Populate as the corresponding features are implemented.

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,0 +1,3 @@
+# EF Core Migrations Placeholder
+
+Runtime migrations now live under `src/api/src/HWInventory.Infrastructure/Migrations` so that they compile with the API solution. Use this folder to store exported SQL scripts (if required for DBA review) or versioned documentation about migration batches that accompany the packaged releases.

--- a/db/seed/README.md
+++ b/db/seed/README.md
@@ -1,0 +1,3 @@
+# Database Seed Data Placeholder
+
+EF Core seed data currently resides in `HWInventory.Infrastructure`. When full migrations are created, move static CSV/JSON seeds into this directory to be packaged with the installer and All-in-One distribution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# HW Inventory – Architecture Skeleton (v1)
+
+This document captures the initial .NET-based architecture that replaces the earlier Python FastAPI prototype. The structure aligns with the Codex implementation brief and provides a foundation for subsequent feature work.
+
+## Projects Overview
+
+* **HWInventory.Domain** – Entities and enums representing inventory assets, audit logs, RBAC objects, connectors, label templates, and settings. Entities derive from `AuditableEntity` to support audit metadata and soft-state transitions.
+* **HWInventory.Application** – Shared contracts (e.g., `IAppDbContext`), paging helpers, and filter descriptors. Application services can depend on these abstractions without referencing ASP.NET Core directly.
+* **HWInventory.Infrastructure** – EF Core persistence layer with entity configurations, SQL Server/InMemory providers, DI extensions, and seeded baseline data (roles, dictionaries, feature modules).
+* **HWInventory.Api** – ASP.NET Core Web API hosting controllers, swagger, health endpoints, and label rendering helpers (QuestPDF). The API exposes CRUD for servers, network devices, workstations, dictionaries, audit, modules, dashboard summary, and label templates/print jobs.
+
+## Persistence
+
+* EF Core `AppDbContext` manages inventory tables and owned collections for VLAN/IP assignments.
+* Seed data creates baseline dictionaries (environment, WSUS priority, OS, server roles, workstation types, VLAN, locations) and feature modules (labels, reports, Zabbix).
+* Database provider defaults to InMemory when no connection string is configured; relational providers trigger migrations when available.
+
+## API Highlights
+
+* Controllers implement pagination with `X-Total-Count` and RFC5988 `Link` headers (limited to simple next/prev semantics for now).
+* Servers/NetworkDevices/Workstations expose CRUD + retire/restore flows to mirror the specification.
+* Workstation handover endpoint updates ownership/location metadata (email/PDF automation to be delivered later).
+* Modules API toggles feature flags to support optional components (labels, reports, Zabbix, etc.).
+* Dashboard summary aggregates counts and latest audit entries.
+* Labels controller manages templates, renders sample PDF previews via QuestPDF, and captures print job requests (persisted for auditing/queue processing).
+
+## Next Steps
+
+* Introduce authentication/authorization middleware, policy-based enforcement, and LDAP/OIDC connectors.
+* Replace placeholder installer with IIS-aware deployment automation and All-in-One packaging scripts.
+* Expand audit logging to capture diffs and export audit events.
+* Implement background job processing for print jobs, report schedules, and import/export pipelines.
+* Build the React admin UI with module toggles, settings wizard, and dark/light theming.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,155 @@
+# HW Inventory Platform – Implementation Plan
+
+This document enumerates the outstanding work required to transform the current monorepo skeleton into a production-ready release that satisfies the full specification from the "HW Inventory – Zadání pro Codex" document. Items are grouped by thematic area and capture dependencies where relevant.
+
+## 1. Platform Foundations
+- **Adopt SQL Server persistence**
+  - Replace the InMemory provider with SQL Server across all environments.
+  - Create comprehensive EF Core migrations for the domain model (servers, network devices, workstations, dictionaries, users/roles, audit, connectors, labels, jobs, reports, backups, updates, settings, modules, etc.).
+  - Seed baseline dictionaries, RBAC roles, feature modules, connectors, and system settings with idempotent scripts.
+- **Configuration model**
+  - Introduce strongly-typed options for App Configuration, Security & Auth, LDAP, SMTP, Connectors, Reports, Import/Export, Maintenance, Observability, Advanced, About/Support, Handover, Updates, Backup & Restore.
+  - Ensure secrets are stored encrypted (DPAPI on Windows / AES-256 elsewhere) and surfaced in the UI as "set/unset" flags with reset flows.
+- **Background job infrastructure**
+  - Integrate Quartz.NET (or Hangfire if selected) for scheduled jobs (LDAP sync, reports, backups, exports, print jobs, maintenance, observability health checks).
+  - Design persistence tables for job definitions, executions, locks, and audit.
+
+## 2. Security, Identity, and RBAC
+- **Identity provider**
+  - Implement ASP.NET Core Identity with support for local accounts and Active Directory/LDAP linked identities.
+  - Add password policies (complexity, expiry, history) and lockout rules in line with the specification.
+- **Authentication mechanisms**
+  - Enable cookie-based sessions for the admin UI plus JWT/OIDC for API access as needed.
+  - Support external SSO/OIDC providers with configurable discovery and claim mapping.
+- **Two-factor authentication (2FA)**
+  - Provide TOTP (OtpNet) and e-mail OTP methods with enforced enrollment for Super Admin.
+  - Implement per-role/group policy enforcement, overrides, reset flows, backup codes, and audit trails.
+- **Self-service password reset (SSPR)**
+  - Build secure token issuance with optional SMS OTP via the SMS connector, CAPTCHA enforcement, rate limiting, and audit logging.
+- **Session management**
+  - Expose active sessions, remote logout, automatic invalidation after password changes, and inactivity timeouts.
+- **RBAC policies**
+  - Materialize policies (Servers.*, Network.*, Workstations.*, Dicts.*, Audit.Read, Settings.*) and map LDAP groups to roles with an auditable ruleset.
+  - Implement data scoping per department/location across queries, exports, dashboards, and print jobs.
+
+## 3. Domain Features
+- **Inventory management**
+  - Complete CRUD flows, retire/restore, hard delete (with password confirmation), comments, audit history, Excel import/export, PDF/CSV exports.
+  - Enforce VLAN/IP pairing logic, status management, and scoped administration for Aplikační admin role.
+- **Workstation handover**
+  - Implement mandatory old/new location capture, PDF generation via QuestPDF, templated e-mails with dynamic recipients, CC/BCC, attachments, and audit entries.
+- **Labels & printing**
+  - Finalize label template editor (JSON schema), Code128/EAN-13/QR rendering, ZPL and PDF outputs, batch printing, print job queue with destinations (download, named printer, raw socket 9100), audit, and artefact retention policies.
+- **Dictionaries**
+  - Build full CRUD with import/export (CSV/XLSX), duplicate detection, referential integrity, VLAN metadata requirements, and audit.
+- **Audit logging**
+  - Persist JSON diffs for all entity operations, support filtering (entity, user, action, timeframe), highlight deletes/restores, and include export functionality that logs access.
+- **Reports & schedules**
+  - Provide report definitions with filters (e.g., retired devices, aging assets, expiring warranties), scheduling (daily/weekly/monthly), async execution with e-mail delivery, and history tracking.
+- **Import/Export jobs**
+  - Implement dry-run validation, async processing with progress tracking, per-user concurrency limits, expiring download links, deduplicated notifications, and audit.
+- **Backup & restore**
+  - Build UI/API for scoped backups (full/partial), AES-256 encryption with password confirmation, scheduling, integrity checks, optional e-mail delivery, restore flows with confirmations, history, and incremental options.
+- **Updates module**
+  - Support upload of update packages (ZIP/PKG), validation, optional backup, maintenance mode, file replacement, migration execution, log viewing, audit, and rollback to previous version.
+- **Connectors catalogue**
+  - CRUD for connector profiles (Database, External SQL, SMTP, SMS, LDAP, OIDC, Webhooks, SFTP/FTPS, Storage, Printing, Observability, Zabbix), test connections with readable errors, secret rotation, retry/backoff, periodic health checks, status dashboard.
+- **Observability**
+  - Expose structured logging, /health, /metrics, OpenTelemetry exporter configuration, correlation IDs in responses, diagnostics export for support.
+
+## 4. Frontend (React + Vite + Tailwind)
+- **App shell**
+  - Implement authentication views, onboarding wizard (9 steps), dark/light theme toggle persisted in localStorage, responsive layout, accessibility considerations.
+- **Feature pages**
+  - Evidence pages for servers, network devices, workstations with tables, filters, scoped data, multi-select actions (batch export, print, retire).
+  - Audit explorer with filtering, highlighting, diff viewer, export.
+  - Labels & printing section with template editor, preview, batch printing workflow, job status list.
+  - Settings subsections (App Configuration, Security & Auth, LDAP/AD Sync, Email, Dictionaries, Roles & Users, Labels & Printing, Reports & Schedules, Import/Export, Maintenance, Observability, Advanced, About & Support, Handover, Updates, Backup & Restore).
+  - Modules page with toggles (GET/POST /api/modules).
+  - Dashboard with counts, recent changes, quick actions.
+  - Help Center integration (embedded manual viewer, contextual "?" tooltips linking to manual chapters).
+- **API integration**
+  - Provide strongly-typed clients (OpenAPI generated or hand-written) with pagination, filters, and consistent error handling.
+  - Implement optimistic UI updates where appropriate and handle async job polling.
+
+## 5. Packaging & Deployment
+- **Installer & builder scripts**
+  - Complete PowerShell installer (installer.ps1) to set up IIS App Pool, file permissions, environment configuration, and health checks.
+  - Provide merge/all-in-one builder supporting MERGE/ALLINONE modes with logging, phase detection, regex fixes, wizard verification, and optional installer automation.
+- **CI/CD**
+  - Author GitHub Actions workflows for build, test (API + web), publish artefacts, generate All-in-One ZIP with SHA256 manifest, and smoke tests.
+- **All-in-One artefact**
+  - Package publish output, API contracts, migrations, installer, documentation, attachments, observability examples, release notes, checksums.
+- **Documentation**
+  - Produce manual.pdf, release notes template updates, user guide, deployment guide, troubleshooting, rollback instructions.
+
+## 6. Testing & Quality
+- **Automated tests**
+  - Unit, integration, and end-to-end tests covering domain logic, API endpoints, RBAC enforcement, background jobs, printing workflows, import/export, backups, updates.
+  - UI tests (Playwright) for key flows including onboarding wizard, settings updates, inventory CRUD, label printing, report scheduling.
+- **Smoke tests**
+  - Scripts verifying /health, login + 2FA, CRUD basics, label rendering, SMTP/LDAP tests post-deployment.
+- **Performance & security**
+  - Add rate limiting, CAPTCHA for login/SSPR, vulnerability scanning, dependency checks, and penetration testing considerations.
+
+## 7. Inputs Required From Stakeholders
+The following information is necessary to implement environment-specific integrations safely:
+1. **SMTP relay details** – host, port, TLS requirements, credentials, from/reply-to policy.
+2. **LDAP/AD topology** – hostnames, base DNs, group naming conventions for role mapping, attribute mapping preferences.
+3. **SMS provider selection** – preferred vendor (Twilio/Vonage/SMPP/HTTP gateway), sender ID policy, compliance requirements.
+4. **Storage locations** – UNC paths or S3 buckets for artefacts, backups, and exports.
+5. **Printing infrastructure** – target printer names or IPs for raw 9100 jobs, supported label sizes/DPI.
+6. **Branding assets** – organization name, logos, color palette, default e-mail templates (CZ/EN), handover PDF branding.
+7. **Security policies** – password complexity rules, session timeout standards, audit retention periods, captcha provider (if any).
+8. **Reporting requirements** – exact report recipients, schedules, filtering thresholds (e.g., warranty expiry days).
+9. **Observability endpoints** – OTEL collector URLs, authentication tokens, log retention policies.
+10. **Support contacts** – helpdesk URLs, diagnostic package recipients, escalation procedures.
+
+Documenting these inputs early will unblock the configuration-driven portions of the build and reduce rework during implementation.
+
+## 8. Recommended execution order
+To turn the blueprint into a production-ready release, iterate through the following milestone-oriented phases. Each phase is
+designed to produce a demonstrable increment that can be validated with automated smoke tests and short stakeholder reviews.
+
+1. **Foundations & Persistence**
+   - Switch to SQL Server, ship the initial migration bundle, and stand up seed data for dictionaries, roles, modules, and feature
+     flags.
+   - Harden the configuration system, secrets storage, and background job infrastructure so subsequent features can rely on
+     durable state and scheduling.
+2. **Identity, RBAC, and Security**
+   - Light up ASP.NET Core Identity, session management, 2FA (TOTP/e-mail), SSPR, CAPTCHA, and policy-based authorization with
+     scoped data filters.
+   - Deliver the first pass of the onboarding wizard to exercise authentication, SMTP test, and LDAP dry-run flows end to end.
+3. **Core Inventory Workflows**
+   - Complete server/network/workstation CRUD, retire/restore, comments, audit diffing, VLAN/IP enforcement, and scoped admin
+     behaviour.
+   - Implement handover PDFs/e-mail notifications, label management with ZPL/PDF rendering, and export/import jobs with dry-run.
+4. **Operations & Integrations**
+   - Finish connectors (SMTP, SMS, LDAP/OIDC, Webhooks, SFTP/FTPS, Storage, Printing, Observability) with health reporting and
+     secret rotation.
+   - Build the Updates, Backup & Restore, Reports & Schedules, and Observability modules plus dashboard widgets.
+5. **Frontend completion & UX polish**
+   - Deliver the full React/Vite admin app, dark/light theming, contextual help, manual viewer, and feature-specific pages.
+   - Add Playwright tests and align UI copy with terminology in the specification.
+6. **Packaging, CI/CD, and Release Enablement**
+   - Finalize PowerShell installers, builder/merger scripts, All-in-One ZIP with SHA256, GitHub Actions pipelines, release notes,
+     manual PDFs, and smoke tests ready for acceptance.
+
+## 9. Immediate actions possible without stakeholder input
+While waiting for environment-specific details, the following engineering work can start immediately inside the repository:
+
+- Replace EF Core InMemory with SQL Server LocalDB/SQL Express configuration and generate baseline migrations.
+- Implement ASP.NET Core Identity with built-in local authentication, password policies, and TOTP 2FA using OtpNet.
+- Create the base React/Vite project, navigation shell, authentication views, and dark/light theme toggle tied to localStorage.
+- Build audit logging infrastructure (entity change diffing, history endpoints) and wire it into existing CRUD handlers.
+- Implement label template storage, QuestPDF previews, and ZPL generation utilities with unit tests.
+- Set up Quartz.NET with tables for scheduled jobs and stub processors for LDAP sync, report scheduling, export, and backup jobs.
+- Draft PowerShell installer scaffolding to create IIS App Pool/sites and prepare configuration placeholders.
+
+These deliverables unblock downstream work and prove the end-to-end tooling without requiring external credentials.
+
+## 10. Items waiting on stakeholder input
+Once the engineering baseline above is in place, integrate the environment-specific values listed in Section 7. A consolidated
+tracking table should be maintained in the project wiki (or issue tracker) so that each dependency is assigned an owner and due
+date. During implementation, guard production-only settings behind feature flags and provide sensible development defaults to
+keep local environments functional while inputs are pending.

--- a/docs/status-report.md
+++ b/docs/status-report.md
@@ -1,0 +1,21 @@
+# HW Inventory Platform – Current Status
+
+_Last updated: 2025-10-07T23:30:00Z_
+
+## Implemented Capabilities
+- Monorepo scaffold targeting .NET 8 (API) and React/Vite (admin UI shell) with Tailwind-based dark/light theming.
+- ASP.NET Core backend structured into Domain, Application, Infrastructure, and Api layers with SQL Server persistence, Entity Framework Core migrations, and seeded baseline dictionaries, feature modules, and RBAC role definitions.
+- Identity foundation using ASP.NET Core Identity with TOTP 2FA helpers, policy-based authorization tied to the mandated RBAC roles (including per-user location/department data scoping), audit log entities that capture change diffs, and Quartz.NET background job wiring (initial label print processor).
+- Security integrations covering LDAP/AD connection tests and dry-runs, configurable OpenID Connect sign-in, password policy management, CAPTCHA validation, SMS-backed SSPR flows that revoke active sessions, auditované změny OIDC konfigurace i datových scopů a middleware, který sleduje aktivní relace uživatelů včetně vzdálených odhlášení, společně s React stránkou „Security Settings“ pro správu OIDC/LDAP/SSPR/CAPTCHA/SMS/politik hesel, mapování AD skupin na role, náhled auditních diffů a přehled aktivních relací s možností odhlášení.
+- First-run wizard skeleton with a dedicated „Bezpečnostní nastavení“ krok, který agreguje klíčové bezpečnostní formuláře přímo v průvodci onboardingem.
+- Label rendering services that produce QuestPDF previews and ZPL output, plus REST endpoints for inventory CRUD (servers, network devices, workstations), dictionaries, modules, dashboard summary, audit exploration, and TOTP enrollment.
+- PowerShell installer scaffold that provisions IIS resources and patches connection strings, alongside documentation describing the remaining backlog and execution plan.
+
+## Outstanding Work (High-Level)
+- Rozšířit security UX: napojit bezpečnostní krok na zbytek onboarding wizardu, dokončit SSO/OIDC hardening, doručit bezpečnostní reporting/dashboardy, vynucení politik hesel na Identity options a doplnit automatizované regresní testy.
+- Complete domain workflows: workstation handover PDF/e-mail process, import/export with dry-run and async jobs, reporting & schedules, connectors catalogue, backup/restore, updates module, observability endpoints, and full audit diff surfacing.
+- Build the full React admin experience: onboarding wizard, inventory tables with filters/batch actions, settings subsections, label template editor, reports dashboards, help center/manual integration, and modules toggles.
+- Deliver packaging & ops tooling: All-in-One builder, CI/CD pipelines, release notes/manual PDFs, smoke/regression tests, and artefact bundling with checksums.
+- Gather stakeholder inputs for SMTP, LDAP, SMS, storage, printing, branding, security policies, reporting thresholds, observability, and support contacts to configure environment-specific connectors.
+
+See [`docs/implementation-plan.md`](implementation-plan.md) for the detailed backlog and sequencing guidance.

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,0 +1,76 @@
+param(
+    [string]$PublishPath = "publish",
+    [string]$SiteName = "HWInventory",
+    [string]$AppPoolName = "HWInventoryPool",
+    [string]$AppPoolIdentity = "ApplicationPoolIdentity",
+    [string]$SqlConnectionString = "Server=localhost;Database=HWInventory;Trusted_Connection=True;TrustServerCertificate=True",
+    [switch]$SkipIisProvisioning
+)
+
+Import-Module WebAdministration -ErrorAction Stop
+
+function Ensure-Directory {
+    param([string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        Write-Host "[HWInventory] Creating directory $Path" -ForegroundColor Green
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function Update-AppSettings {
+    param([string]$ConfigPath, [string]$ConnectionString)
+
+    $json = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+    if (-not $json.ConnectionStrings) {
+        $json | Add-Member -NotePropertyName ConnectionStrings -NotePropertyValue @{ }
+    }
+
+    $json.ConnectionStrings.DefaultConnection = $ConnectionString
+    $json | ConvertTo-Json -Depth 6 | Out-File $ConfigPath -Encoding UTF8
+    Write-Host "[HWInventory] Updated $ConfigPath with SQL Server connection string" -ForegroundColor Green
+}
+
+function Grant-AppPermissions {
+    param([string]$Path, [string]$Identity)
+
+    Write-Host "[HWInventory] Granting Modify permissions to $Identity on $Path" -ForegroundColor Green
+    icacls $Path /grant "$Identity":(OI)(CI)M | Out-Null
+}
+
+Ensure-Directory -Path $PublishPath
+Ensure-Directory -Path (Join-Path $PublishPath "logs")
+
+$webConfigPath = Join-Path $PublishPath "appsettings.Production.json"
+if (-not (Test-Path $webConfigPath)) {
+    $webConfigPath = Join-Path $PublishPath "appsettings.json"
+}
+
+if (Test-Path $webConfigPath) {
+    Update-AppSettings -ConfigPath $webConfigPath -ConnectionString $SqlConnectionString
+} else {
+    Write-Warning "[HWInventory] Unable to locate appsettings file in $PublishPath. Please update the connection string manually."
+}
+
+if (-not $SkipIisProvisioning) {
+    Write-Host "[HWInventory] Configuring IIS application pool $AppPoolName" -ForegroundColor Cyan
+
+    if (-not (Get-Item "IIS:\AppPools\$AppPoolName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\AppPools\$AppPoolName" -Force | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name managedRuntimeVersion -Value ""
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name processModel.identityType -Value $AppPoolIdentity
+
+    Write-Host "[HWInventory] Ensuring IIS site $SiteName" -ForegroundColor Cyan
+    if (-not (Get-Item "IIS:\Sites\$SiteName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\Sites\$SiteName" -Bindings @{ protocol = "http"; bindingInformation = "*:8080:" } -PhysicalPath $PublishPath | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\Sites\$SiteName" -Name applicationPool -Value $AppPoolName
+
+    Grant-AppPermissions -Path $PublishPath -Identity "IIS AppPool\$AppPoolName"
+    Grant-AppPermissions -Path (Join-Path $PublishPath "logs") -Identity "IIS AppPool\$AppPoolName"
+}
+
+Write-Host "[HWInventory] Deployment artifacts staged successfully. Run dotnet ef database update or start the web application to apply migrations." -ForegroundColor Cyan

--- a/src/api/HWInventory.sln
+++ b/src/api/HWInventory.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Api", "src/HWInventory.Api/HWInventory.Api.csproj", "{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Application", "src/HWInventory.Application/HWInventory.Application.csproj", "{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Domain", "src/HWInventory.Domain/HWInventory.Domain.csproj", "{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Infrastructure", "src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj", "{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.Build.0 = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.Build.0 = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.Build.0 = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Produces("application/json")]
+[Route("api/[controller]")]
+public abstract class ApiControllerBase : ControllerBase
+{
+    protected ApiControllerBase(IAppDbContext dbContext)
+    {
+        DbContext = dbContext;
+    }
+
+    protected IAppDbContext DbContext { get; }
+
+    protected record DataScopeContext(bool IsScoped, IReadOnlyCollection<Guid> LocationIds, IReadOnlyCollection<string> DepartmentKeys)
+    {
+        public static DataScopeContext Unrestricted { get; } = new(false, Array.Empty<Guid>(), Array.Empty<string>());
+
+        public bool HasLocationRestrictions => IsScoped && LocationIds.Count > 0;
+
+        public bool HasDepartmentRestrictions => IsScoped && DepartmentKeys.Count > 0;
+    }
+
+    protected string ResolveUserDisplayName()
+    {
+        return User.Identity?.Name ?? User.FindFirstValue(ClaimTypes.Email) ?? "system";
+    }
+
+    protected void StampCreation(AuditableEntity entity)
+    {
+        var actor = ResolveUserDisplayName();
+        entity.CreatedBy = actor;
+        entity.ModifiedBy = actor;
+    }
+
+    protected void StampModification(AuditableEntity entity)
+    {
+        var actor = ResolveUserDisplayName();
+        entity.ModifiedBy = actor;
+    }
+
+    private static readonly JsonSerializerOptions AuditSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    protected void AddAuditLog(string entityType, Guid entityId, string action, string? summary = null, object? changedFields = null)
+    {
+        var actor = ResolveUserDisplayName();
+        var roles = string.Join(",", User.FindAll(ClaimTypes.Role).Select(r => r.Value));
+        var userAgent = Request?.Headers["User-Agent"].ToString();
+        var changedJson = changedFields is null ? null : JsonSerializer.Serialize(changedFields, AuditSerializerOptions);
+
+        var log = new AuditLog
+        {
+            EntityType = entityType,
+            EntityId = entityId,
+            Action = action,
+            PerformedBy = actor,
+            Roles = string.IsNullOrWhiteSpace(roles) ? null : roles,
+            PerformedAtUtc = DateTime.UtcNow,
+            ChangeSummary = summary,
+            ChangedFieldsJson = changedJson,
+            IpAddress = HttpContext?.Connection?.RemoteIpAddress?.ToString(),
+            UserAgent = string.IsNullOrWhiteSpace(userAgent) ? null : userAgent
+        };
+
+        DbContext.AuditLogs.Add(log);
+    }
+
+    protected async Task<DataScopeContext> ResolveDataScopeAsync(CancellationToken cancellationToken = default)
+    {
+        if (User.IsInRole(SystemRoleNames.SuperAdmin))
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdValue, out var userId))
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var scopeRows = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId)
+            .Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey })
+            .ToListAsync(cancellationToken);
+
+        if (scopeRows.Count == 0)
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var locationIds = new HashSet<Guid>();
+        var departmentKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var row in scopeRows)
+        {
+            if (row.ScopeType == DataScopeTypes.Location && row.LocationId.HasValue)
+            {
+                locationIds.Add(row.LocationId.Value);
+            }
+
+            if (row.ScopeType == DataScopeTypes.Department && !string.IsNullOrWhiteSpace(row.DepartmentKey))
+            {
+                departmentKeys.Add(row.DepartmentKey);
+            }
+        }
+
+        if (locationIds.Count == 0 && departmentKeys.Count == 0)
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        return new DataScopeContext(true, locationIds, departmentKeys);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuditController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuditController.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/audit")]
+[Authorize(Policy = AuthorizationPolicies.AuditRead)]
+public class AuditController : ApiControllerBase
+{
+    public AuditController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<AuditLog>>> GetAsync([FromQuery] string? entityType, [FromQuery] string? user, [FromQuery] string? action)
+    {
+        var query = DbContext.AuditLogs.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(entityType))
+        {
+            query = query.Where(x => x.EntityType == entityType);
+        }
+        if (!string.IsNullOrWhiteSpace(user))
+        {
+            query = query.Where(x => x.PerformedBy == user);
+        }
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            query = query.Where(x => x.Action == action);
+        }
+
+        var items = await query.OrderByDescending(x => x.PerformedAtUtc).Take(500).ToListAsync();
+        return Ok(items);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuthController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuthController.cs
@@ -1,0 +1,108 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/auth")]
+[ApiController]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+    private readonly ITotpService _totpService;
+
+    public AuthController(UserManager<AppUser> userManager, SignInManager<AppUser> signInManager, ITotpService totpService)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _totpService = totpService;
+    }
+
+    [HttpGet("me")]
+    [Authorize]
+    public async Task<ActionResult<object>> GetProfileAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return Ok(new
+        {
+            user.Id,
+            user.UserName,
+            user.DisplayName,
+            user.Email,
+            Roles = roles,
+            TwoFactorEnabled = user.TwoFactorEnabled,
+            TwoFactorRequired = user.TwoFactorRequired
+        });
+    }
+
+    [HttpPost("totp/setup")]
+    [Authorize]
+    public async Task<ActionResult<object>> BeginTotpSetupAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            user.AuthenticatorKey = _totpService.GenerateSecretKey();
+            await _userManager.UpdateAsync(user);
+        }
+
+        var code = _totpService.GenerateCode(user.AuthenticatorKey);
+        return Ok(new
+        {
+            SecretKey = user.AuthenticatorKey,
+            VerificationCode = code
+        });
+    }
+
+    [HttpPost("totp/verify")]
+    [Authorize]
+    public async Task<ActionResult> CompleteTotpSetupAsync([FromBody] TotpVerificationRequest request)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "TOTP secret not initialized",
+                Detail = "Call /api/auth/totp/setup before attempting verification."
+            });
+        }
+
+        if (!_totpService.ValidateCode(user.AuthenticatorKey, request.Code))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid verification code",
+                Detail = "The provided TOTP code could not be validated."
+            });
+        }
+
+        user.TwoFactorEnabled = true;
+        await _userManager.UpdateAsync(user);
+        await _userManager.SetTwoFactorEnabledAsync(user, true);
+        await _signInManager.RefreshSignInAsync(user);
+
+        return NoContent();
+    }
+
+    public record TotpVerificationRequest(string Code);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dashboard")]
+[Authorize(Policy = AuthorizationPolicies.DashboardView)]
+public class DashboardController : ApiControllerBase
+{
+    public DashboardController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet("summary")]
+    public async Task<ActionResult<DashboardSummaryResponse>> GetSummaryAsync()
+    {
+        var servers = await DbContext.Servers.CountAsync();
+        var network = await DbContext.NetworkDevices.CountAsync();
+        var workstations = await DbContext.Workstations.CountAsync();
+        var latestChanges = await DbContext.AuditLogs.AsNoTracking()
+            .OrderByDescending(x => x.PerformedAtUtc)
+            .Take(10)
+            .Select(x => new AuditEntryDto(x.EntityType, x.Action, x.PerformedBy, x.PerformedAtUtc))
+            .ToListAsync();
+
+        return Ok(new DashboardSummaryResponse(servers, network, workstations, latestChanges));
+    }
+
+    public record DashboardSummaryResponse(int Servers, int NetworkDevices, int Workstations, IReadOnlyCollection<AuditEntryDto> LatestChanges);
+
+    public record AuditEntryDto(string EntityType, string Action, string PerformedBy, DateTime PerformedAtUtc);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dictionaries")]
+[Authorize(Policy = AuthorizationPolicies.DictionariesManage)]
+public class DictionariesController : ApiControllerBase
+{
+    public DictionariesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<DictionaryEntry>>> GetAsync([FromQuery] string? type)
+    {
+        var query = DbContext.DictionaryEntries.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            query = query.Where(x => x.DictType == type);
+        }
+
+        var result = await query.OrderBy(x => x.DictType).ThenBy(x => x.Order).ThenBy(x => x.Value).ToListAsync();
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> GetByIdAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entry is null ? NotFound() : Ok(entry);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DictionaryEntry>> CreateAsync([FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = new DictionaryEntry
+        {
+            DictType = request.DictType,
+            Key = request.Key,
+            Value = request.Value,
+            Description = request.Description,
+            Order = request.Order,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system"
+        };
+
+        DbContext.DictionaryEntries.Add(entry);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entry.Id }, entry);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> UpdateAsync(Guid id, [FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        entry.DictType = request.DictType;
+        entry.Key = request.Key;
+        entry.Value = request.Value;
+        entry.Description = request.Description;
+        entry.Order = request.Order;
+        entry.ModifiedAtUtc = DateTime.UtcNow;
+        entry.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(entry);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.DictionaryEntries.Remove(entry);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/labels")]
+[Authorize(Policy = AuthorizationPolicies.LabelsManage)]
+public class LabelsController : ApiControllerBase
+{
+    private readonly ILabelRenderingService _labelRenderingService;
+
+    public LabelsController(IAppDbContext dbContext, ILabelRenderingService labelRenderingService) : base(dbContext)
+    {
+        _labelRenderingService = labelRenderingService;
+    }
+
+    [HttpGet("templates")]
+    public async Task<ActionResult<IEnumerable<LabelTemplate>>> GetTemplatesAsync()
+    {
+        var templates = await DbContext.LabelTemplates.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(templates);
+    }
+
+    [HttpPost("templates")]
+    public async Task<ActionResult<LabelTemplate>> CreateTemplateAsync([FromBody] LabelTemplate request)
+    {
+        request.Id = Guid.NewGuid();
+        request.CreatedAtUtc = DateTime.UtcNow;
+        request.CreatedBy = User.Identity?.Name ?? "system";
+        DbContext.LabelTemplates.Add(request);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetTemplateByIdAsync), new { id = request.Id }, request);
+    }
+
+    [HttpGet("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> GetTemplateByIdAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return template is null ? NotFound() : Ok(template);
+    }
+
+    [HttpPut("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> UpdateTemplateAsync(Guid id, [FromBody] LabelTemplate request)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        template.Name = request.Name;
+        template.Code = request.Code;
+        template.Format = request.Format;
+        template.Payload = request.Payload;
+        template.Description = request.Description;
+        template.ModifiedAtUtc = DateTime.UtcNow;
+        template.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(template);
+    }
+
+    [HttpDelete("templates/{id:guid}")]
+    public async Task<IActionResult> DeleteTemplateAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.LabelTemplates.Remove(template);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("templates/{id:guid}/render/pdf")]
+    public async Task<IActionResult> RenderPdfAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var pdf = _labelRenderingService.RenderPdf(template, data);
+        return File(pdf, "application/pdf", $"{template.Code}.pdf");
+    }
+
+    [HttpPost("templates/{id:guid}/render/zpl")]
+    public async Task<IActionResult> RenderZplAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var zpl = _labelRenderingService.RenderZpl(template, data);
+        return Ok(new { zpl });
+    }
+
+    [HttpPost("print-jobs")]
+    public async Task<ActionResult<LabelPrintJob>> CreatePrintJobAsync([FromBody] CreatePrintJobRequest request)
+    {
+        var job = new LabelPrintJob
+        {
+            Target = request.Target,
+            Format = request.Format,
+            JobStatus = "Queued",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system",
+            Items = request.Items.Select(item => new LabelPrintJobItem
+            {
+                AssetId = item.AssetId,
+                AssetType = item.AssetType,
+                Copies = item.Copies
+            }).ToList()
+        };
+
+        DbContext.LabelPrintJobs.Add(job);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetPrintJobByIdAsync), new { id = job.Id }, job);
+    }
+
+    [HttpGet("print-jobs")]
+    public async Task<ActionResult<IEnumerable<LabelPrintJob>>> GetPrintJobsAsync()
+    {
+        var jobs = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items)
+            .OrderByDescending(x => x.CreatedAtUtc).Take(100).ToListAsync();
+        return Ok(jobs);
+    }
+
+    [HttpGet("print-jobs/{id:guid}")]
+    public async Task<ActionResult<LabelPrintJob>> GetPrintJobByIdAsync(Guid id)
+    {
+        var job = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items).FirstOrDefaultAsync(x => x.Id == id);
+        return job is null ? NotFound() : Ok(job);
+    }
+
+    public record CreatePrintJobRequest(string Target, string Format, IReadOnlyCollection<PrintJobItemDto> Items);
+
+    public record PrintJobItemDto(Guid AssetId, string AssetType, int Copies);
+
+    public record LabelRenderRequest(Dictionary<string, string>? Data);
+}

--- a/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/modules")]
+[Authorize(Policy = AuthorizationPolicies.ModulesManage)]
+public class ModulesController : ApiControllerBase
+{
+    public ModulesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<FeatureModule>>> GetAsync()
+    {
+        var modules = await DbContext.FeatureModules.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(modules);
+    }
+
+    [HttpPost("{key}/toggle")]
+    public async Task<IActionResult> ToggleAsync(string key, [FromQuery] bool? enabled, [FromBody] FeatureModuleToggleRequest? body)
+    {
+        var module = await DbContext.FeatureModules.FirstOrDefaultAsync(x => x.Key == key);
+        if (module is null)
+        {
+            return NotFound();
+        }
+
+        var newState = enabled ?? body?.Enabled ?? !module.Enabled;
+        module.Enabled = newState;
+        module.ModifiedAtUtc = DateTime.UtcNow;
+        module.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(module);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
@@ -1,0 +1,240 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/network-devices")]
+public class NetworkDevicesController : ApiControllerBase
+{
+    public NetworkDevicesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<PagedResult<NetworkDevice>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.NetworkDevices.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("network-devices", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<NetworkDevice>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<NetworkDevice>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> CreateAsync([FromBody] NetworkDeviceRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.NetworkDevices.Add(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> UpdateAsync(Guid id, [FromBody] NetworkDeviceRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RetireAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        DbContext.NetworkDevices.Remove(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private static NetworkDevice Map(NetworkDeviceRequestDto request)
+    {
+        return new NetworkDevice
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            DeviceTypeId = request.DeviceTypeId,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(NetworkDevice entity, NetworkDeviceRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.DeviceTypeId = request.DeviceTypeId;
+        entity.Manufacturer = request.Manufacturer;
+        entity.Model = request.Model;
+        entity.LocationId = request.LocationId;
+        entity.RackPosition = request.RackPosition;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.SupportUntil = request.SupportUntil;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/SecurityController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/SecurityController.cs
@@ -1,0 +1,964 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.SecurityManage)]
+public class SecurityController : ApiControllerBase
+{
+    private readonly ILdapSyncService _ldapSyncService;
+    private readonly ILdapConfigurationStore _ldapConfigurationStore;
+    private readonly IExternalIdentityService _externalIdentityService;
+    private readonly ISessionTracker _sessionTracker;
+    private readonly ISsprConfigurationStore _ssprConfigurationStore;
+    private readonly ICaptchaConfigurationStore _captchaConfigurationStore;
+    private readonly ISmsConnectorStore _smsConnectorStore;
+    private readonly IPasswordPolicyConfigurationStore _passwordPolicyConfigurationStore;
+
+    public SecurityController(
+        IAppDbContext dbContext,
+        ILdapSyncService ldapSyncService,
+        ILdapConfigurationStore ldapConfigurationStore,
+        IExternalIdentityService externalIdentityService,
+        ISessionTracker sessionTracker,
+        ISsprConfigurationStore ssprConfigurationStore,
+        ICaptchaConfigurationStore captchaConfigurationStore,
+        ISmsConnectorStore smsConnectorStore,
+        IPasswordPolicyConfigurationStore passwordPolicyConfigurationStore) : base(dbContext)
+    {
+        _ldapSyncService = ldapSyncService;
+        _ldapConfigurationStore = ldapConfigurationStore;
+        _externalIdentityService = externalIdentityService;
+        _sessionTracker = sessionTracker;
+        _ssprConfigurationStore = ssprConfigurationStore;
+        _captchaConfigurationStore = captchaConfigurationStore;
+        _smsConnectorStore = smsConnectorStore;
+        _passwordPolicyConfigurationStore = passwordPolicyConfigurationStore;
+    }
+
+    [HttpGet("oidc")]
+    public async Task<ActionResult<OidcConfiguration?>> GetOidcAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("oidc")]
+    public async Task<ActionResult> ConfigureOidcAsync([FromBody] OidcConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+
+        var configuration = new OidcConfiguration(
+            request.Enabled,
+            request.Authority,
+            request.ClientId,
+            request.ClientSecret,
+            request.ResponseType,
+            request.Scopes ?? Array.Empty<string>(),
+            request.ClaimMappings ?? new Dictionary<string, string>(),
+            request.UsePkce);
+
+        await _externalIdentityService.ConfigureOidcAsync(configuration, cancellationToken);
+
+        var previousSnapshot = previous is null ? null : CreateOidcSnapshot(previous);
+        var currentSnapshot = CreateOidcSnapshot(configuration);
+        if (previousSnapshot is null || !previousSnapshot.Equals(currentSnapshot))
+        {
+            var auditBefore = previous is null ? null : CreateOidcAuditPayload(previous);
+            var auditAfter = CreateOidcAuditPayload(configuration);
+            var summary = configuration.Enabled
+                ? "Aktualizace nastavení OIDC"
+                : "Deaktivace OIDC přihlášení";
+
+            AddAuditLog(
+                "Security.OIDC",
+                Guid.Empty,
+                "Update",
+                summary,
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("ldap/config")]
+    public async Task<ActionResult<LdapConfigurationModel>> GetLdapConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("ldap/config")]
+    public async Task<ActionResult> ConfigureLdapAsync([FromBody] LdapConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        var update = new LdapConfigurationUpdate(
+            request.Enabled,
+            request.Host,
+            request.Port,
+            request.UseSsl,
+            request.BindDn,
+            request.Password,
+            request.ResetPassword,
+            request.IgnoreCertificateErrors,
+            request.UsersBaseDn,
+            request.UsersFilter,
+            request.AttributeMap ?? Array.Empty<string>());
+
+        var updated = await _ldapConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!LdapConfigsEqual(previous, updated))
+        {
+            var auditBefore = CreateLdapAuditPayload(previous);
+            var auditAfter = CreateLdapAuditPayload(updated);
+
+            AddAuditLog(
+                "Security.LDAP",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení LDAP/AD",
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost("ldap/test")]
+    public async Task<ActionResult<LdapConnectionTestResult>> TestLdapAsync([FromBody] LdapConnectionOptions options, CancellationToken cancellationToken)
+    {
+        var result = await _ldapSyncService.TestConnectionAsync(options, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost("ldap/dry-run")]
+    public async Task<ActionResult<LdapDryRunResult>> DryRunLdapAsync([FromBody] LdapDryRunRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ldapSyncService.DryRunAsync(request, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpGet("sspr/config")]
+    public async Task<ActionResult<SsprConfigurationModel>> GetSsprConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _ssprConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("sspr/config")]
+    public async Task<ActionResult> ConfigureSsprAsync([FromBody] SsprConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _ssprConfigurationStore.GetAsync(cancellationToken);
+        var update = new SsprConfigurationUpdate(
+            request.Enabled,
+            request.RequireTwoFactor,
+            request.RequireCaptcha,
+            request.RequireSmsOtp,
+            request.TokenExpiryMinutes,
+            request.ThrottleWindowMinutes,
+            request.MaxRequestsPerWindow,
+            request.SmsConnectorKey);
+
+        var updated = await _ssprConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!SsprConfigsEqual(previous, updated))
+        {
+            var auditBefore = CreateSsprAuditPayload(previous);
+            var auditAfter = CreateSsprAuditPayload(updated);
+
+            AddAuditLog(
+                "Security.SSPR",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení SSPR",
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("password-policy")]
+    public async Task<ActionResult<PasswordPolicyModel>> GetPasswordPolicyAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _passwordPolicyConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("password-policy")]
+    public async Task<ActionResult> ConfigurePasswordPolicyAsync([FromBody] PasswordPolicyRequest request, CancellationToken cancellationToken)
+    {
+        if (request.MinimumLength < 6)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Příliš krátké heslo",
+                Detail = "Minimální délka hesla musí být alespoň 6 znaků."
+            });
+        }
+
+        if (request.LockoutAttempts < 1)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný limit pokusů",
+                Detail = "Počet pokusů pro uzamknutí musí být kladné číslo."
+            });
+        }
+
+        if (request.LockoutDurationMinutes < 1)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná doba uzamčení",
+                Detail = "Doba uzamčení musí být alespoň 1 minuta."
+            });
+        }
+
+        if (request.ExpirationDays < 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná expirace",
+                Detail = "Expirace hesla nemůže být záporná."
+            });
+        }
+
+        if (request.HistoryCount < 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná historie",
+                Detail = "Počet uchovaných hesel nemůže být záporný."
+            });
+        }
+
+        var previous = await _passwordPolicyConfigurationStore.GetAsync(cancellationToken);
+        var update = new PasswordPolicyUpdate(
+            request.Enabled,
+            request.MinimumLength,
+            request.RequireUppercase,
+            request.RequireLowercase,
+            request.RequireDigit,
+            request.RequireNonAlphanumeric,
+            request.ExpirationDays,
+            request.HistoryCount,
+            request.LockoutAttempts,
+            request.LockoutDurationMinutes);
+
+        var updated = await _passwordPolicyConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!PasswordPoliciesEqual(previous, updated))
+        {
+            AddAuditLog(
+                "Security.PasswordPolicy",
+                Guid.Empty,
+                "Update",
+                "Aktualizace politiky hesel",
+                new { Before = previous, After = updated });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("captcha/config")]
+    public async Task<ActionResult<CaptchaConfigurationModel>> GetCaptchaConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _captchaConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("captcha/config")]
+    public async Task<ActionResult> ConfigureCaptchaAsync([FromBody] CaptchaConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _captchaConfigurationStore.GetAsync(cancellationToken);
+        var update = new CaptchaConfigurationUpdate(
+            request.Enabled,
+            request.SiteKey,
+            request.Secret,
+            request.RotateSecret,
+            request.VerificationEndpoint,
+            request.BypassToken);
+
+        var updated = await _captchaConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!CaptchaConfigsEqual(previous, updated))
+        {
+            AddAuditLog(
+                "Security.Captcha",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení CAPTCHA",
+                new { Before = previous, After = updated });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("sms/config")]
+    public async Task<ActionResult<SmsConnectorModel?>> GetSmsConnectorAsync(CancellationToken cancellationToken)
+    {
+        var connector = await _smsConnectorStore.GetAsync(cancellationToken);
+        return Ok(connector);
+    }
+
+    [HttpPost("sms/config")]
+    public async Task<ActionResult<SmsConnectorModel>> ConfigureSmsAsync([FromBody] SmsConnectorRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Endpoint))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí endpoint",
+                Detail = "Je nutné zadat URL endpointu SMS konektoru."
+            });
+        }
+
+        var update = new SmsConnectorUpdate(
+            request.Alias,
+            request.Enabled,
+            request.Endpoint,
+            request.Sender,
+            request.Region,
+            request.Secret,
+            request.RotateSecret);
+
+        var previous = await _smsConnectorStore.GetAsync(cancellationToken);
+        var result = await _smsConnectorStore.SaveAsync(update, cancellationToken);
+
+        if (previous is null || !SmsConfigsEqual(previous, result) || request.RotateSecret)
+        {
+            AddAuditLog(
+                "Security.SMS",
+                result.Id ?? Guid.Empty,
+                "Update",
+                "Aktualizace SMS konektoru",
+                new
+                {
+                    Before = previous,
+                    After = result,
+                    RotatedSecret = request.RotateSecret
+                });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("ldap/role-mappings")]
+    public async Task<ActionResult<IEnumerable<LdapRoleMappingResponse>>> GetLdapRoleMappingsAsync(CancellationToken cancellationToken)
+    {
+        var mappings = await DbContext.LdapRoleMappings
+            .Where(x => x.Status == EntityStatus.Active)
+            .OrderBy(x => x.GroupName)
+            .Select(x => new LdapRoleMappingResponse(x.Id, x.GroupName, x.RoleName))
+            .ToListAsync(cancellationToken);
+
+        return Ok(mappings);
+    }
+
+    [HttpPost("ldap/role-mappings")]
+    public async Task<ActionResult<LdapRoleMappingResponse>> CreateLdapRoleMappingAsync([FromBody] LdapRoleMappingRequest request, CancellationToken cancellationToken)
+    {
+        var normalizedGroup = request.GroupName?.Trim();
+        var normalizedRole = request.RoleName?.Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizedGroup) || string.IsNullOrWhiteSpace(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná data",
+                Detail = "Je nutné zadat skupinu i roli."
+            });
+        }
+
+        if (!IsSupportedRole(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá role",
+                Detail = "Zadaná role není podporována."
+            });
+        }
+
+        var exists = await DbContext.LdapRoleMappings.AnyAsync(x =>
+            x.Status == EntityStatus.Active &&
+            x.GroupName.Equals(normalizedGroup, StringComparison.OrdinalIgnoreCase) &&
+            x.RoleName.Equals(normalizedRole, StringComparison.OrdinalIgnoreCase), cancellationToken);
+
+        if (exists)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Mapování již existuje",
+                Detail = "Kombinace skupiny a role je již definována."
+            });
+        }
+
+        var mapping = new LdapRoleMapping
+        {
+            GroupName = normalizedGroup,
+            RoleName = normalizedRole,
+            Status = EntityStatus.Active
+        };
+
+        StampCreation(mapping);
+        DbContext.LdapRoleMappings.Add(mapping);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Create",
+            "Vytvořeno mapování AD skupiny na roli",
+            new { mapping.GroupName, mapping.RoleName });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new LdapRoleMappingResponse(mapping.Id, mapping.GroupName, mapping.RoleName));
+    }
+
+    [HttpPut("ldap/role-mappings/{id:guid}")]
+    public async Task<ActionResult<LdapRoleMappingResponse>> UpdateLdapRoleMappingAsync(Guid id, [FromBody] LdapRoleMappingRequest request, CancellationToken cancellationToken)
+    {
+        var mapping = await DbContext.LdapRoleMappings.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (mapping is null)
+        {
+            return NotFound();
+        }
+
+        var normalizedGroup = request.GroupName?.Trim();
+        var normalizedRole = request.RoleName?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedGroup) || string.IsNullOrWhiteSpace(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná data",
+                Detail = "Je nutné zadat skupinu i roli."
+            });
+        }
+
+        if (!IsSupportedRole(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá role",
+                Detail = "Zadaná role není podporována."
+            });
+        }
+
+        var before = new { mapping.GroupName, mapping.RoleName, mapping.Status };
+
+        mapping.GroupName = normalizedGroup;
+        mapping.RoleName = normalizedRole;
+        mapping.Status = EntityStatus.Active;
+        StampModification(mapping);
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Update",
+            "Aktualizováno mapování AD skupiny",
+            new { Before = before, After = new { mapping.GroupName, mapping.RoleName, mapping.Status } });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new LdapRoleMappingResponse(mapping.Id, mapping.GroupName, mapping.RoleName));
+    }
+
+    [HttpDelete("ldap/role-mappings/{id:guid}")]
+    public async Task<ActionResult> DeleteLdapRoleMappingAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var mapping = await DbContext.LdapRoleMappings.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (mapping is null)
+        {
+            return NotFound();
+        }
+
+        if (mapping.Status == EntityStatus.Retired)
+        {
+            return NoContent();
+        }
+
+        var before = new { mapping.GroupName, mapping.RoleName, mapping.Status };
+        mapping.Status = EntityStatus.Retired;
+        StampModification(mapping);
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Delete",
+            "Mapování AD skupiny deaktivováno",
+            new { Before = before, After = new { mapping.GroupName, mapping.RoleName, mapping.Status } });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpGet("users/{userId:guid}/scopes")]
+    public async Task<ActionResult<IEnumerable<DataScopeResponse>>> GetScopesAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var scopes = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId && x.Status == EntityStatus.Active)
+            .Select(x => new DataScopeResponse(x.Id, x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToListAsync(cancellationToken);
+
+        return Ok(scopes);
+    }
+
+    [HttpPut("users/{userId:guid}/scopes")]
+    public async Task<ActionResult<IEnumerable<DataScopeResponse>>> UpdateScopesAsync(Guid userId, [FromBody] IEnumerable<DataScopeRequest> scopes, CancellationToken cancellationToken)
+    {
+        var requested = scopes?.ToList() ?? new List<DataScopeRequest>();
+        var validScopeTypes = new[] { DataScopeTypes.Location, DataScopeTypes.Department };
+        if (requested.Any(scope => !validScopeTypes.Contains(scope.ScopeType, StringComparer.OrdinalIgnoreCase)))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid scope type",
+                Detail = "ScopeType must be either Location or Department."
+            });
+        }
+
+        var normalizedRequests = requested.Select(Normalize).ToList();
+        foreach (var normalized in normalizedRequests)
+        {
+            if (normalized.ScopeType == DataScopeTypes.Location && normalized.LocationId is null)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Missing location",
+                    Detail = "Location scopes must include LocationId."
+                });
+            }
+
+            if (normalized.ScopeType == DataScopeTypes.Department && string.IsNullOrWhiteSpace(normalized.DepartmentKey))
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Missing department",
+                    Detail = "Department scopes must include DepartmentKey."
+                });
+            }
+        }
+
+        var existing = await DbContext.DataScopes.Where(x => x.AppUserId == userId).ToListAsync(cancellationToken);
+        var beforeActive = existing
+            .Where(x => x.Status == EntityStatus.Active)
+            .Select(x => new ScopeSnapshot(x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToList();
+
+        foreach (var row in existing)
+        {
+            var match = normalizedRequests.FirstOrDefault(r => r.ScopeType.Equals(row.ScopeType, StringComparison.OrdinalIgnoreCase) &&
+                Nullable.Equals(r.LocationId, row.LocationId) &&
+                string.Equals(r.DepartmentKey, row.DepartmentKey, StringComparison.OrdinalIgnoreCase));
+
+            if (match is null)
+            {
+                if (row.Status != EntityStatus.Retired)
+                {
+                    StampModification(row);
+                    row.Status = EntityStatus.Retired;
+                }
+            }
+            else if (row.Status != EntityStatus.Active)
+            {
+                StampModification(row);
+                row.Status = EntityStatus.Active;
+            }
+        }
+
+        foreach (var normalized in normalizedRequests)
+        {
+            var hasMatch = existing.Any(row => row.ScopeType.Equals(normalized.ScopeType, StringComparison.OrdinalIgnoreCase) &&
+                Nullable.Equals(row.LocationId, normalized.LocationId) &&
+                string.Equals(row.DepartmentKey, normalized.DepartmentKey, StringComparison.OrdinalIgnoreCase));
+
+            if (!hasMatch)
+            {
+                var scope = new DataScope
+                {
+                    AppUserId = userId,
+                    ScopeType = normalized.ScopeType,
+                    LocationId = normalized.LocationId,
+                    DepartmentKey = normalized.DepartmentKey,
+                    Status = EntityStatus.Active
+                };
+
+                StampCreation(scope);
+                DbContext.DataScopes.Add(scope);
+            }
+        }
+
+        var afterActive = normalizedRequests
+            .Select(x => new ScopeSnapshot(x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToList();
+
+        if (!ScopeSetsEqual(beforeActive, afterActive))
+        {
+            var beforeAudit = beforeActive.Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey }).ToList();
+            var afterAudit = afterActive.Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey }).ToList();
+            var summary = $"Aktualizovány datové scope uživatele {userId}";
+
+            AddAuditLog(
+                "Security.DataScopes",
+                userId,
+                "Update",
+                summary,
+                new { Before = beforeAudit, After = afterAudit });
+        }
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        var updated = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId && x.Status == EntityStatus.Active)
+            .Select(x => new DataScopeResponse(x.Id, x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToListAsync(cancellationToken);
+
+        return Ok(updated);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpGet("users/{userId:guid}/sessions")]
+    public async Task<ActionResult<IEnumerable<UserSessionDto>>> GetSessionsAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var sessions = await _sessionTracker.GetActiveSessionsAsync(userId, cancellationToken);
+        return Ok(sessions);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpGet("users")]
+    public async Task<ActionResult<IEnumerable<UserSummary>>> SearchUsersAsync([FromQuery] string? query, CancellationToken cancellationToken)
+    {
+        var normalized = query?.Trim();
+
+        var usersQuery = DbContext.Users
+            .Where(x => x.Status == EntityStatus.Active);
+
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            var likePattern = $"%{normalized}%";
+            usersQuery = usersQuery.Where(x =>
+                EF.Functions.Like(x.DisplayName, likePattern) ||
+                (x.Email != null && EF.Functions.Like(x.Email, likePattern)) ||
+                (x.UserName != null && EF.Functions.Like(x.UserName, likePattern)));
+        }
+
+        var results = await usersQuery
+            .OrderBy(x => x.DisplayName)
+            .ThenBy(x => x.Email)
+            .Take(20)
+            .Select(x => new UserSummary(
+                x.Id,
+                string.IsNullOrWhiteSpace(x.DisplayName) ? (x.UserName ?? x.Email ?? string.Empty) : x.DisplayName,
+                x.Email ?? string.Empty,
+                x.UserName ?? string.Empty))
+            .ToListAsync(cancellationToken);
+
+        return Ok(results);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpPost("sessions/{sessionId:guid}/revoke")]
+    public async Task<ActionResult> RevokeSessionAsync(Guid sessionId, [FromBody] SessionRevokeRequest request, CancellationToken cancellationToken)
+    {
+        var actor = ResolveUserDisplayName();
+        await _sessionTracker.RevokeAsync(sessionId, actor, request?.Reason, cancellationToken);
+
+        AddAuditLog(
+            "Security.Session",
+            sessionId,
+            "Revoke",
+            $"Sezení odhlášeno administrátorem {actor}",
+            new { SessionId = sessionId, Reason = request?.Reason });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpPost("users/{userId:guid}/sessions/revoke-all")]
+    public async Task<ActionResult> RevokeAllSessionsAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var actor = ResolveUserDisplayName();
+        await _sessionTracker.RevokeAllAsync(userId, actor, cancellationToken);
+
+        AddAuditLog(
+            "Security.Session",
+            userId,
+            "RevokeAll",
+            $"Hromadné odhlášení uživatele {userId}",
+            new { UserId = userId });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    public record OidcConfigurationRequest(
+        bool Enabled,
+        string Authority,
+        string ClientId,
+        string? ClientSecret,
+        string? ResponseType,
+        IReadOnlyCollection<string>? Scopes,
+        IReadOnlyDictionary<string, string>? ClaimMappings,
+        bool UsePkce);
+
+    public record PasswordPolicyRequest(
+        bool Enabled,
+        int MinimumLength,
+        bool RequireUppercase,
+        bool RequireLowercase,
+        bool RequireDigit,
+        bool RequireNonAlphanumeric,
+        int ExpirationDays,
+        int HistoryCount,
+        int LockoutAttempts,
+        int LockoutDurationMinutes);
+
+    public record DataScopeRequest(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    public record DataScopeResponse(Guid Id, string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    public record SessionRevokeRequest(string? Reason);
+
+    public record UserSummary(Guid Id, string DisplayName, string Email, string UserName);
+
+    public record LdapConfigurationRequest(
+        bool Enabled,
+        string Host,
+        int Port,
+        bool UseSsl,
+        string BindDn,
+        string? Password,
+        bool ResetPassword,
+        bool IgnoreCertificateErrors,
+        string UsersBaseDn,
+        string? UsersFilter,
+        IReadOnlyCollection<string>? AttributeMap);
+
+    public record SsprConfigurationRequest(
+        bool Enabled,
+        bool RequireTwoFactor,
+        bool RequireCaptcha,
+        bool RequireSmsOtp,
+        int TokenExpiryMinutes,
+        int ThrottleWindowMinutes,
+        int MaxRequestsPerWindow,
+        string? SmsConnectorKey);
+
+    public record CaptchaConfigurationRequest(
+        bool Enabled,
+        string SiteKey,
+        string VerificationEndpoint,
+        string? Secret,
+        bool RotateSecret,
+        string? BypassToken);
+
+    public record SmsConnectorRequest(
+        string Alias,
+        bool Enabled,
+        string Endpoint,
+        string? Sender,
+        string? Region,
+        string? Secret,
+        bool RotateSecret);
+
+    public record LdapRoleMappingRequest(string GroupName, string RoleName);
+
+    public record LdapRoleMappingResponse(Guid Id, string GroupName, string RoleName);
+
+    private static NormalizedScope Normalize(DataScopeRequest request)
+    {
+        var scopeType = request.ScopeType.Equals(DataScopeTypes.Department, StringComparison.OrdinalIgnoreCase)
+            ? DataScopeTypes.Department
+            : DataScopeTypes.Location;
+
+        var locationId = scopeType == DataScopeTypes.Location ? request.LocationId : null;
+        var departmentKey = scopeType == DataScopeTypes.Department ? request.DepartmentKey : null;
+
+        return new NormalizedScope(scopeType, locationId, departmentKey);
+    }
+
+    private static bool CaptchaConfigsEqual(CaptchaConfigurationModel previous, CaptchaConfigurationModel current)
+    {
+        return previous.Enabled == current.Enabled &&
+            string.Equals(previous.SiteKey, current.SiteKey, StringComparison.Ordinal) &&
+            previous.HasSecret == current.HasSecret &&
+            string.Equals(previous.VerificationEndpoint, current.VerificationEndpoint, StringComparison.Ordinal) &&
+            string.Equals(previous.BypassToken, current.BypassToken, StringComparison.Ordinal);
+    }
+
+    private static bool SmsConfigsEqual(SmsConnectorModel before, SmsConnectorModel current)
+    {
+        return string.Equals(before.Alias, current.Alias, StringComparison.Ordinal) &&
+            before.Enabled == current.Enabled &&
+            string.Equals(before.Endpoint, current.Endpoint, StringComparison.Ordinal) &&
+            string.Equals(before.Sender ?? string.Empty, current.Sender ?? string.Empty, StringComparison.Ordinal) &&
+            string.Equals(before.Region ?? string.Empty, current.Region ?? string.Empty, StringComparison.Ordinal) &&
+            before.HasSecret == current.HasSecret;
+    }
+
+    private static readonly string[] SupportedRoles =
+    {
+        SystemRoleNames.SuperAdmin,
+        SystemRoleNames.ServerAdmin,
+        SystemRoleNames.NetworkAdmin,
+        SystemRoleNames.AppAdmin,
+        SystemRoleNames.Helpdesk,
+        SystemRoleNames.HelpdeskRead
+    };
+
+    private static bool IsSupportedRole(string roleName)
+    {
+        return SupportedRoles.Any(r => r.Equals(roleName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static OidcSnapshot CreateOidcSnapshot(OidcConfiguration configuration)
+    {
+        var scopeSignature = string.Join("|", configuration.Scopes.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+        var claimSignature = string.Join("|", configuration.ClaimMappings
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+
+        return new OidcSnapshot(
+            configuration.Enabled,
+            configuration.Authority,
+            configuration.ClientId,
+            !string.IsNullOrWhiteSpace(configuration.ClientSecret),
+            configuration.ResponseType ?? "code",
+            scopeSignature,
+            claimSignature,
+            configuration.UsePkce);
+    }
+
+    private static object CreateOidcAuditPayload(OidcConfiguration configuration) => new
+    {
+        configuration.Enabled,
+        configuration.Authority,
+        configuration.ClientId,
+        ClientSecretSet = !string.IsNullOrWhiteSpace(configuration.ClientSecret),
+        ResponseType = configuration.ResponseType,
+        Scopes = configuration.Scopes,
+        ClaimMappings = configuration.ClaimMappings,
+        configuration.UsePkce
+    };
+
+    private static bool ScopeSetsEqual(IReadOnlyCollection<ScopeSnapshot> before, IReadOnlyCollection<ScopeSnapshot> after)
+    {
+        if (before.Count != after.Count)
+        {
+            return false;
+        }
+
+        var beforeKeys = new HashSet<string>(before.Select(CreateScopeKey), StringComparer.OrdinalIgnoreCase);
+        var afterKeys = new HashSet<string>(after.Select(CreateScopeKey), StringComparer.OrdinalIgnoreCase);
+        return beforeKeys.SetEquals(afterKeys);
+    }
+
+    private static string CreateScopeKey(ScopeSnapshot scope)
+    {
+        var normalizedType = scope.ScopeType.Equals(DataScopeTypes.Department, StringComparison.OrdinalIgnoreCase)
+            ? DataScopeTypes.Department
+            : DataScopeTypes.Location;
+        var location = scope.LocationId?.ToString() ?? string.Empty;
+        var department = scope.DepartmentKey?.Trim().ToLowerInvariant() ?? string.Empty;
+        return $"{normalizedType}|{location}|{department}";
+    }
+
+    private record NormalizedScope(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    private record OidcSnapshot(bool Enabled, string Authority, string ClientId, bool ClientSecretSet, string ResponseType, string ScopeSignature, string ClaimSignature, bool UsePkce);
+
+    private record ScopeSnapshot(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    private static bool LdapConfigsEqual(LdapConfigurationModel before, LdapConfigurationModel after)
+    {
+        return before.Enabled == after.Enabled
+            && string.Equals(before.Host, after.Host, StringComparison.OrdinalIgnoreCase)
+            && before.Port == after.Port
+            && before.UseSsl == after.UseSsl
+            && string.Equals(before.BindDn, after.BindDn, StringComparison.Ordinal)
+            && before.HasPassword == after.HasPassword
+            && before.IgnoreCertificateErrors == after.IgnoreCertificateErrors
+            && string.Equals(before.UsersBaseDn, after.UsersBaseDn, StringComparison.Ordinal)
+            && string.Equals(before.UsersFilter ?? string.Empty, after.UsersFilter ?? string.Empty, StringComparison.Ordinal)
+            && before.AttributeMap.SequenceEqual(after.AttributeMap ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool SsprConfigsEqual(SsprConfigurationModel before, SsprConfigurationModel after)
+    {
+        return before.Enabled == after.Enabled
+            && before.RequireTwoFactor == after.RequireTwoFactor
+            && before.RequireCaptcha == after.RequireCaptcha
+            && before.RequireSmsOtp == after.RequireSmsOtp
+            && before.TokenExpiryMinutes == after.TokenExpiryMinutes
+            && before.ThrottleWindowMinutes == after.ThrottleWindowMinutes
+            && before.MaxRequestsPerWindow == after.MaxRequestsPerWindow
+            && string.Equals(before.SmsConnectorKey ?? string.Empty, after.SmsConnectorKey ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool PasswordPoliciesEqual(PasswordPolicyModel before, PasswordPolicyModel after)
+    {
+        return before.Enabled == after.Enabled
+            && before.MinimumLength == after.MinimumLength
+            && before.RequireUppercase == after.RequireUppercase
+            && before.RequireLowercase == after.RequireLowercase
+            && before.RequireDigit == after.RequireDigit
+            && before.RequireNonAlphanumeric == after.RequireNonAlphanumeric
+            && before.ExpirationDays == after.ExpirationDays
+            && before.HistoryCount == after.HistoryCount
+            && before.LockoutAttempts == after.LockoutAttempts
+            && before.LockoutDurationMinutes == after.LockoutDurationMinutes;
+    }
+
+    private static object CreateLdapAuditPayload(LdapConfigurationModel model) => new
+    {
+        model.Enabled,
+        model.Host,
+        model.Port,
+        model.UseSsl,
+        model.BindDn,
+        PasswordSet = model.HasPassword,
+        model.IgnoreCertificateErrors,
+        model.UsersBaseDn,
+        model.UsersFilter,
+        AttributeMap = model.AttributeMap
+    };
+
+    private static object CreateSsprAuditPayload(SsprConfigurationModel model) => new
+    {
+        model.Enabled,
+        model.RequireTwoFactor,
+        model.RequireCaptcha,
+        model.RequireSmsOtp,
+        model.TokenExpiryMinutes,
+        model.ThrottleWindowMinutes,
+        model.MaxRequestsPerWindow,
+        model.SmsConnectorKey
+    };
+}

--- a/src/api/src/HWInventory.Api/Controllers/ServersController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ServersController.cs
@@ -1,0 +1,262 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+public class ServersController : ApiControllerBase
+{
+    public ServersController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<PagedResult<Server>>> GetServersAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.Servers.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = GeneratePaginationLinksStatic("servers", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Server>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<Server>> GetServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        return Ok(server);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> CreateServerAsync([FromBody] ServerRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        var server = MapServer(request);
+        server.CreatedAtUtc = DateTime.UtcNow;
+        server.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Servers.Add(server);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetServerAsync), new { id = server.Id }, server);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> UpdateServerAsync(Guid id, [FromBody] ServerRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        UpdateServer(server, request);
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(server);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RetireServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        server.Status = EntityStatus.Retired;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RestoreServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        server.Status = EntityStatus.Active;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> DeleteServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        DbContext.Servers.Remove(server);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    internal static string GeneratePaginationLinksStatic(string route, int page, int size, int total)
+    {
+        var links = new List<string>();
+        var lastPage = (int)Math.Ceiling(total / (double)size);
+        if (page > 1)
+        {
+            links.Add($"</api/{route}?page=1&size={size}>; rel=\"first\"");
+            links.Add($"</api/{route}?page={page - 1}&size={size}>; rel=\"prev\"");
+        }
+        if (page < lastPage)
+        {
+            links.Add($"</api/{route}?page={page + 1}&size={size}>; rel=\"next\"");
+            links.Add($"</api/{route}?page={lastPage}&size={size}>; rel=\"last\"");
+        }
+        return string.Join(", ", links);
+    }
+
+    private static Server MapServer(ServerRequestDto request)
+    {
+        return new Server
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            EnvironmentId = request.EnvironmentId,
+            WsusPriorityId = request.WsusPriorityId,
+            OperatingSystemId = request.OperatingSystemId,
+            ServerRoleId = request.ServerRoleId,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments
+                .Select(x => new NetworkEndpoint { Label = x.Label, VlanId = x.VlanId, IpAddress = x.IpAddress })
+                .ToList()
+        };
+    }
+
+    private static void UpdateServer(Server server, ServerRequestDto request)
+    {
+        server.Name = request.Name;
+        server.InventoryNumber = request.InventoryNumber;
+        server.Manufacturer = request.Manufacturer;
+        server.Model = request.Model;
+        server.EnvironmentId = request.EnvironmentId;
+        server.WsusPriorityId = request.WsusPriorityId;
+        server.OperatingSystemId = request.OperatingSystemId;
+        server.ServerRoleId = request.ServerRoleId;
+        server.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        server.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        server.LocationId = request.LocationId;
+        server.RackPosition = request.RackPosition;
+        server.PurchasedAt = request.PurchasedAt;
+        server.SupportUntil = request.SupportUntil;
+        server.Notes = request.Notes;
+
+        server.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            server.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/SsprController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/SsprController.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[AllowAnonymous]
+[Route("api/security/sspr")]
+[ApiController]
+public class SsprController : ControllerBase
+{
+    private readonly ISsprService _ssprService;
+
+    public SsprController(ISsprService ssprService)
+    {
+        _ssprService = ssprService;
+    }
+
+    [HttpPost("request")]
+    public async Task<ActionResult<PasswordResetRequestResult>> RequestAsync([FromBody] PasswordResetRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ssprService.RequestResetAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("complete")]
+    public async Task<ActionResult<PasswordResetCompletionResult>> CompleteAsync([FromBody] PasswordResetCompletionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ssprService.CompleteResetAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
@@ -1,0 +1,348 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/workstations")]
+public class WorkstationsController : ApiControllerBase
+{
+    public WorkstationsController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<PagedResult<Workstation>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.Workstations.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        if (scope.HasDepartmentRestrictions)
+        {
+            var allowedDepartments = scope.DepartmentKeys.ToArray();
+            query = query.Where(x => x.OwnerDepartment != null && allowedDepartments.Contains(x.OwnerDepartment));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("workstations", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Workstation>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<Workstation>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> CreateAsync([FromBody] WorkstationRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.OwnerDepartment) && !scope.DepartmentKeys.Contains(request.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Workstations.Add(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> UpdateAsync(Guid id, [FromBody] WorkstationRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.OwnerDepartment) && !scope.DepartmentKeys.Contains(request.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/handover")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult> HandoverAsync(Guid id, [FromBody] HandoverRequest request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.NewLocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.NewOwnerDepartment) && !scope.DepartmentKeys.Contains(request.NewOwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.OwnerId = request.NewOwnerId;
+        entity.OwnerDisplayName = request.NewOwnerDisplayName;
+        entity.OwnerDepartment = request.NewOwnerDepartment;
+        entity.LocationId = request.NewLocationId;
+        entity.LocationNote = request.NewLocationNote;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RetireAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        DbContext.Workstations.Remove(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private static Workstation Map(WorkstationRequestDto request)
+    {
+        return new Workstation
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            OperatingSystemId = request.OperatingSystemId,
+            WorkstationTypeId = request.WorkstationTypeId,
+            OwnerId = request.OwnerId,
+            OwnerDisplayName = request.OwnerDisplayName,
+            OwnerDepartment = request.OwnerDepartment,
+            LocationId = request.LocationId,
+            LocationNote = request.LocationNote,
+            Cpu = request.Cpu,
+            Ram = request.Ram,
+            Storage = request.Storage,
+            MacAddress = request.MacAddress,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(Workstation entity, WorkstationRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.OperatingSystemId = request.OperatingSystemId;
+        entity.WorkstationTypeId = request.WorkstationTypeId;
+        entity.OwnerId = request.OwnerId;
+        entity.OwnerDisplayName = request.OwnerDisplayName;
+        entity.OwnerDepartment = request.OwnerDepartment;
+        entity.LocationId = request.LocationId;
+        entity.LocationNote = request.LocationNote;
+        entity.Cpu = request.Cpu;
+        entity.Ram = request.Ram;
+        entity.Storage = request.Storage;
+        entity.MacAddress = request.MacAddress;
+        entity.PurchasedAt = request.PurchasedAt;
+        entity.SupportUntil = request.SupportUntil;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+
+    public record HandoverRequest(
+        Guid? NewOwnerId,
+        string? NewOwnerDisplayName,
+        string? NewOwnerDepartment,
+        Guid NewLocationId,
+        string? NewLocationNote,
+        Guid? NewAdminId,
+        IReadOnlyCollection<string>? Emails,
+        string? Comment);
+}

--- a/src/api/src/HWInventory.Api/HWInventory.Api.csproj
+++ b/src/api/src/HWInventory.Api/HWInventory.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Infrastructure/HWInventory.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Api/Middleware/SessionTrackingMiddleware.cs
+++ b/src/api/src/HWInventory.Api/Middleware/SessionTrackingMiddleware.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace HWInventory.Api.Middleware;
+
+public class SessionTrackingMiddleware
+{
+    private const string SessionCookieName = "HWInventory.SessionId";
+    private readonly RequestDelegate _next;
+
+    public SessionTrackingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ISessionTracker sessionTracker)
+    {
+        if (context.User?.Identity?.IsAuthenticated == true)
+        {
+            var userIdClaim = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (Guid.TryParse(userIdClaim, out var userId))
+            {
+                var actor = context.User.Identity?.Name ?? context.User.FindFirstValue(ClaimTypes.Email) ?? "system";
+
+                if (!context.Request.Cookies.TryGetValue(SessionCookieName, out var sessionIdentifier) || string.IsNullOrWhiteSpace(sessionIdentifier))
+                {
+                    sessionIdentifier = Guid.NewGuid().ToString("N");
+                    context.Response.Cookies.Append(SessionCookieName, sessionIdentifier, new CookieOptions
+                    {
+                        HttpOnly = true,
+                        Secure = true,
+                        SameSite = SameSiteMode.Strict,
+                        IsEssential = true,
+                        Expires = DateTimeOffset.UtcNow.AddDays(7)
+                    });
+
+                    await sessionTracker.RegisterAsync(new RegisterSessionRequest(
+                        userId,
+                        sessionIdentifier,
+                        actor,
+                        context.Connection.RemoteIpAddress?.ToString(),
+                        context.Request.Headers.UserAgent.ToString()),
+                        context.RequestAborted);
+                }
+                else
+                {
+                    var active = await sessionTracker.TouchAsync(sessionIdentifier, context.RequestAborted);
+                    if (!active)
+                    {
+                        context.Response.Cookies.Delete(SessionCookieName);
+                        await context.SignOutAsync();
+                        return;
+                    }
+                }
+            }
+        }
+
+        await _next(context);
+    }
+}
+
+public static class SessionTrackingMiddlewareExtensions
+{
+    public static IApplicationBuilder UseSessionTracking(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<SessionTrackingMiddleware>();
+    }
+}

--- a/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Api.Models;
+
+public record DictionaryEntryRequestDto(
+    string DictType,
+    string Key,
+    string Value,
+    string? Description,
+    int Order);

--- a/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
+++ b/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record FeatureModuleToggleRequest(bool Enabled);

--- a/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkDeviceRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid DeviceTypeId,
+    string Manufacturer,
+    string Model,
+    Guid LocationId,
+    string? RackPosition,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkEndpointDto(string Label, Guid? VlanId, string? IpAddress);

--- a/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Api.Models;
+
+public record ServerRequestDto(
+    string Name,
+    string InventoryNumber,
+    string Manufacturer,
+    string Model,
+    Guid EnvironmentId,
+    Guid WsusPriorityId,
+    Guid OperatingSystemId,
+    Guid ServerRoleId,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    Guid LocationId,
+    string? RackPosition,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
@@ -1,0 +1,22 @@
+namespace HWInventory.Api.Models;
+
+public record WorkstationRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid OperatingSystemId,
+    Guid WorkstationTypeId,
+    Guid? OwnerId,
+    string? OwnerDisplayName,
+    string? OwnerDepartment,
+    Guid LocationId,
+    string? LocationNote,
+    string Cpu,
+    string Ram,
+    string Storage,
+    string MacAddress,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Program.cs
+++ b/src/api/src/HWInventory.Api/Program.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+using HWInventory.Api.Middleware;
+using HWInventory.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using QuestPDF.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+QuestPDF.Settings.License = LicenseType.Community;
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status400BadRequest));
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status404NotFound));
+}).AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("default", policy =>
+    {
+        policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin();
+    });
+});
+
+var app = builder.Build();
+
+await app.InitializeDatabaseAsync();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("default");
+app.UseRouting();
+app.UseAuthentication();
+app.UseSessionTracking();
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
+
+await app.RunAsync();

--- a/src/api/src/HWInventory.Api/appsettings.Development.json
+++ b/src/api/src/HWInventory.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/api/src/HWInventory.Api/appsettings.json
+++ b/src/api/src/HWInventory.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
@@ -1,0 +1,25 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IAppDbContext
+{
+    DbSet<Server> Servers { get; }
+    DbSet<NetworkDevice> NetworkDevices { get; }
+    DbSet<Workstation> Workstations { get; }
+    DbSet<DictionaryEntry> DictionaryEntries { get; }
+    DbSet<AuditLog> AuditLogs { get; }
+    DbSet<LabelTemplate> LabelTemplates { get; }
+    DbSet<LabelPrintJob> LabelPrintJobs { get; }
+    DbSet<AppUser> Users { get; }
+    DbSet<AppRole> Roles { get; }
+    DbSet<DataScope> DataScopes { get; }
+    DbSet<FeatureModule> FeatureModules { get; }
+    DbSet<AppSetting> Settings { get; }
+    DbSet<ConnectorProfile> ConnectorProfiles { get; }
+    DbSet<LdapRoleMapping> LdapRoleMappings { get; }
+    DbSet<UserSession> UserSessions { get; }
+    DbSet<PasswordResetToken> PasswordResetTokens { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ICaptchaConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ICaptchaConfigurationStore.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ICaptchaConfigurationStore
+{
+    Task<CaptchaConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<CaptchaConfigurationModel> SaveAsync(CaptchaConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record CaptchaConfigurationModel(
+    bool Enabled,
+    string SiteKey,
+    bool HasSecret,
+    string VerificationEndpoint,
+    string? BypassToken);
+
+public record CaptchaConfigurationUpdate(
+    bool Enabled,
+    string SiteKey,
+    string? Secret,
+    bool RotateSecret,
+    string VerificationEndpoint,
+    string? BypassToken);

--- a/src/api/src/HWInventory.Application/Abstractions/ICaptchaValidator.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ICaptchaValidator.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ICaptchaValidator
+{
+    Task<bool> ValidateAsync(string token, CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IExternalIdentityService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IExternalIdentityService.cs
@@ -1,0 +1,17 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface IExternalIdentityService
+{
+    Task ConfigureOidcAsync(OidcConfiguration configuration, CancellationToken cancellationToken = default);
+    Task<OidcConfiguration?> GetConfigurationAsync(CancellationToken cancellationToken = default);
+}
+
+public record OidcConfiguration(
+    bool Enabled,
+    string Authority,
+    string ClientId,
+    string? ClientSecret,
+    string? ResponseType,
+    IReadOnlyCollection<string> Scopes,
+    IReadOnlyDictionary<string, string> ClaimMappings,
+    bool UsePkce);

--- a/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
@@ -1,0 +1,9 @@
+using HWInventory.Domain.Entities;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ILabelRenderingService
+{
+    string RenderZpl(LabelTemplate template, IDictionary<string, string> data);
+    byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ILdapConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILdapConfigurationStore.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ILdapConfigurationStore
+{
+    Task<LdapConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<LdapConfigurationModel> SaveAsync(LdapConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record LdapConfigurationModel(
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    bool HasPassword,
+    bool IgnoreCertificateErrors,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap);
+
+public record LdapConfigurationUpdate(
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    string? Password,
+    bool ResetPassword,
+    bool IgnoreCertificateErrors,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap);

--- a/src/api/src/HWInventory.Application/Abstractions/ILdapSyncService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILdapSyncService.cs
@@ -1,0 +1,32 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ILdapSyncService
+{
+    Task<LdapConnectionTestResult> TestConnectionAsync(LdapConnectionOptions options, CancellationToken cancellationToken = default);
+    Task<LdapDryRunResult> DryRunAsync(LdapDryRunRequest request, CancellationToken cancellationToken = default);
+}
+
+public record LdapConnectionOptions(
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    string? Password,
+    bool IgnoreCertificateErrors);
+
+public record LdapDryRunRequest(
+    LdapConnectionOptions Connection,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap,
+    int ResultLimit);
+
+public record LdapConnectionTestResult(bool Success, string Message, IReadOnlyDictionary<string, string>? Diagnostics);
+
+public record LdapDryRunResult(
+    IReadOnlyCollection<LdapDryRunUser> Users,
+    int ResultCount,
+    bool Truncated,
+    string? Notes);
+
+public record LdapDryRunUser(string DistinguishedName, IReadOnlyDictionary<string, string?> Attributes);

--- a/src/api/src/HWInventory.Application/Abstractions/IPasswordPolicyConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IPasswordPolicyConfigurationStore.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IPasswordPolicyConfigurationStore
+{
+    Task<PasswordPolicyModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<PasswordPolicyModel> SaveAsync(PasswordPolicyUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record PasswordPolicyModel(
+    bool Enabled,
+    int MinimumLength,
+    bool RequireUppercase,
+    bool RequireLowercase,
+    bool RequireDigit,
+    bool RequireNonAlphanumeric,
+    int ExpirationDays,
+    int HistoryCount,
+    int LockoutAttempts,
+    int LockoutDurationMinutes);
+
+public record PasswordPolicyUpdate(
+    bool Enabled,
+    int MinimumLength,
+    bool RequireUppercase,
+    bool RequireLowercase,
+    bool RequireDigit,
+    bool RequireNonAlphanumeric,
+    int ExpirationDays,
+    int HistoryCount,
+    int LockoutAttempts,
+    int LockoutDurationMinutes);

--- a/src/api/src/HWInventory.Application/Abstractions/ISessionTracker.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISessionTracker.cs
@@ -1,0 +1,14 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISessionTracker
+{
+    Task<UserSessionDto> RegisterAsync(RegisterSessionRequest request, CancellationToken cancellationToken = default);
+    Task<bool> TouchAsync(string sessionIdentifier, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<UserSessionDto>> GetActiveSessionsAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task RevokeAsync(Guid sessionId, string performedBy, string? reason, CancellationToken cancellationToken = default);
+    Task RevokeAllAsync(Guid userId, string performedBy, CancellationToken cancellationToken = default);
+}
+
+public record RegisterSessionRequest(Guid UserId, string SessionIdentifier, string PerformedBy, string? IpAddress, string? UserAgent);
+
+public record UserSessionDto(Guid Id, string SessionIdentifier, DateTime IssuedAtUtc, DateTime LastSeenAtUtc, string? IpAddress, string? UserAgent, bool IsRevoked);

--- a/src/api/src/HWInventory.Application/Abstractions/ISmsConnectorStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISmsConnectorStore.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ISmsConnectorStore
+{
+    Task<SmsConnectorModel?> GetAsync(CancellationToken cancellationToken = default);
+    Task<SmsConnectorModel> SaveAsync(SmsConnectorUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record SmsConnectorModel(
+    Guid? Id,
+    string Alias,
+    bool Enabled,
+    string Endpoint,
+    string? Sender,
+    string? Region,
+    bool HasSecret,
+    string? HealthStatus,
+    DateTime? LastTestedAtUtc);
+
+public record SmsConnectorUpdate(
+    string Alias,
+    bool Enabled,
+    string Endpoint,
+    string? Sender,
+    string? Region,
+    string? Secret,
+    bool RotateSecret);

--- a/src/api/src/HWInventory.Application/Abstractions/ISmsGateway.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISmsGateway.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISmsGateway
+{
+    Task SendAsync(string destination, string message, CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ISsprConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISsprConfigurationStore.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ISsprConfigurationStore
+{
+    Task<SsprConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<SsprConfigurationModel> SaveAsync(SsprConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record SsprConfigurationModel(
+    bool Enabled,
+    bool RequireTwoFactor,
+    bool RequireCaptcha,
+    bool RequireSmsOtp,
+    int TokenExpiryMinutes,
+    int ThrottleWindowMinutes,
+    int MaxRequestsPerWindow,
+    string? SmsConnectorKey);
+
+public record SsprConfigurationUpdate(
+    bool Enabled,
+    bool RequireTwoFactor,
+    bool RequireCaptcha,
+    bool RequireSmsOtp,
+    int TokenExpiryMinutes,
+    int ThrottleWindowMinutes,
+    int MaxRequestsPerWindow,
+    string? SmsConnectorKey);

--- a/src/api/src/HWInventory.Application/Abstractions/ISsprService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISsprService.cs
@@ -1,0 +1,24 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISsprService
+{
+    Task<PasswordResetRequestResult> RequestResetAsync(PasswordResetRequest request, CancellationToken cancellationToken = default);
+    Task<PasswordResetCompletionResult> CompleteResetAsync(PasswordResetCompletionRequest request, CancellationToken cancellationToken = default);
+}
+
+public record PasswordResetRequest(
+    string UsernameOrEmail,
+    string CaptchaToken,
+    string DeliveryMethod,
+    string? DeliveryDestination,
+    bool RequireSmsOtp);
+
+public record PasswordResetRequestResult(bool Success, string Message, Guid? Token, bool SmsOtpIssued);
+
+public record PasswordResetCompletionRequest(
+    Guid Token,
+    string CaptchaToken,
+    string? SmsCode,
+    string NewPassword);
+
+public record PasswordResetCompletionResult(bool Success, string Message);

--- a/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ITotpService
+{
+    string GenerateSecretKey();
+    string GenerateCode(string secretKey);
+    bool ValidateCode(string secretKey, string code);
+}

--- a/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
+++ b/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Common;
+
+public class FilterDescriptor
+{
+    public string Field { get; init; } = string.Empty;
+    public string Operator { get; init; } = string.Empty;
+    public string? Value { get; init; }
+}

--- a/src/api/src/HWInventory.Application/Common/PagedResult.cs
+++ b/src/api/src/HWInventory.Application/Common/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Application.Common;
+
+public class PagedResult<T>
+{
+    public IReadOnlyCollection<T> Items { get; init; } = Array.Empty<T>();
+    public int TotalCount { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/api/src/HWInventory.Application/HWInventory.Application.csproj
+++ b/src/api/src/HWInventory.Application/HWInventory.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Entities/AppRole.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppRole.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppRole : IdentityRole<Guid>
+{
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppSetting : AuditableEntity
+{
+    public string Section { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public bool IsSecret { get; set; }
+    public bool IsMasked => IsSecret && !string.IsNullOrEmpty(Value);
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppUser.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppUser.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppUser : IdentityUser<Guid>
+{
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsDomainAccount { get; set; }
+    public bool TwoFactorRequired { get; set; }
+    public string? Department { get; set; }
+    public string? AuthenticatorKey { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+    public ICollection<DataScope> DataScopes { get; set; } = new List<DataScope>();
+    public ICollection<UserSession> Sessions { get; set; } = new List<UserSession>();
+    public ICollection<PasswordResetToken> PasswordResetTokens { get; set; } = new List<PasswordResetToken>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Domain.Entities;
+
+public class AuditLog : BaseEntity
+{
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string PerformedBy { get; set; } = string.Empty;
+    public string? Roles { get; set; }
+    public DateTime PerformedAtUtc { get; set; }
+    public string? ChangeSummary { get; set; }
+    public string? ChangedFieldsJson { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+}

--- a/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Domain.Entities;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
@@ -1,0 +1,12 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorProfile : AuditableEntity
+{
+    public string Type { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public bool Enabled { get; set; }
+    public string? ConfigurationJson { get; set; }
+    public string? HealthStatus { get; set; }
+    public DateTime? LastTestedAtUtc { get; set; }
+    public ICollection<ConnectorSecret> Secrets { get; set; } = new List<ConnectorSecret>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorSecret : BaseEntity
+{
+    public Guid ConnectorProfileId { get; set; }
+    public ConnectorProfile ConnectorProfile { get; set; } = default!;
+    public string Key { get; set; } = string.Empty;
+    public string SecretReference { get; set; } = string.Empty;
+    public DateTime? RotatedAtUtc { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/DataScope.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DataScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class DataScope : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid? LocationId { get; set; }
+    public string? DepartmentKey { get; set; }
+    public string ScopeType { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class DictionaryEntry : AuditableEntity
+{
+    public string DictType { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int Order { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
+++ b/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class FeatureModule : AuditableEntity
+{
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool Enabled { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJob : AuditableEntity
+{
+    public string Target { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string JobStatus { get; set; } = "Pending";
+    public string? ArtifactPath { get; set; }
+    public ICollection<LabelPrintJobItem> Items { get; set; } = new List<LabelPrintJobItem>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJobItem : BaseEntity
+{
+    public Guid LabelPrintJobId { get; set; }
+    public Guid AssetId { get; set; }
+    public string AssetType { get; set; } = string.Empty;
+    public int Copies { get; set; } = 1;
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelTemplate : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Format { get; set; } = "ZPL";
+    public string Payload { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LdapRoleMapping.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LdapRoleMapping.cs
@@ -1,0 +1,9 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class LdapRoleMapping : AuditableEntity
+{
+    public string GroupName { get; set; } = string.Empty;
+    public string RoleName { get; set; } = SystemRoleNames.AppAdmin;
+}

--- a/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
+++ b/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class NetworkDevice : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid DeviceTypeId { get; set; }
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/PasswordResetToken.cs
+++ b/src/api/src/HWInventory.Domain/Entities/PasswordResetToken.cs
@@ -1,0 +1,17 @@
+namespace HWInventory.Domain.Entities;
+
+public class PasswordResetToken : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid Token { get; set; }
+    public string DeliveryMethod { get; set; } = string.Empty;
+    public string? DeliveryAddress { get; set; }
+    public DateTime ExpiresAtUtc { get; set; }
+    public DateTime? ConsumedAtUtc { get; set; }
+    public string? CaptchaToken { get; set; }
+    public string IdentityToken { get; set; } = string.Empty;
+    public string? SmsCodeHash { get; set; }
+    public bool RequiresSmsVerification { get; set; }
+    public string Status { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/Server.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Server.cs
@@ -1,0 +1,24 @@
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Server : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid EnvironmentId { get; set; }
+    public Guid WsusPriorityId { get; set; }
+    public Guid OperatingSystemId { get; set; }
+    public Guid ServerRoleId { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/UserSession.cs
+++ b/src/api/src/HWInventory.Domain/Entities/UserSession.cs
@@ -1,0 +1,16 @@
+namespace HWInventory.Domain.Entities;
+
+public class UserSession : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public string SessionIdentifier { get; set; } = string.Empty;
+    public DateTime IssuedAtUtc { get; set; }
+    public DateTime LastSeenAtUtc { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+    public bool IsRevoked { get; set; }
+    public DateTime? RevokedAtUtc { get; set; }
+    public string? RevokedBy { get; set; }
+    public string? TerminationReason { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/Workstation.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Workstation.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Workstation : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid OperatingSystemId { get; set; }
+    public Guid WorkstationTypeId { get; set; }
+    public Guid? OwnerId { get; set; }
+    public string? OwnerDisplayName { get; set; }
+    public string? OwnerDepartment { get; set; }
+    public Guid LocationId { get; set; }
+    public string? LocationNote { get; set; }
+    public string Cpu { get; set; } = string.Empty;
+    public string Ram { get; set; } = string.Empty;
+    public string Storage { get; set; } = string.Empty;
+    public string MacAddress { get; set; } = string.Empty;
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum EntityStatus
+{
+    Active = 1,
+    Retired = 2
+}

--- a/src/api/src/HWInventory.Domain/Enums/PasswordResetStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/PasswordResetStatus.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Enums;
+
+public static class PasswordResetStatus
+{
+    public const string Pending = "Pending";
+    public const string Completed = "Completed";
+    public const string Expired = "Expired";
+    public const string Revoked = "Revoked";
+}

--- a/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
+++ b/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
@@ -1,0 +1,11 @@
+namespace HWInventory.Domain.Enums;
+
+public static class SystemRoleNames
+{
+    public const string SuperAdmin = "SuperAdmin";
+    public const string ServerAdmin = "SRV Administrator";
+    public const string NetworkAdmin = "NET Administrator";
+    public const string AppAdmin = "Aplikační admin";
+    public const string Helpdesk = "Helpdesk";
+    public const string HelpdeskRead = "Helpdesk Read";
+}

--- a/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
+++ b/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
+++ b/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
@@ -1,0 +1,21 @@
+namespace HWInventory.Domain.Security;
+
+public static class AuthorizationPolicies
+{
+    public const string ServersRead = "Servers.Read";
+    public const string ServersManage = "Servers.Manage";
+
+    public const string NetworkRead = "Network.Read";
+    public const string NetworkManage = "Network.Manage";
+
+    public const string WorkstationsRead = "Workstations.Read";
+    public const string WorkstationsManage = "Workstations.Manage";
+
+    public const string DictionariesManage = "Dictionaries.Manage";
+    public const string AuditRead = "Audit.Read";
+    public const string LabelsManage = "Labels.Manage";
+    public const string ModulesManage = "Modules.Manage";
+    public const string DashboardView = "Dashboard.View";
+    public const string SecurityManage = "Security.Manage";
+    public const string SessionsManage = "Security.Sessions.Manage";
+}

--- a/src/api/src/HWInventory.Domain/Security/DataScopeTypes.cs
+++ b/src/api/src/HWInventory.Domain/Security/DataScopeTypes.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Security;
+
+public static class DataScopeTypes
+{
+    public const string Location = "Location";
+    public const string Department = "Department";
+}

--- a/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
+++ b/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.ValueObjects;
+
+public class NetworkEndpoint
+{
+    public string Label { get; set; } = string.Empty;
+    public Guid? VlanId { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
+++ b/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Infrastructure.Jobs;
+using HWInventory.Infrastructure.Labels;
+using HWInventory.Infrastructure.Persistence;
+using HWInventory.Infrastructure.Security;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+
+namespace HWInventory.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True";
+        }
+
+        services.AddDbContext<AppDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.EnableRetryOnFailure();
+                sql.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName);
+            });
+        });
+
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+        services.AddHttpContextAccessor();
+
+        var identityBuilder = services.AddIdentityCore<AppUser>(options =>
+        {
+            options.Password.RequireDigit = true;
+            options.Password.RequireLowercase = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequireNonAlphanumeric = true;
+            options.Password.RequiredLength = 12;
+            options.SignIn.RequireConfirmedAccount = false;
+            options.User.RequireUniqueEmail = true;
+            options.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
+        });
+
+        identityBuilder = new IdentityBuilder(identityBuilder.UserType, typeof(AppRole), identityBuilder.Services);
+        identityBuilder.AddRoles<AppRole>();
+        identityBuilder.AddEntityFrameworkStores<AppDbContext>();
+        identityBuilder.AddDefaultTokenProviders();
+        identityBuilder.AddSignInManager();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
+        }).AddIdentityCookies().AddOpenIdConnect("oidc", options =>
+        {
+            options.SignInScheme = IdentityConstants.ExternalScheme;
+            options.ResponseType = "code";
+            options.CallbackPath = "/signin-oidc";
+            options.SaveTokens = true;
+            options.UsePkce = true;
+            options.Scope.Clear();
+            options.Scope.Add("openid");
+            options.Scope.Add("profile");
+            options.Scope.Add("email");
+        });
+
+        services.AddOptions<OpenIdConnectOptions>("oidc").Configure<IServiceProvider>((options, serviceProvider) =>
+        {
+            using var scope = serviceProvider.CreateScope();
+            var identityService = scope.ServiceProvider.GetRequiredService<IExternalIdentityService>();
+            var configuration = identityService.GetConfigurationAsync().GetAwaiter().GetResult();
+
+            if (configuration is null || !configuration.Enabled)
+            {
+                options.Authority = "https://placeholder";
+                options.ClientId = "placeholder";
+                options.ClientSecret = string.Empty;
+                options.DisableTelemetry = true;
+                options.Events ??= new OpenIdConnectEvents();
+                options.Events.OnRedirectToIdentityProvider = context =>
+                {
+                    context.HandleResponse();
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    return Task.CompletedTask;
+                };
+                return;
+            }
+
+            options.Authority = configuration.Authority;
+            options.ClientId = configuration.ClientId;
+            options.ClientSecret = configuration.ClientSecret;
+            options.ResponseType = configuration.ResponseType ?? "code";
+            options.UsePkce = configuration.UsePkce;
+            options.Scope.Clear();
+            foreach (var scopeValue in configuration.Scopes)
+            {
+                options.Scope.Add(scopeValue);
+            }
+
+            options.ClaimActions.DeleteClaim("name");
+            options.ClaimActions.DeleteClaim("email");
+            options.ClaimActions.MapJsonKey("name", configuration.ClaimMappings.TryGetValue("name", out var nameClaim) ? nameClaim : "name");
+            options.ClaimActions.MapJsonKey("email", configuration.ClaimMappings.TryGetValue("email", out var emailClaim) ? emailClaim : "email");
+        });
+
+        services.ConfigureApplicationCookie(options =>
+        {
+            options.Cookie.Name = "HWInventory.Auth";
+            options.SlidingExpiration = true;
+            options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+            options.LoginPath = "/signin";
+            options.LogoutPath = "/signout";
+        });
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(AuthorizationPolicies.ServersRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.AppAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.ServersManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.AppAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk, SystemRoleNames.HelpdeskRead));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.DictionariesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.AuditRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.LabelsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.ModulesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.DashboardView, policy =>
+                policy.RequireRole(
+                    SystemRoleNames.SuperAdmin,
+                    SystemRoleNames.ServerAdmin,
+                    SystemRoleNames.NetworkAdmin,
+                    SystemRoleNames.AppAdmin,
+                    SystemRoleNames.Helpdesk,
+                    SystemRoleNames.HelpdeskRead));
+
+            options.AddPolicy(AuthorizationPolicies.SecurityManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.SessionsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+        });
+
+        services.AddHttpClient("captcha");
+        services.AddHttpClient("sms");
+
+        services.AddScoped<ITotpService, TotpService>();
+        services.AddScoped<ILabelRenderingService, LabelRenderingService>();
+        services.AddScoped<ILdapSyncService, LdapSyncService>();
+        services.AddScoped<ILdapConfigurationStore, LdapConfigurationStore>();
+        services.AddScoped<IExternalIdentityService, ExternalIdentityService>();
+        services.AddScoped<ICaptchaConfigurationStore, CaptchaConfigurationStore>();
+        services.AddScoped<ICaptchaValidator, CaptchaValidator>();
+        services.AddScoped<ISmsGateway, SmsGateway>();
+        services.AddScoped<ISmsConnectorStore, SmsConnectorStore>();
+        services.AddScoped<IPasswordPolicyConfigurationStore, PasswordPolicyConfigurationStore>();
+        services.AddScoped<ISsprService, SsprService>();
+        services.AddScoped<ISsprConfigurationStore, SsprConfigurationStore>();
+        services.AddScoped<ISessionTracker, SessionTracker>();
+
+        services.AddQuartz(q =>
+        {
+            q.UseMicrosoftDependencyInjectionJobFactory();
+            var jobKey = new JobKey("LabelPrintJobProcessor");
+            q.AddJob<LabelPrintJobProcessor>(options => options.WithIdentity(jobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity("LabelPrintJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).RepeatForever()));
+        });
+
+        services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        return services;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
+++ b/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Otp.NET" Version="1.3.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.7.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
+++ b/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
@@ -1,0 +1,28 @@
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace HWInventory.Infrastructure;
+
+public static class HostExtensions
+{
+    public static async Task<IHost> InitializeDatabaseAsync(this IHost host, CancellationToken cancellationToken = default)
+    {
+        using var scope = host.Services.CreateScope();
+        var serviceProvider = scope.ServiceProvider;
+        var context = serviceProvider.GetRequiredService<AppDbContext>();
+
+        if (context.Database.IsRelational())
+        {
+            await context.Database.MigrateAsync(cancellationToken);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        await SeedData.InitializeAsync(serviceProvider, cancellationToken);
+        return host;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.Jobs;
+
+public class LabelPrintJobProcessor : IJob
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly ILogger<LabelPrintJobProcessor> _logger;
+
+    public LabelPrintJobProcessor(IAppDbContext dbContext, ILogger<LabelPrintJobProcessor> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var queuedJobs = await _dbContext.LabelPrintJobs
+            .Where(job => job.JobStatus == "Queued")
+            .Include(job => job.Items)
+            .OrderBy(job => job.CreatedAtUtc)
+            .Take(10)
+            .ToListAsync(context.CancellationToken);
+
+        if (!queuedJobs.Any())
+        {
+            return;
+        }
+
+        foreach (var job in queuedJobs)
+        {
+            job.JobStatus = "Processed";
+            job.ModifiedAtUtc = DateTime.UtcNow;
+            job.ModifiedBy = "system-job";
+            _logger.LogInformation("Processed label print job {JobId} targeting {Target}", job.Id, job.Target);
+        }
+
+        await _dbContext.SaveChangesAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace HWInventory.Infrastructure.Labels;
+
+public class LabelRenderingService : ILabelRenderingService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public string RenderZpl(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var builder = new StringBuilder();
+        builder.AppendLine("^XA");
+        builder.AppendLine("^CI28");
+        builder.AppendLine($"^PW{ToDots(model.WidthMm, model.Dpi)}");
+        builder.AppendLine($"^LL{ToDots(model.HeightMm, model.Dpi)}");
+
+        foreach (var element in model.Elements)
+        {
+            var x = ToDots(element.X, model.Dpi);
+            var y = ToDots(element.Y, model.Dpi);
+            var value = ResolveValue(element, data);
+
+            switch (element.Type)
+            {
+                case LabelElementType.Text:
+                    builder.AppendLine($"^FO{x},{y}^A0N,{element.FontSize},{element.FontSize}^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Barcode128:
+                    builder.AppendLine($"^FO{x},{y}^BCN,{ToDots(element.HeightMm, model.Dpi)},Y,N,N^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Qr:
+                    builder.AppendLine($"^FO{x},{y}^BQN,2,10^FDLA,{Escape(value)}^FS");
+                    break;
+            }
+        }
+
+        builder.AppendLine("^XZ");
+        return builder.ToString();
+    }
+
+    public byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(10);
+                page.Size(model.WidthMm * 2.83465f, model.HeightMm * 2.83465f);
+                page.Content().Canvas((canvas, size) =>
+                {
+                    foreach (var element in model.Elements)
+                    {
+                        var value = ResolveValue(element, data);
+                        var x = element.X * 2.83465f;
+                        var y = element.Y * 2.83465f;
+
+                        switch (element.Type)
+                        {
+                            case LabelElementType.Text:
+                                canvas.DrawText(value, TextStyle.Default.FontSize(element.FontSize), new Position(x, y));
+                                break;
+                            case LabelElementType.Barcode128:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[Code128] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                            case LabelElementType.Qr:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[QR] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                        }
+                    }
+                });
+            });
+        });
+
+        using var stream = new MemoryStream();
+        document.GeneratePdf(stream);
+        return stream.ToArray();
+    }
+
+    private static LabelTemplateModel ParsePayload(LabelTemplate template)
+    {
+        if (string.IsNullOrWhiteSpace(template.Payload))
+        {
+            throw new InvalidOperationException("Label template payload cannot be empty");
+        }
+
+        var model = JsonSerializer.Deserialize<LabelTemplateModel>(template.Payload, SerializerOptions);
+        if (model is null)
+        {
+            throw new InvalidOperationException("Label template payload is invalid");
+        }
+
+        return model;
+    }
+
+    private static string ResolveValue(LabelElement element, IDictionary<string, string> data)
+    {
+        if (!string.IsNullOrWhiteSpace(element.StaticValue))
+        {
+            return element.StaticValue!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(element.DataKey) && data.TryGetValue(element.DataKey!, out var value))
+        {
+            return value;
+        }
+
+        return string.Empty;
+    }
+
+    private static string Escape(string value) => value
+        .Replace("^", " ")
+        .Replace("~", " ");
+
+    private static int ToDots(float millimeters, int dpi)
+        => (int)Math.Round(millimeters / 25.4f * dpi);
+
+    private class LabelTemplateModel
+    {
+        public int Dpi { get; set; } = 203;
+        public float WidthMm { get; set; } = 50;
+        public float HeightMm { get; set; } = 30;
+        public IList<LabelElement> Elements { get; set; } = new List<LabelElement>();
+    }
+
+    private class LabelElement
+    {
+        public LabelElementType Type { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float WidthMm { get; set; } = 30;
+        public float HeightMm { get; set; } = 10;
+        public int FontSize { get; set; } = 12;
+        public string? StaticValue { get; set; }
+        public string? DataKey { get; set; }
+    }
+
+    private enum LabelElementType
+    {
+        Text,
+        Barcode128,
+        Qr
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,755 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: string.Empty),
+                    IsDomainAccount = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorRequired = table.Column<bool>(type: "bit", nullable: false),
+                    Department = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AuthenticatorKey = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: "system"),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AppSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Section = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    EntityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Action = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    PerformedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Roles = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    PerformedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ChangeSummary = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    ChangedFieldsJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    UserAgent = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Alias = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    HealthStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Configuration = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DictionaryEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DictType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DictionaryEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FeatureModules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FeatureModules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Target = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    JobStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ArtifactPath = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDevices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    DeviceTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDevices", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Servers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    EnvironmentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WsusPriorityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerRoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Servers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Workstations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OwnerId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    OwnerDisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    OwnerDepartment = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LocationNote = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Cpu = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Ram = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Storage = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    MacAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Workstations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorSecrets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ConnectorProfileId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    SecretReference = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorSecrets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConnectorSecrets_ConnectorProfiles_ConnectorProfileId",
+                        column: x => x.ConnectorProfileId,
+                        principalTable: "ConnectorProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataScopes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DepartmentKey = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    ScopeType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataScopes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DataScopes_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PasswordResetTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DeliveryMethod = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    DeliveryAddress = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: true),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ConsumedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CaptchaToken = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IdentityToken = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: false),
+                    SmsCodeHash = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    RequiresSmsVerification = table.Column<bool>(type: "bit", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PasswordResetTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PasswordResetTokens_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserSessions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SessionIdentifier = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    IssuedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    LastSeenAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IpAddress = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    UserAgent = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    RevokedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RevokedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    TerminationReason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserSessions_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LabelPrintJobId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Copies = table.Column<int>(type: "int", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LabelPrintJobItems_LabelPrintJobs_LabelPrintJobId",
+                        column: x => x.LabelPrintJobId,
+                        principalTable: "LabelPrintJobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDeviceAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    NetworkDeviceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDeviceAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NetworkDeviceAssignments_NetworkDevices_NetworkDeviceId",
+                        column: x => x.NetworkDeviceId,
+                        principalTable: "NetworkDevices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServerNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServerNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServerNetworkAssignments_Servers_ServerId",
+                        column: x => x.ServerId,
+                        principalTable: "Servers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkstationNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkstationNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkstationNetworkAssignments_Workstations_WorkstationId",
+                        column: x => x.WorkstationId,
+                        principalTable: "Workstations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true,
+                filter: "[NormalizedName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true,
+                filter: "[NormalizedUserName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConnectorSecrets_ConnectorProfileId",
+                table: "ConnectorSecrets",
+                column: "ConnectorProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataScopes_AppUserId",
+                table: "DataScopes",
+                column: "AppUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PasswordResetTokens_AppUserId_Status",
+                table: "PasswordResetTokens",
+                columns: new[] { "AppUserId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PasswordResetTokens_Token",
+                table: "PasswordResetTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_AppUserId_IsRevoked",
+                table: "UserSessions",
+                columns: new[] { "AppUserId", "IsRevoked" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_SessionIdentifier",
+                table: "UserSessions",
+                column: "SessionIdentifier",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LabelPrintJobItems_LabelPrintJobId",
+                table: "LabelPrintJobItems",
+                column: "LabelPrintJobId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NetworkDeviceAssignments_NetworkDeviceId",
+                table: "NetworkDeviceAssignments",
+                column: "NetworkDeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerNetworkAssignments_ServerId",
+                table: "ServerNetworkAssignments",
+                column: "ServerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkstationNetworkAssignments_WorkstationId",
+                table: "WorkstationNetworkAssignments",
+                column: "WorkstationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppSettings");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AuditLogs");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorSecrets");
+
+            migrationBuilder.DropTable(
+                name: "PasswordResetTokens");
+
+            migrationBuilder.DropTable(
+                name: "UserSessions");
+
+            migrationBuilder.DropTable(
+                name: "DataScopes");
+
+            migrationBuilder.DropTable(
+                name: "DictionaryEntries");
+
+            migrationBuilder.DropTable(
+                name: "FeatureModules");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobItems");
+
+            migrationBuilder.DropTable(
+                name: "LabelTemplates");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDeviceAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ServerNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "WorkstationNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorProfiles");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobs");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDevices");
+
+            migrationBuilder.DropTable(
+                name: "Servers");
+
+            migrationBuilder.DropTable(
+                name: "Workstations");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101000500_AddLdapRoleMappingsAndSecurityConnectors.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101000500_AddLdapRoleMappingsAndSecurityConnectors.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddLdapRoleMappingsAndSecurityConnectors : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LdapRoleMappings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    GroupName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    RoleName = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LdapRoleMappings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LdapRoleMappings_GroupName",
+                table: "LdapRoleMappings",
+                column: "GroupName");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LdapRoleMappings");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -1,0 +1,1081 @@
+using System;
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    partial class AppDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppRole", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Description")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("Name")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedName").IsUnique().HasFilter("[NormalizedName] IS NOT NULL");
+
+                b.ToTable("AspNetRoles", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppSetting", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Section")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Value")
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AppSettings");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("AccessFailedCount")
+                    .HasColumnType("int");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue("system");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Department")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("AuthenticatorKey")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("DisplayName")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue(string.Empty);
+
+                b.Property<string>("Email")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<bool>("EmailConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("IsDomainAccount")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("LockoutEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<DateTimeOffset?>("LockoutEnd")
+                    .HasColumnType("datetimeoffset");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("NormalizedEmail")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedUserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("PasswordHash")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("PhoneNumber")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("PhoneNumberConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<string>("SecurityStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<bool>("TwoFactorEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("TwoFactorRequired")
+                    .HasColumnType("bit");
+
+                b.Property<string>("UserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedEmail");
+
+                b.HasIndex("NormalizedUserName").IsUnique().HasFilter("[NormalizedUserName] IS NOT NULL");
+
+                b.ToTable("AspNetUsers", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AuditLog", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Action")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ChangeSummary")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("ChangedFieldsJson")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid>("EntityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("EntityType")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("IpAddress")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<DateTime>("PerformedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("PerformedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Roles")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("UserAgent")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AuditLogs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Alias")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Configuration")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("HealthStatus")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("Type")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.ToTable("ConnectorProfiles");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ConnectorProfileId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("SecretReference")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ConnectorProfileId");
+
+                b.ToTable("ConnectorSecrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("DepartmentKey")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid?>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("ScopeType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId");
+
+                b.ToTable("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LdapRoleMapping", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("GroupName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("RoleName")
+                    .IsRequired()
+                    .HasMaxLength(128)
+                    .HasColumnType("nvarchar(128)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("GroupName");
+
+                b.ToTable("LdapRoleMappings");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.PasswordResetToken", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CaptchaToken")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime?>("ConsumedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("DeliveryAddress")
+                    .HasMaxLength(300)
+                    .HasColumnType("nvarchar(300)");
+
+                b.Property<string>("DeliveryMethod")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<DateTime>("ExpiresAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("IdentityToken")
+                    .IsRequired()
+                    .HasMaxLength(2048)
+                    .HasColumnType("nvarchar(2048)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<bool>("RequiresSmsVerification")
+                    .HasColumnType("bit");
+
+                b.Property<string>("SmsCodeHash")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid>("Token")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId", "Status");
+
+                b.HasIndex("Token")
+                    .IsUnique();
+
+                b.ToTable("PasswordResetTokens");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.UserSession", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("IssuedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<bool>("IsRevoked")
+                    .HasColumnType("bit");
+
+                b.Property<DateTime>("LastSeenAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RevokedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("RevokedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("SessionIdentifier")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("TerminationReason")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("IpAddress")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("UserAgent")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId", "IsRevoked");
+
+                b.HasIndex("SessionIdentifier")
+                    .IsUnique();
+
+                b.ToTable("UserSessions");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DictionaryEntry", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("DictType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Value")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("DictionaryEntries");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.FeatureModule", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("Enabled")
+                    .HasColumnType("bit");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("FeatureModules");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ArtifactPath")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("JobStatus")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Target")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelPrintJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AssetId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("AssetType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<int>("Copies")
+                    .HasColumnType("int")
+                    .HasDefaultValue(1);
+
+                b.Property<Guid>("LabelPrintJobId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("LabelPrintJobId");
+
+                b.ToTable("LabelPrintJobItems");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelTemplate", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Code")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Payload")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelTemplates");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("DeviceTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.HasKey("Id");
+
+                b.ToTable("NetworkDevices");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("EnvironmentId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ServerRoleId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WsusPriorityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Servers");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Cpu")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("LocationNote")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("MacAddress")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("OwnerId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("OwnerDepartment")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("OwnerDisplayName")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Ram")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Storage")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WorkstationTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Workstations");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.ConnectorProfile", "ConnectorProfile")
+                    .WithMany("Secrets")
+                    .HasForeignKey("ConnectorProfileId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("ConnectorProfile");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.AppUser", "AppUser")
+                    .WithMany("DataScopes")
+                    .HasForeignKey("AppUserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("AppUser");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.LabelPrintJob", null)
+                    .WithMany("Items")
+                    .HasForeignKey("LabelPrintJobId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("NetworkDeviceId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("NetworkDeviceId");
+
+                    b1.ToTable("NetworkDeviceAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("ServerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("ServerId");
+
+                    b1.ToTable("ServerNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("WorkstationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("WorkstationId");
+
+                    b1.ToTable("WorkstationNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Navigation("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Navigation("Secrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Navigation("Items");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,123 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public class AppDbContext : IdentityDbContext<AppUser, AppRole, Guid, IdentityUserClaim<Guid>, IdentityUserRole<Guid>, IdentityUserLogin<Guid>, IdentityRoleClaim<Guid>, IdentityUserToken<Guid>>, IAppDbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Server> Servers => Set<Server>();
+    public DbSet<NetworkDevice> NetworkDevices => Set<NetworkDevice>();
+    public DbSet<Workstation> Workstations => Set<Workstation>();
+    public DbSet<DictionaryEntry> DictionaryEntries => Set<DictionaryEntry>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<LabelTemplate> LabelTemplates => Set<LabelTemplate>();
+    public DbSet<LabelPrintJob> LabelPrintJobs => Set<LabelPrintJob>();
+    public new DbSet<AppUser> Users => Set<AppUser>();
+    public new DbSet<AppRole> Roles => Set<AppRole>();
+    public DbSet<FeatureModule> FeatureModules => Set<FeatureModule>();
+    public DbSet<AppSetting> Settings => Set<AppSetting>();
+    public DbSet<ConnectorProfile> ConnectorProfiles => Set<ConnectorProfile>();
+    public DbSet<LdapRoleMapping> LdapRoleMappings => Set<LdapRoleMapping>();
+    public DbSet<DataScope> DataScopes => Set<DataScope>();
+    public DbSet<UserSession> UserSessions => Set<UserSession>();
+    public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var auditLogs = BuildAuditEntries();
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        if (auditLogs.Count > 0)
+        {
+            AuditLogs.AddRange(auditLogs);
+            await base.SaveChangesAsync(cancellationToken);
+        }
+
+        return result;
+    }
+
+    private List<AuditLog> BuildAuditEntries()
+    {
+        var auditEntries = new List<AuditLog>();
+        var now = DateTime.UtcNow;
+
+        foreach (var entry in ChangeTracker.Entries<AuditableEntity>())
+        {
+            if (entry.State == EntityState.Detached || entry.State == EntityState.Unchanged)
+            {
+                continue;
+            }
+
+            var auditLog = new AuditLog
+            {
+                EntityType = entry.Entity.GetType().Name,
+                EntityId = entry.Entity.Id,
+                PerformedAtUtc = now,
+                PerformedBy = entry.Entity.ModifiedBy ?? entry.Entity.CreatedBy,
+                Roles = null
+            };
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    entry.Entity.CreatedAtUtc = now;
+                    auditLog.Action = "Create";
+                    auditLog.ChangeSummary = "Entity created";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.CurrentValues.ToObject());
+                    break;
+                case EntityState.Modified:
+                    entry.Entity.ModifiedAtUtc = now;
+                    auditLog.Action = "Update";
+                    auditLog.ChangeSummary = "Entity updated";
+                    auditLog.ChangedFieldsJson = SerializeChanges(entry);
+                    break;
+                case EntityState.Deleted:
+                    auditLog.Action = "Delete";
+                    auditLog.ChangeSummary = "Entity deleted";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.OriginalValues.ToObject());
+                    break;
+            }
+
+            auditEntries.Add(auditLog);
+        }
+
+        return auditEntries;
+    }
+
+    private static string SerializeChanges(EntityEntry entry)
+    {
+        var changes = new Dictionary<string, object?>();
+
+        foreach (var property in entry.Properties)
+        {
+            if (!property.IsModified)
+            {
+                continue;
+            }
+
+            changes[property.Metadata.Name] = new
+            {
+                Original = property.OriginalValue,
+                Current = property.CurrentValue
+            };
+        }
+
+        return JsonSerializer.Serialize(changes);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppRoleConfiguration : IEntityTypeConfiguration<AppRole>
+{
+    public void Configure(EntityTypeBuilder<AppRole> builder)
+    {
+        builder.ToTable("AspNetRoles");
+        builder.Property(x => x.Description).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppSettingConfiguration : IEntityTypeConfiguration<AppSetting>
+{
+    public void Configure(EntityTypeBuilder<AppSetting> builder)
+    {
+        builder.ToTable("AppSettings");
+        builder.Property(x => x.Section).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
@@ -1,0 +1,27 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.ToTable("AspNetUsers");
+        builder.Property(x => x.DisplayName).HasMaxLength(200);
+        builder.Property(x => x.Department).HasMaxLength(200);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.AuthenticatorKey).HasMaxLength(256);
+        builder.HasMany(x => x.DataScopes)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+        builder.HasMany(x => x.Sessions)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+        builder.HasMany(x => x.PasswordResetTokens)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+{
+    public void Configure(EntityTypeBuilder<AuditLog> builder)
+    {
+        builder.ToTable("AuditLogs");
+        builder.Property(x => x.EntityType).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Action).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.PerformedBy).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Roles).HasMaxLength(200);
+        builder.Property(x => x.ChangeSummary).HasMaxLength(400);
+        builder.Property(x => x.IpAddress).HasMaxLength(50);
+        builder.Property(x => x.UserAgent).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorProfileConfiguration : IEntityTypeConfiguration<ConnectorProfile>
+{
+    public void Configure(EntityTypeBuilder<ConnectorProfile> builder)
+    {
+        builder.ToTable("ConnectorProfiles");
+        builder.Property(x => x.Type).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Alias).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.HealthStatus).HasMaxLength(50);
+        builder.HasMany(x => x.Secrets)
+            .WithOne(x => x.ConnectorProfile)
+            .HasForeignKey(x => x.ConnectorProfileId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorSecretConfiguration : IEntityTypeConfiguration<ConnectorSecret>
+{
+    public void Configure(EntityTypeBuilder<ConnectorSecret> builder)
+    {
+        builder.ToTable("ConnectorSecrets");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.SecretReference).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
@@ -1,0 +1,18 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DataScopeConfiguration : IEntityTypeConfiguration<DataScope>
+{
+    public void Configure(EntityTypeBuilder<DataScope> builder)
+    {
+        builder.ToTable("DataScopes");
+        builder.Property(x => x.ScopeType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.DepartmentKey).HasMaxLength(200);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status).HasMaxLength(50);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DictionaryEntryConfiguration : IEntityTypeConfiguration<DictionaryEntry>
+{
+    public void Configure(EntityTypeBuilder<DictionaryEntry> builder)
+    {
+        builder.ToTable("DictionaryEntries");
+        builder.Property(x => x.DictType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class FeatureModuleConfiguration : IEntityTypeConfiguration<FeatureModule>
+{
+    public void Configure(EntityTypeBuilder<FeatureModule> builder)
+    {
+        builder.ToTable("FeatureModules");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobConfiguration : IEntityTypeConfiguration<LabelPrintJob>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJob> builder)
+    {
+        builder.ToTable("LabelPrintJobs");
+        builder.Property(x => x.Target).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.JobStatus).HasMaxLength(50).IsRequired();
+        builder.HasMany(x => x.Items)
+            .WithOne()
+            .HasForeignKey(x => x.LabelPrintJobId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobItemConfiguration : IEntityTypeConfiguration<LabelPrintJobItem>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJobItem> builder)
+    {
+        builder.ToTable("LabelPrintJobItems");
+        builder.Property(x => x.AssetType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Copies).HasDefaultValue(1);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelTemplateConfiguration : IEntityTypeConfiguration<LabelTemplate>
+{
+    public void Configure(EntityTypeBuilder<LabelTemplate> builder)
+    {
+        builder.ToTable("LabelTemplates");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Code).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).HasDefaultValue("ZPL");
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LdapRoleMappingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LdapRoleMappingConfiguration.cs
@@ -1,0 +1,30 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LdapRoleMappingConfiguration : IEntityTypeConfiguration<LdapRoleMapping>
+{
+    public void Configure(EntityTypeBuilder<LdapRoleMapping> builder)
+    {
+        builder.ToTable("LdapRoleMappings");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.GroupName)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(x => x.RoleName)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status)
+            .HasMaxLength(50)
+            .HasConversion<string>();
+
+        builder.HasIndex(x => x.GroupName);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class NetworkDeviceConfiguration : IEntityTypeConfiguration<NetworkDevice>
+{
+    public void Configure(EntityTypeBuilder<NetworkDevice> builder)
+    {
+        builder.ToTable("NetworkDevices");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("NetworkDeviceAssignments");
+            nb.WithOwner().HasForeignKey("NetworkDeviceId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordResetTokenConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordResetTokenConfiguration.cs
@@ -1,0 +1,21 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class PasswordResetTokenConfiguration : IEntityTypeConfiguration<PasswordResetToken>
+{
+    public void Configure(EntityTypeBuilder<PasswordResetToken> builder)
+    {
+        builder.ToTable("PasswordResetTokens");
+        builder.HasIndex(x => x.Token).IsUnique();
+        builder.Property(x => x.DeliveryMethod).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.DeliveryAddress).HasMaxLength(300);
+        builder.Property(x => x.Status).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.SmsCodeHash).HasMaxLength(256);
+        builder.Property(x => x.IdentityToken).HasMaxLength(2048).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ServerConfiguration : IEntityTypeConfiguration<Server>
+{
+    public void Configure(EntityTypeBuilder<Server> builder)
+    {
+        builder.ToTable("Servers");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("ServerNetworkAssignments");
+            nb.WithOwner().HasForeignKey("ServerId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class UserSessionConfiguration : IEntityTypeConfiguration<UserSession>
+{
+    public void Configure(EntityTypeBuilder<UserSession> builder)
+    {
+        builder.ToTable("UserSessions");
+        builder.Property(x => x.SessionIdentifier).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.IpAddress).HasMaxLength(200);
+        builder.Property(x => x.UserAgent).HasMaxLength(512);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status).HasMaxLength(50);
+        builder.HasIndex(x => new { x.AppUserId, x.IsRevoked });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
@@ -1,0 +1,28 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class WorkstationConfiguration : IEntityTypeConfiguration<Workstation>
+{
+    public void Configure(EntityTypeBuilder<Workstation> builder)
+    {
+        builder.ToTable("Workstations");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Cpu).HasMaxLength(200);
+        builder.Property(x => x.Ram).HasMaxLength(100);
+        builder.Property(x => x.Storage).HasMaxLength(200);
+        builder.Property(x => x.MacAddress).HasMaxLength(100).IsRequired();
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("WorkstationNetworkAssignments");
+            nb.WithOwner().HasForeignKey("WorkstationId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
@@ -1,0 +1,81 @@
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public static class SeedData
+{
+    private static readonly (string Dict, string Key, string Value)[] DictionarySeeds =
+    {
+        ("Environment", "PROD", "Production"),
+        ("Environment", "TEST", "Testing"),
+        ("Environment", "DEV", "Development"),
+        ("WsusPriority", "HIGH", "Vysoká"),
+        ("WsusPriority", "NORMAL", "Standard"),
+        ("OperatingSystem", "WIN2022", "Windows Server 2022"),
+        ("OperatingSystem", "WIN11", "Windows 11"),
+        ("ServerRole", "APP", "Application Server"),
+        ("ServerRole", "DB", "Database Server"),
+        ("WorkstationType", "PC", "Desktop"),
+        ("WorkstationType", "LAPTOP", "Notebook"),
+        ("Location", "HQ-1F", "HQ 1st Floor"),
+        ("Location", "HQ-2F", "HQ 2nd Floor"),
+        ("VLAN", "VLAN10", "Production 10"),
+        ("VLAN", "VLAN20", "DMZ 20"),
+    };
+
+    public static async Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<AppRole>>();
+
+        if (!await roleManager.Roles.AnyAsync(cancellationToken))
+        {
+            var roles = new[]
+            {
+                new AppRole { Name = SystemRoleNames.SuperAdmin, NormalizedName = SystemRoleNames.SuperAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.ServerAdmin, NormalizedName = SystemRoleNames.ServerAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.NetworkAdmin, NormalizedName = SystemRoleNames.NetworkAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.AppAdmin, NormalizedName = SystemRoleNames.AppAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.Helpdesk, NormalizedName = SystemRoleNames.Helpdesk.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.HelpdeskRead, NormalizedName = SystemRoleNames.HelpdeskRead.ToUpperInvariant() }
+            };
+
+            foreach (var role in roles)
+            {
+                await roleManager.CreateAsync(role);
+            }
+        }
+
+        foreach (var seed in DictionarySeeds)
+        {
+            if (!await context.DictionaryEntries.AnyAsync(x => x.DictType == seed.Dict && x.Key == seed.Key, cancellationToken))
+            {
+                context.DictionaryEntries.Add(new DictionaryEntry
+                {
+                    DictType = seed.Dict,
+                    Key = seed.Key,
+                    Value = seed.Value,
+                    CreatedAtUtc = DateTime.UtcNow,
+                    CreatedBy = "seed"
+                });
+            }
+        }
+
+        if (!await context.FeatureModules.AnyAsync(cancellationToken))
+        {
+            context.FeatureModules.AddRange(new[]
+            {
+                new FeatureModule { Key = "labels", Name = "Labels & Printing", Enabled = true, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "reports", Name = "Reports & Schedules", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "zabbix", Name = "Zabbix Metrics", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" }
+            });
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/CaptchaConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/CaptchaConfigurationStore.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class CaptchaConfigurationStore : ICaptchaConfigurationStore
+{
+    private const string SectionName = "Security.Captcha";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CaptchaConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<CaptchaConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        var enabled = ReadBool(settings, "Enabled");
+        var siteKey = ReadString(settings, "SiteKey");
+        var endpoint = ReadString(settings, "VerificationEndpoint");
+        var bypass = ReadNullableString(settings, "BypassToken");
+        var hasSecret = settings.TryGetValue("Secret", out var secretSetting) && !string.IsNullOrWhiteSpace(secretSetting.Value);
+
+        return new CaptchaConfigurationModel(enabled, siteKey, hasSecret, endpoint, bypass);
+    }
+
+    public async Task<CaptchaConfigurationModel> SaveAsync(CaptchaConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("SiteKey", update.SiteKey, false);
+        Upsert("VerificationEndpoint", update.VerificationEndpoint, false);
+        Upsert("BypassToken", update.BypassToken, false);
+
+        if (update.RotateSecret)
+        {
+            Upsert("Secret", update.Secret, true);
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Secret))
+        {
+            Upsert("Secret", update.Secret, true);
+        }
+        else if (!existing.Any(x => x.Key == "Secret"))
+        {
+            Upsert("Secret", null, true);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static string ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value!;
+        }
+
+        return string.Empty;
+    }
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return null;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/CaptchaValidator.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/CaptchaValidator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using HWInventory.Application.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class CaptchaValidator : ICaptchaValidator
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<CaptchaValidator> _logger;
+
+    public CaptchaValidator(IAppDbContext dbContext, IHttpClientFactory httpClientFactory, ILogger<CaptchaValidator> logger)
+    {
+        _dbContext = dbContext;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<bool> ValidateAsync(string token, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == "Security.Captcha")
+            .ToDictionaryAsync(x => x.Key, x => x.Value, cancellationToken);
+
+        var isEnabled = settings.TryGetValue("Enabled", out var enabledValue) && bool.TryParse(enabledValue, out var enabled) && enabled;
+        if (!isEnabled)
+        {
+            return true;
+        }
+
+        if (settings.TryGetValue("BypassToken", out var bypassToken) && !string.IsNullOrWhiteSpace(bypassToken) &&
+            string.Equals(token, bypassToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!settings.TryGetValue("VerificationEndpoint", out var endpoint) || string.IsNullOrWhiteSpace(endpoint))
+        {
+            _logger.LogWarning("Captcha verification endpoint not configured. Rejecting tokens.");
+            return false;
+        }
+
+        settings.TryGetValue("Secret", out var secret);
+        settings.TryGetValue("SiteKey", out var siteKey);
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient("captcha");
+            var response = await client.PostAsJsonAsync(endpoint, new
+            {
+                token,
+                secret,
+                siteKey
+            }, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Captcha verification failed with status {StatusCode}", response.StatusCode);
+                return false;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<CaptchaResponse>(cancellationToken: cancellationToken);
+            return result?.Success ?? false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Captcha verification error");
+            return false;
+        }
+    }
+
+    private sealed record CaptchaResponse(bool Success, IEnumerable<string>? Errors);
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/ExternalIdentityService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/ExternalIdentityService.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class ExternalIdentityService : IExternalIdentityService
+{
+    private const string SectionName = "Security.Oidc";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ExternalIdentityService> _logger;
+
+    public ExternalIdentityService(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor, ILogger<ExternalIdentityService> logger)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task ConfigureOidcAsync(OidcConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        var actor = ResolveActor();
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret
+                };
+
+                row.CreatedBy = actor;
+                row.ModifiedBy = actor;
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.ModifiedBy = actor;
+                row.Value = value;
+                row.IsSecret = isSecret;
+            }
+        }
+
+        Upsert("Enabled", configuration.Enabled.ToString(), false);
+        Upsert("Authority", configuration.Authority, false);
+        Upsert("ClientId", configuration.ClientId, true);
+        Upsert("ClientSecret", configuration.ClientSecret, true);
+        Upsert("ResponseType", configuration.ResponseType ?? "code", false);
+        Upsert("UsePkce", configuration.UsePkce.ToString(), false);
+        Upsert("Scopes", string.Join(' ', configuration.Scopes), false);
+
+        var claimMappings = string.Join(';', configuration.ClaimMappings.Select(pair => $"{pair.Key}:{pair.Value}"));
+        Upsert("ClaimMappings", claimMappings, false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("OIDC configuration updated by {Actor}", actor);
+    }
+
+    public async Task<OidcConfiguration?> GetConfigurationAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        if (settings.Count == 0)
+        {
+            return null;
+        }
+
+        bool enabled = settings.TryGetValue("Enabled", out var enabledSetting) && bool.TryParse(enabledSetting.Value, out var enabledValue) && enabledValue;
+        settings.TryGetValue("Authority", out var authoritySetting);
+        settings.TryGetValue("ClientId", out var clientIdSetting);
+        settings.TryGetValue("ClientSecret", out var secretSetting);
+        settings.TryGetValue("ResponseType", out var responseTypeSetting);
+        settings.TryGetValue("UsePkce", out var pkceSetting);
+        settings.TryGetValue("Scopes", out var scopesSetting);
+        settings.TryGetValue("ClaimMappings", out var claimsSetting);
+
+        var scopes = (scopesSetting?.Value ?? "openid profile email").Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var claimMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(claimsSetting?.Value))
+        {
+            foreach (var pair in claimsSetting.Value.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kvp = pair.Split(':', 2);
+                if (kvp.Length == 2)
+                {
+                    claimMap[kvp[0]] = kvp[1];
+                }
+            }
+        }
+
+        var configuration = new OidcConfiguration(
+            enabled,
+            authoritySetting?.Value ?? string.Empty,
+            clientIdSetting?.Value ?? string.Empty,
+            secretSetting?.Value,
+            responseTypeSetting?.Value,
+            scopes,
+            claimMap,
+            pkceSetting != null && bool.TryParse(pkceSetting.Value, out var pkce) && pkce);
+
+        _logger.LogDebug("OIDC configuration requested. Enabled={Enabled}", configuration.Enabled);
+        return configuration;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/LdapConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/LdapConfigurationStore.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class LdapConfigurationStore : ILdapConfigurationStore
+{
+    private const string SectionName = "Security.Ldap";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LdapConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<LdapConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new LdapConfigurationModel(
+            ReadBool(settings, "Enabled"),
+            ReadString(settings, "Host"),
+            ReadInt(settings, "Port", 389),
+            ReadBool(settings, "UseSsl"),
+            ReadString(settings, "BindDn"),
+            settings.TryGetValue("Password", out var passwordSetting) && !string.IsNullOrWhiteSpace(passwordSetting.Value),
+            ReadBool(settings, "IgnoreCertificateErrors"),
+            ReadString(settings, "UsersBaseDn"),
+            ReadNullableString(settings, "UsersFilter"),
+            ReadList(settings, "AttributeMap"));
+    }
+
+    public async Task<LdapConfigurationModel> SaveAsync(LdapConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("Host", update.Host, false);
+        Upsert("Port", update.Port.ToString(), false);
+        Upsert("UseSsl", update.UseSsl.ToString(), false);
+        Upsert("BindDn", update.BindDn, false);
+        Upsert("IgnoreCertificateErrors", update.IgnoreCertificateErrors.ToString(), false);
+        Upsert("UsersBaseDn", update.UsersBaseDn, false);
+        Upsert("UsersFilter", update.UsersFilter, false);
+        Upsert("AttributeMap", string.Join('\n', update.AttributeMap ?? Array.Empty<string>()), false);
+
+        if (update.ResetPassword)
+        {
+            Upsert("Password", null, true);
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Password))
+        {
+            Upsert("Password", update.Password, true);
+        }
+        else if (!existing.Any(x => x.Key == "Password"))
+        {
+            Upsert("Password", null, true);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static string ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value!;
+        }
+
+        return string.Empty;
+    }
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyCollection<string> ReadList(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToArray();
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/LdapSyncService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/LdapSyncService.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.DirectoryServices.Protocols;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class LdapSyncService : ILdapSyncService
+{
+    private readonly ILogger<LdapSyncService> _logger;
+
+    public LdapSyncService(ILogger<LdapSyncService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<LdapConnectionTestResult> TestConnectionAsync(LdapConnectionOptions options, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteTest(options), cancellationToken);
+    }
+
+    public Task<LdapDryRunResult> DryRunAsync(LdapDryRunRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteDryRun(request), cancellationToken);
+    }
+
+    private LdapConnectionTestResult ExecuteTest(LdapConnectionOptions options)
+    {
+        try
+        {
+            using var connection = CreateConnection(options);
+            connection.Bind();
+            var diagnostics = new Dictionary<string, string>
+            {
+                ["Server"] = options.Host,
+                ["Port"] = options.Port.ToString(),
+                ["Secure"] = options.UseSsl.ToString()
+            };
+
+            return new LdapConnectionTestResult(true, "Bind succeeded", diagnostics);
+        }
+        catch (LdapException ex)
+        {
+            _logger.LogWarning(ex, "LDAP bind failed");
+            return new LdapConnectionTestResult(false, ex.Message, BuildDiagnosticsFromException(ex));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected LDAP error");
+            return new LdapConnectionTestResult(false, ex.Message, BuildDiagnosticsFromException(ex));
+        }
+    }
+
+    private LdapDryRunResult ExecuteDryRun(LdapDryRunRequest request)
+    {
+        try
+        {
+            using var connection = CreateConnection(request.Connection);
+            connection.Bind();
+
+            var searchRequest = new SearchRequest(
+                request.UsersBaseDn,
+                string.IsNullOrWhiteSpace(request.UsersFilter) ? "(objectClass=user)" : request.UsersFilter,
+                SearchScope.Subtree,
+                request.AttributeMap.ToArray());
+
+            var response = (SearchResponse)connection.SendRequest(searchRequest);
+
+            var users = new List<LdapDryRunUser>();
+            foreach (SearchResultEntry entry in response.Entries)
+            {
+                var attributes = new Dictionary<string, string?>();
+                foreach (var attributeKey in request.AttributeMap)
+                {
+                    if (entry.Attributes.Contains(attributeKey))
+                    {
+                        var attribute = entry.Attributes[attributeKey];
+                        attributes[attributeKey] = attribute?.GetValues(typeof(string)).Cast<string?>().FirstOrDefault();
+                    }
+                    else
+                    {
+                        attributes[attributeKey] = null;
+                    }
+                }
+
+                users.Add(new LdapDryRunUser(entry.DistinguishedName, attributes));
+                if (users.Count >= request.ResultLimit)
+                {
+                    break;
+                }
+            }
+
+            var truncated = users.Count >= request.ResultLimit && response.Entries.Count > request.ResultLimit;
+            var notesBuilder = new StringBuilder();
+            if (truncated)
+            {
+                notesBuilder.Append("Result set truncated to limit");
+            }
+
+            return new LdapDryRunResult(users, response.Entries.Count, truncated, notesBuilder.Length == 0 ? null : notesBuilder.ToString());
+        }
+        catch (LdapException ex)
+        {
+            _logger.LogWarning(ex, "LDAP dry run failed");
+            throw;
+        }
+    }
+
+    private static LdapConnection CreateConnection(LdapConnectionOptions options)
+    {
+        var identifier = new LdapDirectoryIdentifier(options.Host, options.Port);
+        var connection = new LdapConnection(identifier)
+        {
+            Credential = new NetworkCredential(options.BindDn, options.Password ?? string.Empty),
+            AuthType = AuthType.Basic
+        };
+
+        if (options.UseSsl)
+        {
+            connection.SessionOptions.SecureSocketLayer = true;
+        }
+
+        if (options.IgnoreCertificateErrors)
+        {
+            connection.SessionOptions.VerifyServerCertificate += (_, _) => true;
+        }
+
+        connection.SessionOptions.ProtocolVersion = 3;
+        connection.Timeout = TimeSpan.FromSeconds(15);
+        return connection;
+    }
+
+    private static Dictionary<string, string> BuildDiagnosticsFromException(Exception ex)
+    {
+        var diagnostics = new Dictionary<string, string>
+        {
+            ["ExceptionType"] = ex.GetType().FullName ?? ex.GetType().Name,
+            ["Message"] = ex.Message
+        };
+
+        if (ex is LdapException ldapEx)
+        {
+            diagnostics["ErrorCode"] = ldapEx.ErrorCode.ToString();
+            diagnostics["ServerErrorMessage"] = ldapEx.ServerErrorMessage ?? string.Empty;
+        }
+
+        return diagnostics;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyConfigurationStore.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class PasswordPolicyConfigurationStore : IPasswordPolicyConfigurationStore
+{
+    private const string SectionName = "Security.PasswordPolicy";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public PasswordPolicyConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<PasswordPolicyModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new PasswordPolicyModel(
+            ReadBool(settings, "Enabled"),
+            ReadInt(settings, "MinimumLength", 12),
+            ReadBool(settings, "RequireUppercase", true),
+            ReadBool(settings, "RequireLowercase", true),
+            ReadBool(settings, "RequireDigit", true),
+            ReadBool(settings, "RequireNonAlphanumeric", false),
+            ReadInt(settings, "ExpirationDays", 90),
+            ReadInt(settings, "HistoryCount", 5),
+            ReadInt(settings, "LockoutAttempts", 5),
+            ReadInt(settings, "LockoutDurationMinutes", 15));
+    }
+
+    public async Task<PasswordPolicyModel> SaveAsync(PasswordPolicyUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = false,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString());
+        Upsert("MinimumLength", update.MinimumLength.ToString());
+        Upsert("RequireUppercase", update.RequireUppercase.ToString());
+        Upsert("RequireLowercase", update.RequireLowercase.ToString());
+        Upsert("RequireDigit", update.RequireDigit.ToString());
+        Upsert("RequireNonAlphanumeric", update.RequireNonAlphanumeric.ToString());
+        Upsert("ExpirationDays", update.ExpirationDays.ToString());
+        Upsert("HistoryCount", update.HistoryCount.ToString());
+        Upsert("LockoutAttempts", update.LockoutAttempts.ToString());
+        Upsert("LockoutDurationMinutes", update.LockoutDurationMinutes.ToString());
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key, bool fallback = false)
+    {
+        if (settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SessionTracker.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SessionTracker.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SessionTracker : ISessionTracker
+{
+    private readonly IAppDbContext _dbContext;
+
+    public SessionTracker(IAppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<UserSessionDto> RegisterAsync(RegisterSessionRequest request, CancellationToken cancellationToken = default)
+    {
+        var actor = string.IsNullOrWhiteSpace(request.PerformedBy) ? "system" : request.PerformedBy;
+        var session = new UserSession
+        {
+            AppUserId = request.UserId,
+            SessionIdentifier = request.SessionIdentifier,
+            IssuedAtUtc = DateTime.UtcNow,
+            LastSeenAtUtc = DateTime.UtcNow,
+            IpAddress = request.IpAddress,
+            UserAgent = request.UserAgent,
+            CreatedBy = actor,
+            ModifiedBy = actor
+        };
+
+        _dbContext.UserSessions.Add(session);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new UserSessionDto(session.Id, session.SessionIdentifier, session.IssuedAtUtc, session.LastSeenAtUtc, session.IpAddress, session.UserAgent, session.IsRevoked);
+    }
+
+    public async Task<bool> TouchAsync(string sessionIdentifier, CancellationToken cancellationToken = default)
+    {
+        var session = await _dbContext.UserSessions.FirstOrDefaultAsync(x => x.SessionIdentifier == sessionIdentifier, cancellationToken);
+        if (session is null)
+        {
+            return false;
+        }
+
+        if (session.IsRevoked)
+        {
+            return false;
+        }
+
+        session.LastSeenAtUtc = DateTime.UtcNow;
+        session.ModifiedBy = session.ModifiedBy ?? "system";
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return !session.IsRevoked;
+    }
+
+    public async Task<IReadOnlyCollection<UserSessionDto>> GetActiveSessionsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var sessions = await _dbContext.UserSessions
+            .Where(x => x.AppUserId == userId && !x.IsRevoked)
+            .OrderByDescending(x => x.LastSeenAtUtc)
+            .Select(x => new UserSessionDto(x.Id, x.SessionIdentifier, x.IssuedAtUtc, x.LastSeenAtUtc, x.IpAddress, x.UserAgent, x.IsRevoked))
+            .ToListAsync(cancellationToken);
+
+        return sessions;
+    }
+
+    public async Task RevokeAsync(Guid sessionId, string performedBy, string? reason, CancellationToken cancellationToken = default)
+    {
+        var session = await _dbContext.UserSessions.FirstOrDefaultAsync(x => x.Id == sessionId, cancellationToken);
+        if (session is null)
+        {
+            return;
+        }
+
+        session.IsRevoked = true;
+        session.RevokedAtUtc = DateTime.UtcNow;
+        session.RevokedBy = performedBy;
+        session.TerminationReason = reason;
+        session.ModifiedBy = performedBy;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task RevokeAllAsync(Guid userId, string performedBy, CancellationToken cancellationToken = default)
+    {
+        var sessions = await _dbContext.UserSessions.Where(x => x.AppUserId == userId && !x.IsRevoked).ToListAsync(cancellationToken);
+        var now = DateTime.UtcNow;
+        foreach (var session in sessions)
+        {
+            session.IsRevoked = true;
+            session.RevokedAtUtc = now;
+            session.RevokedBy = performedBy;
+            session.ModifiedBy = performedBy;
+            session.TerminationReason = "Revoked by administrator";
+        }
+
+        if (sessions.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SmsConnectorStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SmsConnectorStore.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SmsConnectorStore : ISmsConnectorStore
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public SmsConnectorStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<SmsConnectorModel?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS", cancellationToken);
+
+        if (connector is null)
+        {
+            return null;
+        }
+
+        var config = ParseConfiguration(connector.ConfigurationJson);
+        var hasSecret = connector.Secrets.Any();
+
+        return new SmsConnectorModel(
+            connector.Id,
+            connector.Alias,
+            connector.Enabled,
+            config.TryGetValue("endpoint", out var endpoint) ? endpoint ?? string.Empty : string.Empty,
+            config.TryGetValue("sender", out var sender) ? sender : null,
+            config.TryGetValue("region", out var region) ? region : null,
+            hasSecret,
+            connector.HealthStatus,
+            connector.LastTestedAtUtc);
+    }
+
+    public async Task<SmsConnectorModel> SaveAsync(SmsConnectorUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS", cancellationToken);
+
+        var config = new Dictionary<string, string?>
+        {
+            ["endpoint"] = update.Endpoint,
+            ["sender"] = update.Sender,
+            ["region"] = update.Region
+        };
+
+        if (connector is null)
+        {
+            connector = new ConnectorProfile
+            {
+                Type = "SMS",
+                Alias = string.IsNullOrWhiteSpace(update.Alias) ? "Primary SMS" : update.Alias,
+                Enabled = update.Enabled,
+                ConfigurationJson = JsonSerializer.Serialize(config),
+                CreatedBy = actor,
+                ModifiedBy = actor
+            };
+
+            _dbContext.ConnectorProfiles.Add(connector);
+        }
+        else
+        {
+            connector.Alias = string.IsNullOrWhiteSpace(update.Alias) ? connector.Alias : update.Alias;
+            connector.Enabled = update.Enabled;
+            connector.ConfigurationJson = JsonSerializer.Serialize(config);
+            connector.ModifiedBy = actor;
+        }
+
+        if (update.RotateSecret && string.IsNullOrWhiteSpace(update.Secret))
+        {
+            connector.Secrets.Clear();
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Secret))
+        {
+            connector.Secrets.Clear();
+            connector.Secrets.Add(new ConnectorSecret
+            {
+                Key = "token",
+                SecretReference = update.Secret!,
+                RotatedAtUtc = DateTime.UtcNow
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return (await GetAsync(cancellationToken))!;
+    }
+
+    private static Dictionary<string, string?> ParseConfiguration(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string?>>(json) ?? new Dictionary<string, string?>();
+        }
+        catch
+        {
+            return new Dictionary<string, string?>();
+        }
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SmsGateway.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SmsGateway.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HWInventory.Application.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SmsGateway : ISmsGateway
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<SmsGateway> _logger;
+
+    public SmsGateway(IAppDbContext dbContext, IHttpClientFactory httpClientFactory, ILogger<SmsGateway> logger)
+    {
+        _dbContext = dbContext;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(string destination, string message, CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS" && x.Enabled, cancellationToken);
+
+        if (connector is null)
+        {
+            _logger.LogWarning("SMS connector not configured. Message to {Destination} dropped.", destination);
+            return;
+        }
+
+        try
+        {
+            var config = connector.ConfigurationJson is null
+                ? new Dictionary<string, string>()
+                : JsonSerializer.Deserialize<Dictionary<string, string>>(connector.ConfigurationJson) ?? new Dictionary<string, string>();
+
+            config.TryGetValue("endpoint", out var endpoint);
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                _logger.LogWarning("SMS connector endpoint missing. Message to {Destination} dropped.", destination);
+                return;
+            }
+
+            var client = _httpClientFactory.CreateClient("sms");
+            var payload = new
+            {
+                to = destination,
+                message,
+                sender = config.TryGetValue("sender", out var sender) ? sender : null,
+                token = connector.Secrets.FirstOrDefault()?.SecretReference
+            };
+
+            var response = await client.PostAsJsonAsync(endpoint, payload, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("SMS send failed for {Destination} with status {Status}", destination, response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SMS send error for {Destination}", destination);
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SsprConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SsprConfigurationStore.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SsprConfigurationStore : ISsprConfigurationStore
+{
+    private const string SectionName = "Security.Sspr";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public SsprConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<SsprConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new SsprConfigurationModel(
+            ReadBool(settings, "Enabled"),
+            ReadBool(settings, "RequireTwoFactor"),
+            ReadBool(settings, "RequireCaptcha"),
+            ReadBool(settings, "RequireSmsOtp"),
+            ReadInt(settings, "TokenExpiryMinutes", 30),
+            ReadInt(settings, "ThrottleWindowMinutes", 15),
+            ReadInt(settings, "MaxRequestsPerWindow", 3),
+            ReadString(settings, "SmsConnectorKey", allowNull: true));
+    }
+
+    public async Task<SsprConfigurationModel> SaveAsync(SsprConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("RequireTwoFactor", update.RequireTwoFactor.ToString(), false);
+        Upsert("RequireCaptcha", update.RequireCaptcha.ToString(), false);
+        Upsert("RequireSmsOtp", update.RequireSmsOtp.ToString(), false);
+        Upsert("TokenExpiryMinutes", update.TokenExpiryMinutes.ToString(), false);
+        Upsert("ThrottleWindowMinutes", update.ThrottleWindowMinutes.ToString(), false);
+        Upsert("MaxRequestsPerWindow", update.MaxRequestsPerWindow.ToString(), false);
+        Upsert("SmsConnectorKey", string.IsNullOrWhiteSpace(update.SmsConnectorKey) ? null : update.SmsConnectorKey, false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key, bool allowNull = false)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return allowNull ? null : string.Empty;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SsprService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SsprService.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SsprService : ISsprService
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICaptchaValidator _captchaValidator;
+    private readonly ISmsGateway _smsGateway;
+    private readonly ILogger<SsprService> _logger;
+    private readonly ISessionTracker _sessionTracker;
+
+    public SsprService(UserManager<AppUser> userManager, IAppDbContext dbContext, ICaptchaValidator captchaValidator, ISmsGateway smsGateway, ISessionTracker sessionTracker, ILogger<SsprService> logger)
+    {
+        _userManager = userManager;
+        _dbContext = dbContext;
+        _captchaValidator = captchaValidator;
+        _smsGateway = smsGateway;
+        _sessionTracker = sessionTracker;
+        _logger = logger;
+    }
+
+    public async Task<PasswordResetRequestResult> RequestResetAsync(PasswordResetRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!await _captchaValidator.ValidateAsync(request.CaptchaToken, cancellationToken))
+        {
+            return new PasswordResetRequestResult(false, "CAPTCHA validation failed.", null, false);
+        }
+
+        var user = await _userManager.Users.FirstOrDefaultAsync(x => x.Email == request.UsernameOrEmail || x.UserName == request.UsernameOrEmail, cancellationToken);
+        if (user is null)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken); // mitigate enumeration
+            return new PasswordResetRequestResult(false, "User not found.", null, false);
+        }
+
+        var identityToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var resetToken = new PasswordResetToken
+        {
+            AppUserId = user.Id,
+            Token = Guid.NewGuid(),
+            DeliveryMethod = request.DeliveryMethod,
+            DeliveryAddress = request.DeliveryDestination,
+            ExpiresAtUtc = DateTime.UtcNow.AddMinutes(30),
+            RequiresSmsVerification = request.RequireSmsOtp,
+            Status = PasswordResetStatus.Pending,
+            CreatedBy = user.UserName ?? user.Email ?? "system",
+            ModifiedBy = user.UserName ?? user.Email ?? "system",
+            CaptchaToken = request.CaptchaToken,
+            IdentityToken = identityToken
+        };
+
+        string? smsCode = null;
+        if (request.RequireSmsOtp && !string.IsNullOrWhiteSpace(request.DeliveryDestination))
+        {
+            smsCode = GenerateSmsCode();
+            resetToken.SmsCodeHash = HashValue(smsCode);
+            await _smsGateway.SendAsync(request.DeliveryDestination, $"HWInventory reset kód: {smsCode}", cancellationToken);
+        }
+
+        _dbContext.PasswordResetTokens.Add(resetToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new PasswordResetRequestResult(true, "Reset token issued.", resetToken.Token, smsCode is not null);
+    }
+
+    public async Task<PasswordResetCompletionResult> CompleteResetAsync(PasswordResetCompletionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!await _captchaValidator.ValidateAsync(request.CaptchaToken, cancellationToken))
+        {
+            return new PasswordResetCompletionResult(false, "CAPTCHA validation failed.");
+        }
+
+        var token = await _dbContext.PasswordResetTokens
+            .Include(x => x.AppUser)
+            .FirstOrDefaultAsync(x => x.Token == request.Token, cancellationToken);
+
+        if (token is null)
+        {
+            return new PasswordResetCompletionResult(false, "Reset token not found.");
+        }
+
+        if (token.Status != PasswordResetStatus.Pending)
+        {
+            return new PasswordResetCompletionResult(false, "Reset token is not active.");
+        }
+
+        if (token.ExpiresAtUtc < DateTime.UtcNow)
+        {
+            token.Status = PasswordResetStatus.Expired;
+            token.ModifiedBy = token.ModifiedBy ?? "system";
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new PasswordResetCompletionResult(false, "Reset token expired.");
+        }
+
+        if (token.RequiresSmsVerification)
+        {
+            if (string.IsNullOrWhiteSpace(request.SmsCode) || token.SmsCodeHash != HashValue(request.SmsCode))
+            {
+                return new PasswordResetCompletionResult(false, "SMS code invalid.");
+            }
+        }
+
+        var user = token.AppUser;
+        var result = await _userManager.ResetPasswordAsync(user, token.IdentityToken, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            var message = string.Join(",", result.Errors.Select(e => e.Description));
+            _logger.LogWarning("Failed to reset password for user {UserId}: {Message}", user.Id, message);
+            return new PasswordResetCompletionResult(false, message);
+        }
+
+        token.Status = PasswordResetStatus.Completed;
+        token.ConsumedAtUtc = DateTime.UtcNow;
+        token.ModifiedBy = user.UserName ?? user.Email ?? "system";
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _sessionTracker.RevokeAllAsync(user.Id, user.UserName ?? user.Email ?? "system", cancellationToken);
+
+        return new PasswordResetCompletionResult(true, "Password reset successfully.");
+    }
+
+    private static string GenerateSmsCode()
+    {
+        var randomBytes = RandomNumberGenerator.GetBytes(4);
+        var value = BitConverter.ToUInt32(randomBytes, 0) % 1000000;
+        return value.ToString("D6");
+    }
+
+    private static string HashValue(string value)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
@@ -1,0 +1,34 @@
+using System.Security.Cryptography;
+using HWInventory.Application.Abstractions;
+using OtpNet;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class TotpService : ITotpService
+{
+    private const int SecretSize = 20;
+
+    public string GenerateSecretKey()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(SecretSize);
+        return Base32Encoding.ToString(bytes);
+    }
+
+    public string GenerateCode(string secretKey)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.ComputeTotp(DateTime.UtcNow);
+    }
+
+    public bool ValidateCode(string secretKey, string code)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.VerifyTotp(code, out _, VerificationWindow.RfcSpecifiedNetworkDelay);
+    }
+
+    private static Totp CreateTotp(string secretKey)
+    {
+        var key = Base32Encoding.ToBytes(secretKey);
+        return new Totp(key, mode: OtpHashMode.Sha1, step: 30, totpSize: 6);
+    }
+}

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,0 +1,10 @@
+# HW Inventory Admin UI (Placeholder)
+
+The React + Vite + Tailwind admin application will live in this directory. Upcoming milestones:
+
+1. Scaffold Vite project structure with routing, layout shell, and Tailwind theme tokens.
+2. Implement authentication shell (login, MFA prompt) integrated with the API once auth is available.
+3. Build pages for dashboard, servers, network, workstations, dictionaries, audit, labels, modules, and settings (including the onboarding wizard).
+4. Connect to API endpoints, implement pagination/filtering, and render label previews.
+
+Until the UI is generated the directory contains documentation placeholders only.

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HW Inventory Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "hw-inventory-admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.17.0",
+    "axios": "^1.6.0",
+    "clsx": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/web/postcss.config.cjs
+++ b/src/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,0 +1,79 @@
+import { Link, Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import { useTheme } from './hooks/useTheme';
+import { DashboardPage } from './pages/DashboardPage';
+import { FirstRunWizardPage } from './pages/FirstRunWizardPage';
+import { PlaceholderPage } from './pages/PlaceholderPage';
+import { SecuritySettingsPage } from './pages/SecuritySettingsPage';
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/servers', label: 'Servers' },
+  { to: '/network', label: 'Network' },
+  { to: '/workstations', label: 'Workstations' },
+  { to: '/audit', label: 'Audit' },
+  { to: '/labels', label: 'Labels' },
+  { to: '/settings/security', label: 'Settings' },
+  { to: '/modules', label: 'Modules' }
+];
+
+const Layout = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="min-h-screen bg-slate-100 dark:bg-slate-950">
+      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-white">HW Inventory</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Operations control center</p>
+          </div>
+          <button
+            onClick={toggleTheme}
+            className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium shadow-sm transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            type="button"
+          >
+            {theme === 'light' ? '🌙 Dark mode' : '☀️ Light mode'}
+          </button>
+        </div>
+        <nav className="bg-slate-50 dark:bg-slate-950">
+          <div className="mx-auto flex max-w-6xl flex-wrap gap-3 px-6 py-2 text-sm font-medium">
+            {navItems.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className="rounded px-3 py-1 text-slate-700 transition hover:bg-slate-200 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+const App = () => (
+  <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<DashboardPage />} />
+        <Route path="first-run" element={<FirstRunWizardPage />} />
+      <Route path="servers" element={<PlaceholderPage title="Servers" description="Server inventory grid will appear here." />} />
+      <Route path="network" element={<PlaceholderPage title="Network devices" description="Network device management workspace." />} />
+      <Route path="workstations" element={<PlaceholderPage title="Workstations" description="Workstation lifecycle management UI." />} />
+      <Route path="audit" element={<PlaceholderPage title="Audit" description="Audit trail filters and export tools." />} />
+      <Route path="labels" element={<PlaceholderPage title="Labels" description="Label editor and batch printing." />} />
+      <Route path="settings" element={<Outlet />}>
+        <Route index element={<Navigate to="security" replace />} />
+        <Route path="security" element={<SecuritySettingsPage />} />
+        <Route path="*" element={<PlaceholderPage title="Settings" description="Administrative configuration center." />} />
+      </Route>
+      <Route path="modules" element={<PlaceholderPage title="Modules" description="Feature toggle management." />} />
+    </Route>
+  </Routes>
+);
+
+export default App;

--- a/src/web/src/api/audit.ts
+++ b/src/web/src/api/audit.ts
@@ -1,0 +1,19 @@
+import { apiClient } from './client';
+
+export interface AuditLogEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  action: string;
+  performedBy: string;
+  roles?: string | null;
+  performedAtUtc: string;
+  changeSummary?: string | null;
+  changedFieldsJson?: string | null;
+}
+
+export const getAuditLogs = async (entityType?: string) => {
+  const params = entityType ? { entityType } : undefined;
+  const { data } = await apiClient.get<AuditLogEntry[]>('/audit', { params });
+  return data;
+};

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: '/api',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const message = error?.response?.data?.detail || error?.message || 'Neznámá chyba';
+    return Promise.reject(new Error(message));
+  }
+);

--- a/src/web/src/api/security.ts
+++ b/src/web/src/api/security.ts
@@ -1,0 +1,258 @@
+import { apiClient } from './client';
+
+export interface OidcConfiguration {
+  enabled: boolean;
+  authority: string;
+  clientId: string;
+  clientSecret?: string | null;
+  responseType?: string | null;
+  scopes: string[];
+  claimMappings: Record<string, string>;
+  usePkce: boolean;
+}
+
+export interface LdapConfiguration {
+  enabled: boolean;
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  hasPassword: boolean;
+  ignoreCertificateErrors: boolean;
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+}
+
+export interface LdapConfigurationRequest {
+  enabled: boolean;
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  password?: string | null;
+  resetPassword: boolean;
+  ignoreCertificateErrors: boolean;
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+}
+
+export interface LdapConnectionOptions {
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  password?: string | null;
+  ignoreCertificateErrors: boolean;
+}
+
+export interface LdapDryRunRequest {
+  connection: LdapConnectionOptions & { password?: string | null };
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+  resultLimit: number;
+}
+
+export interface LdapConnectionTestResult {
+  success: boolean;
+  message: string;
+  diagnostics?: Record<string, string> | null;
+}
+
+export interface LdapDryRunResult {
+  users: Array<{ distinguishedName: string; attributes: Record<string, string | null> }>;
+  resultCount: number;
+  truncated: boolean;
+  notes?: string | null;
+}
+
+export interface SsprConfiguration {
+  enabled: boolean;
+  requireTwoFactor: boolean;
+  requireCaptcha: boolean;
+  requireSmsOtp: boolean;
+  tokenExpiryMinutes: number;
+  throttleWindowMinutes: number;
+  maxRequestsPerWindow: number;
+  smsConnectorKey?: string | null;
+}
+
+export interface CaptchaConfiguration {
+  enabled: boolean;
+  siteKey: string;
+  hasSecret: boolean;
+  verificationEndpoint: string;
+  bypassToken?: string | null;
+}
+
+export interface CaptchaConfigurationRequest {
+  enabled: boolean;
+  siteKey: string;
+  verificationEndpoint: string;
+  secret?: string | null;
+  rotateSecret: boolean;
+  bypassToken?: string | null;
+}
+
+export interface SmsConnectorConfiguration {
+  id?: string | null;
+  alias: string;
+  enabled: boolean;
+  endpoint: string;
+  sender?: string | null;
+  region?: string | null;
+  hasSecret: boolean;
+  healthStatus?: string | null;
+  lastTestedAtUtc?: string | null;
+}
+
+export interface SmsConnectorRequest {
+  alias: string;
+  enabled: boolean;
+  endpoint: string;
+  sender?: string | null;
+  region?: string | null;
+  secret?: string | null;
+  rotateSecret: boolean;
+}
+
+export interface LdapRoleMapping {
+  id: string;
+  groupName: string;
+  roleName: string;
+}
+
+export interface PasswordPolicyConfiguration {
+  enabled: boolean;
+  minimumLength: number;
+  requireUppercase: boolean;
+  requireLowercase: boolean;
+  requireDigit: boolean;
+  requireNonAlphanumeric: boolean;
+  expirationDays: number;
+  historyCount: number;
+  lockoutAttempts: number;
+  lockoutDurationMinutes: number;
+}
+
+export interface UserSummary {
+  id: string;
+  displayName: string;
+  email: string;
+  userName: string;
+}
+
+export interface UserSession {
+  id: string;
+  sessionIdentifier: string;
+  issuedAtUtc: string;
+  lastSeenAtUtc: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  isRevoked: boolean;
+}
+
+export const getOidcConfiguration = async () => {
+  const { data } = await apiClient.get<OidcConfiguration>('/security/oidc');
+  return data;
+};
+
+export const updateOidcConfiguration = async (payload: OidcConfiguration) => {
+  await apiClient.post('/security/oidc', payload);
+};
+
+export const getLdapConfiguration = async () => {
+  const { data } = await apiClient.get<LdapConfiguration>('/security/ldap/config');
+  return data;
+};
+
+export const updateLdapConfiguration = async (payload: LdapConfigurationRequest) => {
+  await apiClient.post('/security/ldap/config', payload);
+};
+
+export const testLdapConnection = async (options: LdapConnectionOptions & { password?: string | null }) => {
+  const { data } = await apiClient.post<LdapConnectionTestResult>('/security/ldap/test', options);
+  return data;
+};
+
+export const dryRunLdap = async (request: LdapDryRunRequest) => {
+  const { data } = await apiClient.post<LdapDryRunResult>('/security/ldap/dry-run', request);
+  return data;
+};
+
+export const getSsprConfiguration = async () => {
+  const { data } = await apiClient.get<SsprConfiguration>('/security/sspr/config');
+  return data;
+};
+
+export const updateSsprConfiguration = async (payload: SsprConfiguration) => {
+  await apiClient.post('/security/sspr/config', payload);
+};
+
+export const getCaptchaConfiguration = async () => {
+  const { data } = await apiClient.get<CaptchaConfiguration>('/security/captcha/config');
+  return data;
+};
+
+export const updateCaptchaConfiguration = async (payload: CaptchaConfigurationRequest) => {
+  await apiClient.post('/security/captcha/config', payload);
+};
+
+export const getSmsConfiguration = async () => {
+  const { data } = await apiClient.get<SmsConnectorConfiguration | null>('/security/sms/config');
+  return data;
+};
+
+export const updateSmsConfiguration = async (payload: SmsConnectorRequest) => {
+  const { data } = await apiClient.post<SmsConnectorConfiguration>('/security/sms/config', payload);
+  return data;
+};
+
+export const getPasswordPolicyConfiguration = async () => {
+  const { data } = await apiClient.get<PasswordPolicyConfiguration>('/security/password-policy');
+  return data;
+};
+
+export const updatePasswordPolicyConfiguration = async (payload: PasswordPolicyConfiguration) => {
+  await apiClient.post('/security/password-policy', payload);
+};
+
+export const getLdapRoleMappings = async () => {
+  const { data } = await apiClient.get<LdapRoleMapping[]>('/security/ldap/role-mappings');
+  return data;
+};
+
+export const createLdapRoleMapping = async (payload: { groupName: string; roleName: string }) => {
+  const { data } = await apiClient.post<LdapRoleMapping>('/security/ldap/role-mappings', payload);
+  return data;
+};
+
+export const updateLdapRoleMapping = async (id: string, payload: { groupName: string; roleName: string }) => {
+  const { data } = await apiClient.put<LdapRoleMapping>(`/security/ldap/role-mappings/${id}`, payload);
+  return data;
+};
+
+export const deleteLdapRoleMapping = async (id: string) => {
+  await apiClient.delete(`/security/ldap/role-mappings/${id}`);
+};
+
+export const searchSecurityUsers = async (query: string) => {
+  const params = query.trim().length > 0 ? { params: { query } } : {};
+  const { data } = await apiClient.get<UserSummary[]>('/security/users', params);
+  return data;
+};
+
+export const getUserSessions = async (userId: string) => {
+  const { data } = await apiClient.get<UserSession[]>(`/security/users/${userId}/sessions`);
+  return data;
+};
+
+export const revokeSession = async (sessionId: string, reason?: string) => {
+  await apiClient.post(`/security/sessions/${sessionId}/revoke`, reason ? { reason } : {});
+};
+
+export const revokeAllSessions = async (userId: string) => {
+  await apiClient.post(`/security/users/${userId}/sessions/revoke-all`);
+};

--- a/src/web/src/hooks/useTheme.ts
+++ b/src/web/src/hooks/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../theme/ThemeProvider';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+};

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </ThemeProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/web/src/pages/DashboardPage.tsx
+++ b/src/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,29 @@
+export const DashboardPage = () => {
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Quick stats</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Connect the dashboard to /api/dashboard/summary to surface real-time insights across servers, network devices and workstations.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          {['Servers', 'Network devices', 'Workstations'].map((label) => (
+            <div key={label} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <p className="text-sm text-slate-500 dark:text-slate-400">{label}</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">0</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Getting started checklist</h3>
+        <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+          <li>1. Configure SQL Server connection and run the onboarding wizard.</li>
+          <li>2. Enable authentication providers and test 2FA enrollment.</li>
+          <li>3. Sync baseline dictionaries and import inventory data.</li>
+          <li>4. Review scheduled jobs, backup policies, and alerting connectors.</li>
+        </ul>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/FirstRunWizardPage.tsx
+++ b/src/web/src/pages/FirstRunWizardPage.tsx
@@ -1,0 +1,132 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SecuritySettingsPage } from './SecuritySettingsPage';
+
+const stepDefinitions = [
+  {
+    key: 'intro',
+    title: 'Vítejte v průvodci prvním spuštěním',
+    description:
+      'Před tím, než začnete spravovat inventář, nastavte kritické bezpečnostní integrace. Průvodce je možné kdykoli znovu otevřít v menu Nastavení.',
+    content: (
+      <div className="space-y-4 text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          Tento průvodce vás provede konfigurací externí autentizace, LDAP/AD připojení a self-service resetu hesel. Všechny
+          změny se ukládají okamžitě a zapisují se do auditu.
+        </p>
+        <p>
+          Připravte si přístupové údaje k OIDC providerovi, LDAP/AD serveru, SMTP a případným SMS/CAPTCHA konektorům. Každý krok
+          lze přeskočit a později dokončit v Nastavení.
+        </p>
+      </div>
+    )
+  },
+  {
+    key: 'security',
+    title: 'Bezpečnostní nastavení',
+    description:
+      'Zadejte údaje pro OIDC, LDAP/AD, SSPR, CAPTCHA a SMS konektory. Rozhraní níže je shodné s administrací Nastavení → Security.',
+    content: <SecuritySettingsPage variant="wizard" />
+  },
+  {
+    key: 'summary',
+    title: 'Hotovo',
+    description: 'Základní bezpečnostní integrace jsou připraveny. Doporučujeme pokračovat konfigurací zbylých modulů aplikace.',
+    content: (
+      <div className="space-y-4 text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          Konfigurace byla dokončena. V Nastavení můžete kdykoli upravit jednotlivé konektory, přidat další mapování AD skupin
+          nebo sledovat auditní záznamy.
+        </p>
+        <p>
+          Pokračujte na dashboard, kde najdete souhrn aktivovaných modulů a další kroky pro nasazení platformy HW Inventory.
+        </p>
+      </div>
+    )
+  }
+];
+
+export const FirstRunWizardPage = () => {
+  const navigate = useNavigate();
+  const [activeStep, setActiveStep] = useState(0);
+
+  const clampedStep = useMemo(() => Math.min(Math.max(activeStep, 0), stepDefinitions.length - 1), [activeStep]);
+  const step = stepDefinitions[clampedStep];
+
+  const goNext = () => {
+    if (clampedStep < stepDefinitions.length - 1) {
+      setActiveStep((current) => current + 1);
+    }
+  };
+
+  const goPrevious = () => {
+    if (clampedStep > 0) {
+      setActiveStep((current) => current - 1);
+    }
+  };
+
+  const finish = () => {
+    navigate('/');
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Průvodce prvním spuštěním</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Krok {clampedStep + 1} z {stepDefinitions.length} – {step.title}
+        </p>
+        <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
+      </header>
+
+      <nav className="flex flex-wrap gap-3">
+        {stepDefinitions.map((definition, index) => (
+          <button
+            key={definition.key}
+            type="button"
+            onClick={() => setActiveStep(index)}
+            className={`rounded px-3 py-1 text-sm transition ${
+              index === clampedStep
+                ? 'bg-sky-600 text-white shadow'
+                : 'border border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800'
+            }`}
+          >
+            {index + 1}. {definition.title}
+          </button>
+        ))}
+      </nav>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        {step.content}
+      </section>
+
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={goPrevious}
+          disabled={clampedStep === 0}
+          className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+        >
+          Zpět
+        </button>
+        {clampedStep < stepDefinitions.length - 1 ? (
+          <button
+            type="button"
+            onClick={goNext}
+            className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700"
+          >
+            Pokračovat
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={finish}
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+          >
+            Dokončit
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/web/src/pages/PlaceholderPage.tsx
+++ b/src/web/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type PlaceholderPageProps = {
+  title: string;
+  description: string;
+};
+
+export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title, description }) => (
+  <div className="space-y-4 rounded-lg border border-dashed border-slate-300 bg-white p-6 text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+    <h2 className="text-xl font-semibold">{title}</h2>
+    <p>{description}</p>
+    <p className="text-sm text-slate-500 dark:text-slate-400">
+      Scaffold API clients with React Query to fetch data from the secured ASP.NET Core backend. This shell ensures the dark/light
+      theme toggle and navigation system are ready for the upcoming modules.
+    </p>
+  </div>
+);

--- a/src/web/src/pages/SecuritySettingsPage.tsx
+++ b/src/web/src/pages/SecuritySettingsPage.tsx
@@ -1,0 +1,1715 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  CaptchaConfiguration,
+  CaptchaConfigurationRequest,
+  LdapConfiguration,
+  LdapConfigurationRequest,
+  LdapConnectionTestResult,
+  LdapRoleMapping,
+  OidcConfiguration,
+  SmsConnectorConfiguration,
+  SmsConnectorRequest,
+  SsprConfiguration,
+  PasswordPolicyConfiguration,
+  UserSummary,
+  UserSession,
+  createLdapRoleMapping,
+  deleteLdapRoleMapping,
+  dryRunLdap,
+  getCaptchaConfiguration,
+  getLdapConfiguration,
+  getLdapRoleMappings,
+  getOidcConfiguration,
+  getSmsConfiguration,
+  getSsprConfiguration,
+  getPasswordPolicyConfiguration,
+  testLdapConnection,
+  getUserSessions,
+  updateCaptchaConfiguration,
+  updateLdapConfiguration,
+  updateLdapRoleMapping,
+  updateOidcConfiguration,
+  updateSmsConfiguration,
+  updateSsprConfiguration,
+  updatePasswordPolicyConfiguration,
+  searchSecurityUsers,
+  revokeSession,
+  revokeAllSessions
+} from '../api/security';
+import { AuditLogEntry, getAuditLogs } from '../api/audit';
+
+interface FlashMessage {
+  type: 'success' | 'error';
+  message: string;
+}
+
+const parseClaimMappings = (input: string): Record<string, string> => {
+  const mappings: Record<string, string> = {};
+  input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [key, value] = line.split('=', 2);
+      if (key && value) {
+        mappings[key.trim()] = value.trim();
+      }
+    });
+  return mappings;
+};
+
+const stringifyClaimMappings = (mappings: Record<string, string>): string =>
+  Object.entries(mappings)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+const parseList = (input: string): string[] =>
+  input
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const stringifyList = (items: string[]): string => items.join('\n');
+
+const SECURITY_AUDIT_TYPES = [
+  'Security.OIDC',
+  'Security.LDAP',
+  'Security.SSPR',
+  'Security.Captcha',
+  'Security.SMS',
+  'Security.PasswordPolicy',
+  'Security.Session',
+  'Security.LdapRoleMapping',
+  'Security.DataScopes'
+];
+
+const ROLE_OPTIONS = [
+  { value: 'SuperAdmin', label: 'Super Admin' },
+  { value: 'SRV Administrator', label: 'SRV Administrator' },
+  { value: 'NET Administrator', label: 'NET Administrator' },
+  { value: 'Aplikační admin', label: 'Aplikační admin' },
+  { value: 'Helpdesk', label: 'Helpdesk' },
+  { value: 'Helpdesk Read', label: 'Helpdesk Read' }
+];
+
+interface SecuritySettingsPageProps {
+  variant?: 'full' | 'wizard';
+}
+
+export const SecuritySettingsPage = ({ variant = 'full' }: SecuritySettingsPageProps) => {
+  const queryClient = useQueryClient();
+  const [flash, setFlash] = useState<FlashMessage | null>(null);
+  const headerDescription =
+    variant === 'wizard'
+      ? 'V rámci průvodce prvním spuštěním nastavte klíčové bezpečnostní integrace. Změny se uloží okamžitě.'
+      : 'Spravujte externí identity, připojení k LDAP/AD a pravidla self-service resetu hesel. Změny se okamžitě zapisují do auditu.';
+
+  const [oidcState, setOidcState] = useState<OidcConfiguration>({
+    enabled: false,
+    authority: '',
+    clientId: '',
+    clientSecret: '',
+    responseType: 'code',
+    scopes: ['openid', 'profile', 'email'],
+    claimMappings: { name: 'name', email: 'email' },
+    usePkce: true
+  });
+  const [scopesInput, setScopesInput] = useState('openid profile email');
+  const [claimMappingsInput, setClaimMappingsInput] = useState('name=name\nemail=email');
+
+  const [ldapState, setLdapState] = useState<{
+    form: LdapConfigurationRequest;
+    hasPassword: boolean;
+  }>({
+    form: {
+      enabled: false,
+      host: '',
+      port: 389,
+      useSsl: false,
+      bindDn: '',
+      password: '',
+      resetPassword: false,
+      ignoreCertificateErrors: false,
+      usersBaseDn: '',
+      usersFilter: '',
+      attributeMap: []
+    },
+    hasPassword: false
+  });
+  const [ldapTestResult, setLdapTestResult] = useState<LdapConnectionTestResult | null>(null);
+  const [ldapDryRunResult, setLdapDryRunResult] = useState<{
+    resultCount: number;
+    truncated: boolean;
+    notes?: string | null;
+    users: Array<{ distinguishedName: string; attributes: Record<string, string | null> }>;
+  } | null>(null);
+  const [ldapAttributeMapInput, setLdapAttributeMapInput] = useState('');
+
+  const [ssprState, setSsprState] = useState<SsprConfiguration>({
+    enabled: false,
+    requireTwoFactor: true,
+    requireCaptcha: true,
+    requireSmsOtp: false,
+    tokenExpiryMinutes: 30,
+    throttleWindowMinutes: 15,
+    maxRequestsPerWindow: 3,
+    smsConnectorKey: ''
+  });
+
+  const [captchaState, setCaptchaState] = useState<CaptchaConfiguration>({
+    enabled: false,
+    siteKey: '',
+    hasSecret: false,
+    verificationEndpoint: '',
+    bypassToken: ''
+  });
+  const [captchaSecretInput, setCaptchaSecretInput] = useState('');
+  const [captchaRotateSecret, setCaptchaRotateSecret] = useState(false);
+
+  const [smsState, setSmsState] = useState<SmsConnectorConfiguration>({
+    id: null,
+    alias: 'Primary SMS',
+    enabled: false,
+    endpoint: '',
+    sender: '',
+    region: '',
+    hasSecret: false,
+    healthStatus: undefined,
+    lastTestedAtUtc: undefined
+  });
+  const [smsSecretInput, setSmsSecretInput] = useState('');
+  const [smsRotateSecret, setSmsRotateSecret] = useState(false);
+
+  const [passwordPolicyState, setPasswordPolicyState] = useState<PasswordPolicyConfiguration>({
+    enabled: true,
+    minimumLength: 12,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireDigit: true,
+    requireNonAlphanumeric: false,
+    expirationDays: 90,
+    historyCount: 5,
+    lockoutAttempts: 5,
+    lockoutDurationMinutes: 15
+  });
+
+  const [sessionSearchTerm, setSessionSearchTerm] = useState('');
+  const [selectedUser, setSelectedUser] = useState<UserSummary | null>(null);
+  const [revokeReason, setRevokeReason] = useState('');
+
+  const [roleMappings, setRoleMappings] = useState<LdapRoleMapping[]>([]);
+  const [mappingDrafts, setMappingDrafts] = useState<Record<string, { groupName: string; roleName: string }>>({});
+  const [newMapping, setNewMapping] = useState<{ groupName: string; roleName: string }>({
+    groupName: '',
+    roleName: ROLE_OPTIONS[0].value
+  });
+
+  const [auditExpanded, setAuditExpanded] = useState<string | null>(null);
+
+  const oidcQuery = useQuery({
+    queryKey: ['security', 'oidc'],
+    queryFn: getOidcConfiguration,
+    onSuccess: (data) => {
+      if (data) {
+        setOidcState(data);
+        setScopesInput(data.scopes.join(' '));
+        setClaimMappingsInput(stringifyClaimMappings(data.claimMappings));
+      }
+    }
+  });
+
+  const ldapQuery = useQuery({
+    queryKey: ['security', 'ldap'],
+    queryFn: getLdapConfiguration,
+    onSuccess: (data: LdapConfiguration) => {
+      setLdapState({
+        form: {
+          enabled: data.enabled,
+          host: data.host,
+          port: data.port,
+          useSsl: data.useSsl,
+          bindDn: data.bindDn,
+          password: '',
+          resetPassword: false,
+          ignoreCertificateErrors: data.ignoreCertificateErrors,
+          usersBaseDn: data.usersBaseDn,
+          usersFilter: data.usersFilter ?? '',
+          attributeMap: data.attributeMap
+        },
+        hasPassword: data.hasPassword
+      });
+      setLdapAttributeMapInput(stringifyList(data.attributeMap));
+    }
+  });
+
+  const ssprQuery = useQuery({
+    queryKey: ['security', 'sspr'],
+    queryFn: getSsprConfiguration,
+    onSuccess: (data) => {
+      setSsprState(data);
+    }
+  });
+
+  const captchaQuery = useQuery({
+    queryKey: ['security', 'captcha'],
+    queryFn: getCaptchaConfiguration,
+    onSuccess: (data: CaptchaConfiguration) => {
+      setCaptchaState(data);
+      setCaptchaSecretInput('');
+      setCaptchaRotateSecret(false);
+    }
+  });
+
+  const smsQuery = useQuery({
+    queryKey: ['security', 'sms'],
+    queryFn: getSmsConfiguration,
+    onSuccess: (data: SmsConnectorConfiguration | null) => {
+      if (data) {
+        setSmsState({ ...data });
+      } else {
+        setSmsState({
+          id: null,
+          alias: 'Primary SMS',
+          enabled: false,
+          endpoint: '',
+          sender: '',
+          region: '',
+          hasSecret: false,
+          healthStatus: undefined,
+          lastTestedAtUtc: undefined
+        });
+      }
+      setSmsSecretInput('');
+      setSmsRotateSecret(false);
+    }
+  });
+
+  const passwordPolicyQuery = useQuery({
+    queryKey: ['security', 'password-policy'],
+    queryFn: getPasswordPolicyConfiguration,
+    onSuccess: (data: PasswordPolicyConfiguration) => {
+      setPasswordPolicyState(data);
+    }
+  });
+
+  const normalizedSearchTerm = sessionSearchTerm.trim();
+
+  const userSearchQuery = useQuery({
+    queryKey: ['security', 'user-search', normalizedSearchTerm],
+    queryFn: () => searchSecurityUsers(normalizedSearchTerm),
+    enabled: normalizedSearchTerm.length === 0 || normalizedSearchTerm.length >= 2
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['security', 'sessions', selectedUser?.id ?? 'none'],
+    queryFn: async () => {
+      if (!selectedUser) {
+        return [] as UserSession[];
+      }
+      return getUserSessions(selectedUser.id);
+    },
+    enabled: Boolean(selectedUser?.id)
+  });
+
+  const roleMappingQuery = useQuery({
+    queryKey: ['security', 'ldap-role-mappings'],
+    queryFn: getLdapRoleMappings,
+    onSuccess: (data: LdapRoleMapping[]) => {
+      setRoleMappings(data);
+      const drafts = data.reduce<Record<string, { groupName: string; roleName: string }>>((acc, mapping) => {
+        acc[mapping.id] = { groupName: mapping.groupName, roleName: mapping.roleName };
+        return acc;
+      }, {});
+      setMappingDrafts(drafts);
+    }
+  });
+
+  const auditQuery = useQuery({
+    queryKey: ['audit', 'security'],
+    queryFn: async () => {
+      const responses = await Promise.all(SECURITY_AUDIT_TYPES.map((type) => getAuditLogs(type)));
+      return responses.flat().sort((a, b) => new Date(b.performedAtUtc).getTime() - new Date(a.performedAtUtc).getTime());
+    }
+  });
+
+  const showFlash = (message: FlashMessage) => {
+    setFlash(message);
+    window.setTimeout(() => setFlash(null), 5000);
+  };
+
+  const oidcMutation = useMutation({
+    mutationFn: updateOidcConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'oidc'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'OIDC konfigurace byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit OIDC konfiguraci.' });
+    }
+  });
+
+  const ldapMutation = useMutation({
+    mutationFn: updateLdapConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'LDAP konfigurace byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit LDAP konfiguraci.' });
+    }
+  });
+
+  const ssprMutation = useMutation({
+    mutationFn: updateSsprConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'sspr'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'SSPR nastavení byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit SSPR nastavení.' });
+    }
+  });
+
+  const captchaMutation = useMutation({
+    mutationFn: updateCaptchaConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'captcha'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'CAPTCHA nastavení bylo uloženo.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit CAPTCHA nastavení.' });
+    }
+  });
+
+  const smsMutation = useMutation({
+    mutationFn: updateSmsConfiguration,
+    onSuccess: (data: SmsConnectorConfiguration) => {
+      setSmsState(data);
+      setSmsSecretInput('');
+      setSmsRotateSecret(false);
+      queryClient.invalidateQueries({ queryKey: ['security', 'sms'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'SMS konektor byl uložen.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit SMS konektor.' });
+    }
+  });
+
+  const passwordPolicyMutation = useMutation({
+    mutationFn: updatePasswordPolicyConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'password-policy'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Politika hesel byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit politiku hesel.' });
+    }
+  });
+
+  const revokeSessionMutation = useMutation({
+    mutationFn: ({ sessionId, reason }: { sessionId: string; reason?: string }) => revokeSession(sessionId, reason),
+    onSuccess: () => {
+      if (selectedUser?.id) {
+        queryClient.invalidateQueries({ queryKey: ['security', 'sessions', selectedUser.id] });
+      }
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Sezení bylo odhlášeno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odhlásit sezení.' });
+    }
+  });
+
+  const revokeAllSessionsMutation = useMutation({
+    mutationFn: revokeAllSessions,
+    onSuccess: () => {
+      if (selectedUser?.id) {
+        queryClient.invalidateQueries({ queryKey: ['security', 'sessions', selectedUser.id] });
+      }
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Všechna sezení byla odhlášena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odhlásit všechna sezení.' });
+    }
+  });
+
+  const createMappingMutation = useMutation({
+    mutationFn: createLdapRoleMapping,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo přidáno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se přidat mapování.' });
+    }
+  });
+
+  const updateMappingMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { groupName: string; roleName: string } }) =>
+      updateLdapRoleMapping(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo aktualizováno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se aktualizovat mapování.' });
+    }
+  });
+
+  const deleteMappingMutation = useMutation({
+    mutationFn: deleteLdapRoleMapping,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo odstraněno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odstranit mapování.' });
+    }
+  });
+
+  const ldapTestMutation = useMutation({
+    mutationFn: testLdapConnection,
+    onSuccess: (data) => {
+      setLdapTestResult(data);
+      showFlash({ type: 'success', message: 'Test LDAP připojení dokončen.' });
+    },
+    onError: (error: unknown) => {
+      setLdapTestResult(null);
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'LDAP test selhal.' });
+    }
+  });
+
+  const ldapDryRunMutation = useMutation({
+    mutationFn: dryRunLdap,
+    onSuccess: (data) => {
+      setLdapDryRunResult(data);
+      showFlash({ type: 'success', message: 'LDAP dry-run byl úspěšný.' });
+    },
+    onError: (error: unknown) => {
+      setLdapDryRunResult(null);
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'LDAP dry-run selhal.' });
+    }
+  });
+
+  const handleOidcSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const payload: OidcConfiguration = {
+      ...oidcState,
+      scopes: scopesInput.split(/\s+/).map((scope) => scope.trim()).filter(Boolean),
+      claimMappings: parseClaimMappings(claimMappingsInput)
+    };
+    oidcMutation.mutate(payload);
+  };
+
+  const handleLdapSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmedFilter = ldapState.form.usersFilter?.trim();
+    const payload: LdapConfigurationRequest = {
+      ...ldapState.form,
+      usersBaseDn: ldapState.form.usersBaseDn.trim(),
+      usersFilter: trimmedFilter ? trimmedFilter : undefined,
+      attributeMap: parseList(ldapAttributeMapInput),
+      password: ldapState.form.password ? ldapState.form.password : undefined
+    };
+    ldapMutation.mutate(payload);
+  };
+
+  const handleSsprSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const payload: SsprConfiguration = {
+      ...ssprState,
+      smsConnectorKey: ssprState.smsConnectorKey?.trim() ? ssprState.smsConnectorKey.trim() : undefined
+    };
+    ssprMutation.mutate(payload);
+  };
+
+  const handlePasswordPolicySubmit = (event: FormEvent) => {
+    event.preventDefault();
+    passwordPolicyMutation.mutate({ ...passwordPolicyState });
+  };
+
+  const handleCaptchaSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const secret = captchaSecretInput.trim();
+    const payload: CaptchaConfigurationRequest = {
+      enabled: captchaState.enabled,
+      siteKey: captchaState.siteKey.trim(),
+      verificationEndpoint: captchaState.verificationEndpoint.trim(),
+      secret: secret ? secret : undefined,
+      rotateSecret: captchaRotateSecret || (!!secret && !captchaState.hasSecret),
+      bypassToken: captchaState.bypassToken?.trim() ? captchaState.bypassToken.trim() : undefined
+    };
+    captchaMutation.mutate(payload);
+  };
+
+  const handleSmsSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const secret = smsSecretInput.trim();
+    const payload: SmsConnectorRequest = {
+      alias: smsState.alias?.trim() ? smsState.alias.trim() : 'Primary SMS',
+      enabled: smsState.enabled,
+      endpoint: smsState.endpoint.trim(),
+      sender: smsState.sender && smsState.sender.toString().trim() ? smsState.sender.toString().trim() : undefined,
+      region: smsState.region && smsState.region.toString().trim() ? smsState.region.toString().trim() : undefined,
+      secret: secret ? secret : undefined,
+      rotateSecret: smsRotateSecret || (!!secret && !smsState.hasSecret)
+    };
+    smsMutation.mutate(payload);
+  };
+
+  const handleAddMapping = (event: FormEvent) => {
+    event.preventDefault();
+    const groupName = newMapping.groupName.trim();
+    if (!groupName) {
+      showFlash({ type: 'error', message: 'Zadejte název AD skupiny.' });
+      return;
+    }
+    createMappingMutation.mutate({ groupName, roleName: newMapping.roleName });
+    setNewMapping({ groupName: '', roleName: ROLE_OPTIONS[0].value });
+  };
+
+  const handleMappingDraftChange = (id: string, field: 'groupName' | 'roleName', value: string) => {
+    setMappingDrafts((current) => ({
+      ...current,
+      [id]: {
+        ...(current[id] ?? { groupName: '', roleName: ROLE_OPTIONS[0].value }),
+        [field]: value
+      }
+    }));
+  };
+
+  const handleSaveMapping = (id: string) => {
+    const draft = mappingDrafts[id];
+    if (!draft) {
+      return;
+    }
+    const groupName = draft.groupName.trim();
+    if (!groupName) {
+      showFlash({ type: 'error', message: 'Zadejte název AD skupiny.' });
+      return;
+    }
+    updateMappingMutation.mutate({ id, data: { groupName, roleName: draft.roleName } });
+  };
+
+  const handleDeleteMapping = (id: string) => {
+    deleteMappingMutation.mutate(id);
+  };
+
+  useEffect(() => {
+    if (ldapMutation.isSuccess) {
+      setLdapState((current) => ({
+        form: { ...current.form, password: '', resetPassword: false },
+        hasPassword: current.form.password ? true : current.hasPassword
+      }));
+    }
+  }, [ldapMutation.isSuccess]);
+
+  const securityAuditEntries = useMemo(() => auditQuery.data ?? [], [auditQuery.data]);
+
+  const renderAuditDetails = (entry: AuditLogEntry) => {
+    if (!entry.changedFieldsJson) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(entry.changedFieldsJson);
+      return <pre className="mt-2 whitespace-pre-wrap rounded bg-slate-900/80 p-3 text-xs text-slate-100">{JSON.stringify(parsed, null, 2)}</pre>;
+    } catch (error) {
+      return <pre className="mt-2 whitespace-pre-wrap rounded bg-slate-900/80 p-3 text-xs text-slate-100">{entry.changedFieldsJson}</pre>;
+    }
+  };
+
+  const handleSelectUser = (user: UserSummary) => {
+    setSelectedUser(user);
+    setRevokeReason('');
+    queryClient.invalidateQueries({ queryKey: ['security', 'sessions', user.id] });
+  };
+
+  const handleRevokeSession = (sessionId: string) => {
+    revokeSessionMutation.mutate({ sessionId, reason: revokeReason.trim() ? revokeReason.trim() : undefined });
+  };
+
+  const handleRevokeAllSessions = () => {
+    if (selectedUser) {
+      revokeAllSessionsMutation.mutate(selectedUser.id);
+    }
+  };
+
+  const userResults = userSearchQuery.data ?? [];
+  const sessions = sessionsQuery.data ?? [];
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Bezpečnostní nastavení</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{headerDescription}</p>
+      </header>
+
+      {flash && (
+        <div
+          className={`rounded-md border px-4 py-3 text-sm ${
+            flash.type === 'success'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-100'
+              : 'border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-100'
+          }`}
+        >
+          {flash.message}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleOidcSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">SSO / OIDC</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Konfigurace OpenID Connect přihlášení.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={oidcState.enabled}
+                onChange={(event) => setOidcState((state) => ({ ...state, enabled: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit OIDC
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Authority URL
+              <input
+                value={oidcState.authority}
+                onChange={(event) => setOidcState((state) => ({ ...state, authority: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://login.example.com"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Client ID
+              <input
+                value={oidcState.clientId}
+                onChange={(event) => setOidcState((state) => ({ ...state, clientId: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="hw-inventory"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Client secret
+              <input
+                value={oidcState.clientSecret ?? ''}
+                onChange={(event) => setOidcState((state) => ({ ...state, clientSecret: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="••••••"
+                type="password"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Response type
+              <input
+                value={oidcState.responseType ?? 'code'}
+                onChange={(event) => setOidcState((state) => ({ ...state, responseType: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="code"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Scope hodnoty
+              <input
+                value={scopesInput}
+                onChange={(event) => setScopesInput(event.target.value)}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="openid profile email"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Claim mapování (key=value)
+              <textarea
+                value={claimMappingsInput}
+                onChange={(event) => setClaimMappingsInput(event.target.value)}
+                className="mt-1 h-24 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+          </div>
+
+          <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={oidcState.usePkce}
+              onChange={(event) => setOidcState((state) => ({ ...state, usePkce: event.target.checked }))}
+              className="h-4 w-4"
+            />
+            Použít PKCE
+          </label>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={oidcMutation.isPending}
+            >
+              {oidcMutation.isPending ? 'Ukládám…' : 'Uložit OIDC' }
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleLdapSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">LDAP / AD</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Základní připojení a mapování atributů.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.enabled}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, enabled: event.target.checked }
+                  }))
+                }
+                className="h-4 w-4"
+              />
+              Povolit LDAP synchronizaci
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Host
+              <input
+                value={ldapState.form.host}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, host: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="ldap.example.com"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Port
+              <input
+                type="number"
+                value={ldapState.form.port}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, port: Number(event.target.value) }
+                  }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Bind DN
+              <input
+                value={ldapState.form.bindDn}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, bindDn: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="CN=Service,OU=Accounts,DC=example,DC=com"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Heslo
+              <input
+                type="password"
+                value={ldapState.form.password ?? ''}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, password: event.target.value }
+                  }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder={ldapState.hasPassword ? '••••••' : 'Zadejte heslo'}
+              />
+              <label className="mt-2 inline-flex items-center gap-2 text-xs font-normal text-slate-500 dark:text-slate-400">
+                <input
+                  type="checkbox"
+                  checked={ldapState.form.resetPassword}
+                  onChange={(event) =>
+                    setLdapState((state) => ({
+                      ...state,
+                      form: { ...state.form, resetPassword: event.target.checked }
+                    }))
+                  }
+                  className="h-4 w-4"
+                />
+                Resetovat uložené heslo (ponechá prázdné)
+              </label>
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.useSsl}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, useSsl: event.target.checked } }))}
+                className="h-4 w-4"
+              />
+              Použít LDAPS / SSL
+            </label>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.ignoreCertificateErrors}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, ignoreCertificateErrors: event.target.checked }
+                  }))
+                }
+                className="h-4 w-4"
+              />
+              Ignorovat chyby certifikátu
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Base DN pro uživatele
+              <input
+                value={ldapState.form.usersBaseDn}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, usersBaseDn: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="OU=Users,DC=example,DC=com"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Filtr uživatelů
+              <input
+                value={ldapState.form.usersFilter ?? ''}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, usersFilter: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="(objectClass=person)"
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+            Mapování atributů (každý řádek: attribute)
+            <textarea
+              value={ldapAttributeMapInput}
+              onChange={(event) => setLdapAttributeMapInput(event.target.value)}
+              className="mt-1 h-28 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder={'displayName\nmail\ndepartment'}
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={ldapMutation.isPending}
+            >
+              {ldapMutation.isPending ? 'Ukládám…' : 'Uložit LDAP'}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+              onClick={() =>
+                ldapTestMutation.mutate({
+                  host: ldapState.form.host,
+                  port: ldapState.form.port,
+                  useSsl: ldapState.form.useSsl,
+                  bindDn: ldapState.form.bindDn,
+                  password: ldapState.form.password || undefined,
+                  ignoreCertificateErrors: ldapState.form.ignoreCertificateErrors
+                })
+              }
+              disabled={ldapTestMutation.isPending}
+            >
+              {ldapTestMutation.isPending ? 'Testuji…' : 'Test připojení'}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+              onClick={() =>
+                ldapDryRunMutation.mutate({
+                  connection: {
+                    host: ldapState.form.host,
+                    port: ldapState.form.port,
+                    useSsl: ldapState.form.useSsl,
+                    bindDn: ldapState.form.bindDn,
+                    password: ldapState.form.password || undefined,
+                    ignoreCertificateErrors: ldapState.form.ignoreCertificateErrors
+                  },
+                  usersBaseDn: ldapState.form.usersBaseDn,
+                  usersFilter: ldapState.form.usersFilter || undefined,
+                  attributeMap: parseList(ldapAttributeMapInput),
+                  resultLimit: 20
+                })
+              }
+              disabled={ldapDryRunMutation.isPending}
+            >
+              {ldapDryRunMutation.isPending ? 'Spouštím…' : 'Dry-run náhled'}
+            </button>
+          </div>
+
+          {ldapTestResult && (
+            <div className={`rounded-md border px-4 py-3 text-sm ${ldapTestResult.success ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-100' : 'border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-100'}`}>
+              <p className="font-medium">Výsledek testu: {ldapTestResult.message}</p>
+              {ldapTestResult.diagnostics && (
+                <pre className="mt-2 whitespace-pre-wrap text-xs text-slate-600 dark:text-slate-300">
+                  {JSON.stringify(ldapTestResult.diagnostics, null, 2)}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {ldapDryRunResult && (
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100">
+              <p className="font-medium">
+                Dry-run: {ldapDryRunResult.resultCount} záznamů{ldapDryRunResult.truncated ? ' (výsledek zkrácen)' : ''}
+              </p>
+              {ldapDryRunResult.notes && <p className="mt-1 text-xs text-slate-500">{ldapDryRunResult.notes}</p>}
+              <div className="mt-3 space-y-3">
+                {ldapDryRunResult.users.map((user) => (
+                  <div key={user.distinguishedName} className="rounded border border-slate-200 bg-white p-3 text-xs dark:border-slate-700 dark:bg-slate-900">
+                    <p className="font-semibold text-slate-700 dark:text-slate-200">{user.distinguishedName}</p>
+                    <pre className="mt-2 whitespace-pre-wrap text-[11px] text-slate-600 dark:text-slate-300">
+                      {JSON.stringify(user.attributes, null, 2)}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleSsprSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Self-service reset hesla (SSPR)</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Ovládá proces obnovy hesla pro lokální účty.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.enabled}
+                onChange={(event) => setSsprState((state) => ({ ...state, enabled: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit SSPR
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireTwoFactor}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireTwoFactor: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Vyžadovat 2FA před odesláním resetu
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireCaptcha}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireCaptcha: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Vyžadovat CAPTCHA
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireSmsOtp}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireSmsOtp: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit SMS OTP
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Expirace tokenu (minuty)
+              <input
+                type="number"
+                value={ssprState.tokenExpiryMinutes}
+                onChange={(event) => setSsprState((state) => ({ ...state, tokenExpiryMinutes: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={5}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Okno throttlingu (minuty)
+              <input
+                type="number"
+                value={ssprState.throttleWindowMinutes}
+                onChange={(event) => setSsprState((state) => ({ ...state, throttleWindowMinutes: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Max. požadavků v okně
+              <input
+                type="number"
+                value={ssprState.maxRequestsPerWindow}
+                onChange={(event) => setSsprState((state) => ({ ...state, maxRequestsPerWindow: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+            SMS konektor (alias)
+            <input
+              value={ssprState.smsConnectorKey ?? ''}
+              onChange={(event) => setSsprState((state) => ({ ...state, smsConnectorKey: event.target.value }))}
+              className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="sms-primary"
+            />
+          </label>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={ssprMutation.isPending}
+            >
+              {ssprMutation.isPending ? 'Ukládám…' : 'Uložit SSPR'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handlePasswordPolicySubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Politika hesel a uzamykání účtů</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Spravujte minimální požadavky na hesla, expiraci a reakci na opakované neúspěšné pokusy.
+              </p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.enabled}
+                onChange={(event) => setPasswordPolicyState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              Vynucovat politiku hesel
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Minimální délka hesla
+              <input
+                type="number"
+                min={6}
+                value={passwordPolicyState.minimumLength}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, minimumLength: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Expirace hesla (dny, 0 = bez expirace)
+              <input
+                type="number"
+                min={0}
+                value={passwordPolicyState.expirationDays}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, expirationDays: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Historie hesel (počet uchovaných)
+              <input
+                type="number"
+                min={0}
+                value={passwordPolicyState.historyCount}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, historyCount: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Uzamknout po (počet pokusů)
+              <input
+                type="number"
+                min={1}
+                value={passwordPolicyState.lockoutAttempts}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, lockoutAttempts: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Doba uzamčení (minuty)
+              <input
+                type="number"
+                min={1}
+                value={passwordPolicyState.lockoutDurationMinutes}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, lockoutDurationMinutes: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireUppercase}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireUppercase: event.target.checked }))
+                }
+              />
+              Vyžadovat velká písmena
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireLowercase}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireLowercase: event.target.checked }))
+                }
+              />
+              Vyžadovat malá písmena
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireDigit}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireDigit: event.target.checked }))
+                }
+              />
+              Vyžadovat číslice
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireNonAlphanumeric}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireNonAlphanumeric: event.target.checked }))
+                }
+              />
+              Vyžadovat speciální znak
+            </label>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={passwordPolicyMutation.isPending}
+            >
+              {passwordPolicyMutation.isPending ? 'Ukládám…' : 'Uložit politiku hesel'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleCaptchaSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">CAPTCHA a ochrana formulářů</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Definujte CAPTCHA konektor použitý pro přihlášení a SSPR.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={captchaState.enabled}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              CAPTCHA povolena
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Site key
+              <input
+                value={captchaState.siteKey}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, siteKey: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="public-site-key"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Verifikační endpoint
+              <input
+                value={captchaState.verificationEndpoint}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, verificationEndpoint: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://captcha.example.com/verify"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Bypass token (pro podporu)
+              <input
+                value={captchaState.bypassToken ?? ''}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, bypassToken: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="DEV-BYPASS"
+              />
+            </label>
+            <div className="space-y-2">
+              <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={captchaRotateSecret}
+                  onChange={(event) => setCaptchaRotateSecret(event.target.checked)}
+                />
+                Obnovit tajný klíč (aktuálně {captchaState.hasSecret ? 'nastaven' : 'není nastaven'})
+              </label>
+              <input
+                type="password"
+                value={captchaSecretInput}
+                onChange={(event) => setCaptchaSecretInput(event.target.value)}
+                disabled={!captchaRotateSecret && captchaState.hasSecret}
+                className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:disabled:bg-slate-800/60"
+                placeholder="Nový tajný klíč"
+              />
+            </div>
+          </div>
+
+          {captchaQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst aktuální nastavení CAPTCHA.</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={captchaMutation.isPending || captchaQuery.isLoading}
+            >
+              {captchaMutation.isPending ? 'Ukládám…' : 'Uložit CAPTCHA'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleSmsSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">SMS konektor</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Používá se pro zasílání OTP a notifikací.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={smsState.enabled}
+                onChange={(event) => setSmsState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              Aktivní konektor
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Alias konektoru
+              <input
+                value={smsState.alias ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, alias: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="primary-sms"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Endpoint URL
+              <input
+                value={smsState.endpoint}
+                onChange={(event) => setSmsState((state) => ({ ...state, endpoint: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://sms-gateway.example.com/send"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Sender ID
+              <input
+                value={smsState.sender ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, sender: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="HWINVENTORY"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Region / poznámka
+              <input
+                value={smsState.region ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, region: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="EU"
+              />
+            </label>
+          </div>
+
+          <div className="space-y-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={smsRotateSecret}
+                onChange={(event) => setSmsRotateSecret(event.target.checked)}
+              />
+              Obnovit API token (aktuálně {smsState.hasSecret ? 'nastaven' : 'není nastaven'})
+            </label>
+            <input
+              type="password"
+              value={smsSecretInput}
+              onChange={(event) => setSmsSecretInput(event.target.value)}
+              disabled={!smsRotateSecret && smsState.hasSecret}
+              className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:disabled:bg-slate-800/60"
+              placeholder="Nový API token"
+            />
+          </div>
+
+          {smsQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst konfiguraci SMS konektoru.</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={smsMutation.isPending || smsQuery.isLoading}
+            >
+              {smsMutation.isPending ? 'Ukládám…' : 'Uložit SMS konektor'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {variant === 'full' && (
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Správa aktivních relací</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Vyhledejte uživatele, zobrazte jeho aktivní relace a případně je ukončete. Všechny zásahy se zapisují do auditu.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
+          <div className="space-y-3">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Vyhledat uživatele (jméno, e-mail nebo login)
+              <input
+                value={sessionSearchTerm}
+                onChange={(event) => setSessionSearchTerm(event.target.value)}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="např. jana.novakova"
+              />
+            </label>
+            {normalizedSearchTerm.length === 1 && (
+              <p className="text-xs text-slate-500 dark:text-slate-400">Pro vyhledávání zadejte alespoň 2 znaky.</p>
+            )}
+            <div className="max-h-60 space-y-2 overflow-y-auto rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+              {userSearchQuery.isLoading ? (
+                <p className="text-sm text-slate-500 dark:text-slate-400">Načítám uživatele…</p>
+              ) : userResults.length === 0 ? (
+                <p className="text-sm text-slate-500 dark:text-slate-400">Žádný uživatel neodpovídá zadaným kritériím.</p>
+              ) : (
+                userResults.map((user) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => handleSelectUser(user)}
+                    className={`flex w-full flex-col rounded border px-3 py-2 text-left text-sm transition ${
+                      selectedUser?.id === user.id
+                        ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-500 dark:bg-sky-900/40 dark:text-sky-100'
+                        : 'border-slate-200 hover:border-sky-400 hover:bg-slate-50 dark:border-slate-700 dark:hover:border-sky-500 dark:hover:bg-slate-800'
+                    }`}
+                  >
+                    <span className="font-semibold">{user.displayName}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{user.email || 'bez e-mailu'}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{user.userName}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="rounded border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+            {selectedUser ? (
+              <div className="space-y-2">
+                <p className="font-semibold text-slate-900 dark:text-slate-100">Vybraný uživatel</p>
+                <p>
+                  {selectedUser.displayName}
+                  <br />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{selectedUser.email || 'bez e-mailu'}</span>
+                  <br />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{selectedUser.userName}</span>
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setSelectedUser(null)}
+                  className="rounded border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+                >
+                  Zrušit výběr
+                </button>
+              </div>
+            ) : (
+              <p className="text-slate-500 dark:text-slate-400">Zvolte uživatele ze seznamu vlevo.</p>
+            )}
+          </div>
+        </div>
+
+        {selectedUser && (
+          <div className="mt-6 space-y-4">
+            <div className="grid gap-4 md:grid-cols-[2fr,1fr]">
+              <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+                Důvod odhlášení (uloží se do auditu)
+                <input
+                  value={revokeReason}
+                  onChange={(event) => setRevokeReason(event.target.value)}
+                  className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                  placeholder="např. porušení politiky"
+                />
+              </label>
+              <div className="flex items-end justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleRevokeAllSessions}
+                  disabled={revokeAllSessionsMutation.isPending || sessions.length === 0}
+                  className="rounded border border-rose-400 px-3 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-600 dark:text-rose-300 dark:hover:bg-rose-900/40"
+                >
+                  {revokeAllSessionsMutation.isPending ? 'Odhlasuji…' : 'Odhlásit všechna sezení'}
+                </button>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto rounded border border-slate-200 dark:border-slate-700">
+              <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+                <thead className="bg-slate-50 dark:bg-slate-800">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Sezení</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Poslední aktivita</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">IP</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Akce</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                  {sessions.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-3 py-4 text-center text-slate-500 dark:text-slate-400">
+                        Uživatel nemá žádná aktivní sezení.
+                      </td>
+                    </tr>
+                  ) : (
+                    sessions.map((session) => (
+                      <tr key={session.id} className="bg-white text-slate-700 dark:bg-slate-900 dark:text-slate-200">
+                        <td className="px-3 py-2">
+                          <p className="font-mono text-xs">{session.sessionIdentifier}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">Vytvořeno: {new Date(session.issuedAtUtc).toLocaleString()}</p>
+                        </td>
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-300">{new Date(session.lastSeenAtUtc).toLocaleString()}</td>
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-300">{session.ipAddress ?? 'N/A'}</td>
+                        <td className="px-3 py-2 text-right">
+                          <button
+                            type="button"
+                            onClick={() => handleRevokeSession(session.id)}
+                            disabled={revokeSessionMutation.isPending}
+                            className="rounded border border-rose-400 px-3 py-1 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-600 dark:text-rose-300 dark:hover:bg-rose-900/40"
+                          >
+                            {revokeSessionMutation.isPending ? 'Odhlasuji…' : 'Odhlásit'}
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+        </section>
+      )}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Mapování AD skupin na role</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Každé mapování přiřadí uživatelům z konkrétní skupiny odpovídající roli v aplikaci. Všechny změny jsou auditovány.
+          </p>
+        </div>
+
+        <form onSubmit={handleAddMapping} className="mb-6 grid gap-4 md:grid-cols-[2fr,1fr,auto]">
+          <input
+            value={newMapping.groupName}
+            onChange={(event) => setNewMapping((state) => ({ ...state, groupName: event.target.value }))}
+            placeholder="CN=SRV-ADMINS,OU=Groups,DC=example,DC=com"
+            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          />
+          <select
+            value={newMapping.roleName}
+            onChange={(event) => setNewMapping((state) => ({ ...state, roleName: event.target.value }))}
+            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
+            disabled={createMappingMutation.isPending}
+          >
+            {createMappingMutation.isPending ? 'Přidávám…' : 'Přidat mapování'}
+          </button>
+        </form>
+
+        <div className="space-y-4">
+          {roleMappingQuery.isLoading && <p className="text-sm text-slate-500 dark:text-slate-400">Načítám mapování…</p>}
+          {roleMappingQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst mapování AD skupin.</p>
+          )}
+          {!roleMappingQuery.isLoading && roleMappings.length === 0 && (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Zatím není definováno žádné mapování.</p>
+          )}
+
+          {roleMappings.map((mapping) => {
+            const draft = mappingDrafts[mapping.id] ?? { groupName: mapping.groupName, roleName: mapping.roleName };
+            return (
+              <div
+                key={mapping.id}
+                className="rounded border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <div className="grid gap-4 md:grid-cols-[2fr,1fr]">
+                  <input
+                    value={draft.groupName}
+                    onChange={(event) => handleMappingDraftChange(mapping.id, 'groupName', event.target.value)}
+                    className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  />
+                  <select
+                    value={draft.roleName}
+                    onChange={(event) => handleMappingDraftChange(mapping.id, 'roleName', event.target.value)}
+                    className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  >
+                    {ROLE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mt-3 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleSaveMapping(mapping.id)}
+                    className="rounded bg-sky-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+                    disabled={updateMappingMutation.isPending}
+                  >
+                    {updateMappingMutation.isPending ? 'Ukládám…' : 'Uložit'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteMapping(mapping.id)}
+                    className="rounded bg-rose-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-50"
+                    disabled={deleteMappingMutation.isPending}
+                  >
+                    {deleteMappingMutation.isPending ? 'Mažu…' : 'Odstranit'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Audit bezpečnostních změn</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Poslední operace na nastaveních OIDC, LDAP, SSPR, CAPTCHA, SMS a mapování rolí.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => queryClient.invalidateQueries({ queryKey: ['audit', 'security'] })}
+            className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+          >
+            Obnovit
+          </button>
+        </div>
+
+        {auditQuery.isLoading && <p className="text-sm text-slate-500 dark:text-slate-400">Načítám audit…</p>}
+        {auditQuery.isError && <p className="text-sm text-rose-600">Nepodařilo se načíst auditní záznamy.</p>}
+
+        <div className="divide-y divide-slate-200 dark:divide-slate-700">
+          {securityAuditEntries.map((entry) => (
+            <div key={entry.id} className="py-3">
+              <button
+                type="button"
+                onClick={() => setAuditExpanded((current) => (current === entry.id ? null : entry.id))}
+                className="flex w-full items-start justify-between gap-3 text-left"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    {entry.entityType} – {entry.action}
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    {new Date(entry.performedAtUtc).toLocaleString()} • {entry.performedBy}
+                  </p>
+                  {entry.changeSummary && (
+                    <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">{entry.changeSummary}</p>
+                  )}
+                </div>
+                <span className="text-xs text-slate-500 dark:text-slate-400">{auditExpanded === entry.id ? '▲' : '▼'}</span>
+              </button>
+              {auditExpanded === entry.id && renderAuditDetails(entry)}
+            </div>
+          ))}
+
+          {securityAuditEntries.length === 0 && !auditQuery.isLoading && (
+            <p className="py-4 text-sm text-slate-500 dark:text-slate-400">Zatím nejsou k dispozici žádné záznamy.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/styles.css
+++ b/src/web/src/styles.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 transition-colors duration-200;
+}
+
+[data-theme='dark'] body {
+  @apply bg-slate-900 text-slate-100;
+}

--- a/src/web/src/theme/ThemeProvider.tsx
+++ b/src/web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => undefined
+});
+
+const STORAGE_KEY = 'hw-inventory:theme';
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/src/web/tailwind.config.cjs
+++ b/src/web/tailwind.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          dark: '#1d4ed8'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/web/tsconfig.node.json
+++ b/src/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: false
+  },
+  preview: {
+    port: 4173
+  }
+});


### PR DESCRIPTION
## Summary
- add backend stores, migrations, and API endpoints for CAPTCHA/SMS connectors plus LDAP group-to-role mappings with audit coverage
- extend security domain services and validator logic to persist new settings, expose data scope management, and register the new stores
- enhance the React security settings page with CAPTCHA/SMS forms and role mapping UI and introduce a first-run wizard security step

## Testing
- not run (dotnet SDK unavailable in the execution environment)
- not run (node/yarn tooling unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e519d659008324a7e28854833a88fb