### PR TITLE
Build inventory and label management admin views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Build outputs
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Node
+node_modules/
+dist/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Installer artifacts
+publish/
+artifacts/
+*.zip
+*.pkg
+
+# Secrets
+*.pfx
+appsettings.Local.json
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-# HwInventory
+# HW Inventory Platform
+
+This repository provides a .NET 8 and React monorepo scaffold for the HW Inventory platform described in the consolidated specification. The previous Python prototype has been replaced with the target architecture so that future iterations can focus on completing feature depth rather than replatforming.
+
+> **Status:** the solution is **not** production-ready. The current codebase now boots with SQL Server, ASP.NET Core Identity (including TOTP 2FA scaffolding), baseline policy-based RBAC guard rails with per-user location/department scoping, persistent audit logging, Quartz.NET job scheduling, a label rendering engine, and a React administration experience with dark/light theming. Security integrations cover LDAP/AD test/dry-run endpoints, hardened HTTPS+PKCE OIDC configuration, configurable password policies with history/lockout enforcement, CAPTCHA and SMS connector management, SMTP connector management with test e-mail delivery, AD group-to-role mappings, middleware-backed session tracking with remote logout APIs, a security readiness summary API/UI (blocking the onboarding wizard until all critical connectors are configured), and dedicated React pages „Security Settings“, „Email (SMTP)“, „Konektory“, „Observabilita“, „Backup & Restore“, „Import/Export“ a „Aktualizace“. Inventární moduly nyní zahrnují plnohodnotné React stránky pro Servery, Síťová zařízení, Pracovní stanice, Audit, Číselníky, Štítky a Moduly, včetně CRUD formulářů, stránkovaných tabulek a integrace s číselníky a renderováním štítků. Zbývají však pokročilé workflow (např. dokončení importní pipeline, plánované reporty, další konektory, handover PDF/e-mail proces, CI/CD balení) – kompletní backlog viz [`docs/implementation-plan.md`](docs/implementation-plan.md).
+
+## Structure
+
+```
+/attachments      Supporting templates and artefacts (placeholders)
+/db               Database migrations and seed data (to be completed)
+/docs             Product documentation (manual, release notes, etc.)
+/scripts          Deployment helpers (IIS installer placeholder)
+/src
+  /api            ASP.NET Core solution (Domain, Application, Infrastructure, Api)
+  /web            React admin shell (Vite + Tailwind, dark/light theme toggle)
+```
+
+### API Solution
+
+The API solution (`src/api/HWInventory.sln`) includes four projects:
+
+* **HWInventory.Domain** – entity definitions for servers, network devices, workstations, audit, RBAC, connectors, labels, and settings.
+* **HWInventory.Application** – shared abstractions (e.g., `IAppDbContext`), paging helpers, and DTOs for application services.
+* **HWInventory.Infrastructure** – EF Core `DbContext`, SQL Server migrations, Identity integration, Quartz.NET job wiring (label print and backup processors), label rendering services, and initial seed data.
+* **HWInventory.Api** – ASP.NET Core Web API exposing the required endpoints (`/api/servers`, `/api/network-devices`, `/api/workstations`, `/api/dictionaries`, `/api/audit`, `/api/modules`, `/api/dashboard/summary`, `/api/labels/*`, `/api/auth/*`).
+
+The API defaults to SQL Server (LocalDB for development, configurable via `appsettings.json`), runs migrations on startup, and seeds baseline dictionaries, roles, and feature modules. Controllers implement CRUD, soft-retire/restore flows, module toggling, dashboard summaries, label rendering (QuestPDF + ZPL), `/api/auth` endpoints for profile introspection plus TOTP enrollment, observability settings, connector management, and backup/restore maintenance APIs. Background processing is orchestrated through Quartz.NET (`LabelPrintJobProcessor`, `BackupJobProcessor`).
+
+### Remaining Work
+
+The skeleton is intentionally incomplete compared to the full specification. Major follow-up tasks include (see the implementation plan for detail):
+
+* Rozšířit bezpečnostní governance o pokročilé dashboardy (hlavní homepage widgety, observability metriky), širší regresní pokrytí (LDAP sync, SSPR edge cases, CAPTCHA throttling) a další bezpečnostní alerting.
+* Dovršit React administraci o onboarding wizard s validacemi, help centrum a pokročilé filtry/hromadné akce v inventárních tabulkách, doplnit UI pro plánované reporty a tisk štítků z výběrů.
+* Delivering domain workflows: workstation handover PDFs/e-mails, rozšířená importní pipeline (konfliktní strategie se zápisem do DB, XLSX, mapování sloupců, UI validace), export enhancements (filtry, expirace odkazů, auditované stažení), reports & schedules, extended connectors (SFTP/FTPS, storage, printing, webhooks), incremental/advanced backup features (např. dedikované storage konektory, incremental snapshoty, archivace), observability dashboards/alerting, Help Center.
+* Completing packaging: installer scripts, All-in-One builder, GitHub Actions, documentation set (manual, release notes, deployment guide), and smoke tests.
+
+### SQL Server & IIS deployment checklist
+
+1. Publish the API project (`dotnet publish src/api/src/HWInventory.Api/HWInventory.Api.csproj -c Release -o publish`).
+2. Copy the contents of the `publish` folder to the IIS server.
+3. Run `scripts/installer.ps1` with administrator privileges:
+   ```powershell
+   cd scripts
+   .\installer.ps1 -PublishPath "C:\inetpub\HWInventory" -SiteName "HWInventory" -AppPoolName "HWInventoryPool" -SqlConnectionString "Server=sql01;Database=HWInventory;User Id=hwinv;Password=Secret;TrustServerCertificate=True"
+   ```
+   The script updates `appsettings*.json` with the provided SQL Server connection string, provisions/updates the IIS site + app pool (unless `-SkipIisProvisioning` is supplied), and grants modify permissions to the pool identity.
+4. Verify SQL connectivity by running the API locally (`dotnet run`) or starting the IIS site, then execute EF Core migrations (the API performs `DbContext.Database.Migrate()` on startup) and confirm `/health` returns `OK`.
+5. Complete the first-run wizard in the browser to configure SMTP, LDAP/SSPR connectors, and seed the Super Admin account.
+
+### Update workflow (Settings → Aktualizace)
+
+* Upload ZIP/PKG packages through the new REST endpoint `POST /api/updates` or via the React administration page **Settings → Aktualizace**.
+* Each upload computes an SHA256 hash, persists the package under `%ProgramFiles%/HWInventory/updates`, and optionally triggers a full backup before processing.
+* Quartz job `UpdatePackageProcessor` validates integrity, extracts the archive to a staging directory, parses `update-manifest.json` (if present), and stores verbose log output available under `GET /api/updates/{id}/log`.
+* The updates UI lists package history, surface errors, and provides one-click download of logs and manifest preview, ensuring administrators have an audit trail before swapping binaries in production.
+
+### Suggested execution order
+
+If you are planning the next development iteration, tackle the milestones in this order (summarised from the implementation plan):
+
+1. **Foundations & persistence** – move to SQL Server, produce migrations, seed data, configuration options, and job scheduling infrastructure.
+2. **Identity & security** – wire up Identity, 2FA, SSPR, CAPTCHA, scoped RBAC, and the onboarding wizard steps that exercise SMTP/LDAP connectivity.
+3. **Inventory workflows** – finish CRUD, audit diffing, VLAN/IP enforcement, handover PDFs/e-mails, labels, imports/exports, and async jobs.
+4. **Operations & integrations** – connectors catalogue, Updates, Backup & Restore, Reports & Schedules, Observability dashboards.
+5. **Frontend completion** – full React admin, theming, contextual help/manual integration, UI automation tests.
+6. **Packaging & release** – installers, builder scripts, GitHub Actions, All-in-One ZIP with SHA256, documentation, and smoke/regression test suites.
+
+## Getting Started
+
+1. Ensure the .NET 8 SDK is installed.
+2. Restore dependencies and build the solution:
+   ```bash
+   cd src/api
+   dotnet restore
+   dotnet build
+   dotnet run --project src/HWInventory.Api/HWInventory.Api.csproj
+   ```
+3. Browse Swagger UI at `https://localhost:5001/swagger` (or configured URL).
+
+> **Note:** In this environment the .NET SDK and third-party packages (e.g., QuestPDF) are not pre-installed. The project files are provided so that the solution restores and builds once the SDK is available.
+
+## Licensing
+
+QuestPDF is licensed under the Polyform Noncommercial license. Evaluate licensing implications before production use.

--- a/attachments/README.md
+++ b/attachments/README.md
@@ -1,0 +1,3 @@
+# Attachments Placeholder
+
+This folder will host import/export templates, label samples (ZPL/PDF/PNG), email templates, BPMN diagrams, and other artefacts referenced in the delivery checklist. Populate as the corresponding features are implemented.

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,0 +1,3 @@
+# EF Core Migrations Placeholder
+
+Runtime migrations now live under `src/api/src/HWInventory.Infrastructure/Migrations` so that they compile with the API solution. Use this folder to store exported SQL scripts (if required for DBA review) or versioned documentation about migration batches that accompany the packaged releases.

--- a/db/seed/README.md
+++ b/db/seed/README.md
@@ -1,0 +1,3 @@
+# Database Seed Data Placeholder
+
+EF Core seed data currently resides in `HWInventory.Infrastructure`. When full migrations are created, move static CSV/JSON seeds into this directory to be packaged with the installer and All-in-One distribution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,36 @@
+# HW Inventory – Architecture Skeleton (v1)
+
+This document captures the initial .NET-based architecture that replaces the earlier Python FastAPI prototype. The structure aligns with the Codex implementation brief and provides a foundation for subsequent feature work.
+
+## Projects Overview
+
+* **HWInventory.Domain** – Entities and enums representing inventory assets, audit logs, RBAC objects, connectors, label templates, maintenance artefacts (backup jobs/schedules), export/import jobs, and settings. Entities derive from `AuditableEntity` to support audit metadata and soft-state transitions.
+* **HWInventory.Application** – Shared contracts (e.g., `IAppDbContext`), paging helpers, and filter descriptors. Application services can depend on these abstractions without referencing ASP.NET Core directly.
+* **HWInventory.Infrastructure** – EF Core persistence layer with entity configurations, SQL Server/InMemory providers, DI extensions, and seeded baseline data (roles, dictionaries, feature modules).
+* **HWInventory.Api** – ASP.NET Core Web API hosting controllers, swagger, health endpoints, label rendering helpers (QuestPDF), observability configuration, connector management, maintenance endpoints for backup/restore flows, a rozhraní `/api/exports/*` a `/api/imports/*` pro asynchronní exportní a importní joby.
+
+## Persistence
+
+* EF Core `AppDbContext` manages inventory tables and owned collections for VLAN/IP assignments.
+* Seed data creates baseline dictionaries (environment, WSUS priority, OS, server roles, workstation types, VLAN, locations) and feature modules (labels, reports, Zabbix).
+* Database provider defaults to InMemory when no connection string is configured; relational providers trigger migrations when available.
+
+## API Highlights
+
+* Controllers implement pagination with `X-Total-Count` and RFC5988 `Link` headers (limited to simple next/prev semantics for now).
+* Servers/NetworkDevices/Workstations expose CRUD + retire/restore flows to mirror the specification.
+* Workstation handover endpoint updates ownership/location metadata (email/PDF automation to be delivered later).
+* Modules API toggles feature flags to support optional components (labels, reports, Zabbix, etc.).
+* Dashboard summary aggregates counts and latest audit entries.
+* Labels controller manages templates, renders sample PDF previews via QuestPDF, and captures print job requests (persisted for auditing/queue processing).
+* Maintenance controller (`/api/maintenance/*`) queues backups (full/partial), stores AES-256 encrypted artefacts, exposes history and integrity checks, and manages scheduled backups via Quartz.
+* Exports controller (`/api/exports/*`) přijímá exportní požadavky, ukládá je do fronty, generuje CSV soubory (Servers/NetworkDevices/Workstations/Dictionaries/AuditLogs), posílá volitelné notifikace a vystavuje artefakt ke stažení.
+* Updates controller (`/api/updates`) přijímá ZIP/PKG balíčky, provádí kontrolu SHA256, volitelně spouští zálohu, extrahuje obsah do staging adresáře, uchovává manifest/logy a deleguje zpracování na Quartz job `UpdatePackageProcessor`.
+
+## Next Steps
+
+* Introduce authentication/authorization middleware, policy-based enforcement, and LDAP/OIDC connectors.
+* Replace placeholder installer with IIS-aware deployment automation and All-in-One packaging scripts.
+* Expand audit logging to capture diffs and export audit events.
+* Implement background job processing for print jobs, backup/report schedules, a rozšířené import/export pipelines (Quartz wiring now obsluhuje štítky, zálohy, exporty i importy — zbývá dopracovat validace, konfliktní logiku a mapování).
+* Build the React admin UI with module toggles, settings wizard, and dark/light theming.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,158 @@
+# HW Inventory Platform – Implementation Plan
+
+This document enumerates the outstanding work required to transform the current monorepo skeleton into a production-ready release that satisfies the full specification from the "HW Inventory – Zadání pro Codex" document. Items are grouped by thematic area and capture dependencies where relevant.
+
+## 1. Platform Foundations
+- **Adopt SQL Server persistence**
+  - Replace the InMemory provider with SQL Server across all environments.
+  - Create comprehensive EF Core migrations for the domain model (servers, network devices, workstations, dictionaries, users/roles, audit, connectors, labels, jobs, reports, backups, updates, settings, modules, etc.).
+  - Seed baseline dictionaries, RBAC roles, feature modules, connectors, and system settings with idempotent scripts.
+- **Configuration model**
+  - Introduce strongly-typed options for App Configuration, Security & Auth, LDAP, SMTP, Connectors, Reports, Import/Export, Maintenance, Observability, Advanced, About/Support, Handover, Updates, Backup & Restore.
+  - Ensure secrets are stored encrypted (DPAPI on Windows / AES-256 elsewhere) and surfaced in the UI as "set/unset" flags with reset flows.
+- **Background job infrastructure**
+  - Integrate Quartz.NET (or Hangfire if selected) for scheduled jobs (LDAP sync, reports, backups, exports, print jobs, maintenance, observability health checks).
+  - Design persistence tables for job definitions, executions, locks, and audit.
+
+## 2. Security, Identity, and RBAC
+> _Progress update:_ Identity foundation, PKCE-enforced OIDC configuration, password history enforcement, security readiness summary, and baseline regression tests are in place. Items below track the remaining enhancements required for full compliance.
+- **Identity provider**
+  - Implement ASP.NET Core Identity with support for local accounts and Active Directory/LDAP linked identities.
+  - Add password policies (complexity, expiry, history) and lockout rules in line with the specification.
+- **Authentication mechanisms**
+  - Enable cookie-based sessions for the admin UI plus JWT/OIDC for API access as needed.
+  - Support external SSO/OIDC providers with configurable discovery and claim mapping.
+- **Two-factor authentication (2FA)**
+  - Provide TOTP (OtpNet) and e-mail OTP methods with enforced enrollment for Super Admin.
+  - Implement per-role/group policy enforcement, overrides, reset flows, backup codes, and audit trails.
+- **Self-service password reset (SSPR)**
+  - Build secure token issuance with optional SMS OTP via the SMS connector, CAPTCHA enforcement, rate limiting, and audit logging.
+- **Session management**
+  - Expose active sessions, remote logout, automatic invalidation after password changes, and inactivity timeouts.
+- **RBAC policies**
+  - Materialize policies (Servers.*, Network.*, Workstations.*, Dicts.*, Audit.Read, Settings.*) and map LDAP groups to roles with an auditable ruleset.
+  - Implement data scoping per department/location across queries, exports, dashboards, and print jobs.
+
+## 3. Domain Features
+- **Inventory management**
+  - Complete CRUD flows, retire/restore, hard delete (with password confirmation), comments, audit history, Excel import/export, PDF/CSV exports.
+  - Enforce VLAN/IP pairing logic, status management, and scoped administration for Aplikační admin role.
+- **Workstation handover**
+  - Implement mandatory old/new location capture, PDF generation via QuestPDF, templated e-mails with dynamic recipients, CC/BCC, attachments, and audit entries.
+- **Labels & printing**
+  - Finalize label template editor (JSON schema), Code128/EAN-13/QR rendering, ZPL and PDF outputs, batch printing, print job queue with destinations (download, named printer, raw socket 9100), audit, and artefact retention policies.
+- **Dictionaries**
+  - Build full CRUD with import/export (CSV/XLSX), duplicate detection, referential integrity, VLAN metadata requirements, and audit.
+- **Audit logging**
+  - Persist JSON diffs for all entity operations, support filtering (entity, user, action, timeframe), highlight deletes/restores, and include export functionality that logs access.
+- **Reports & schedules**
+  - Provide report definitions with filters (e.g., retired devices, aging assets, expiring warranties), scheduling (daily/weekly/monthly), async execution with e-mail delivery, and history tracking.
+- **Import/Export jobs**
+  - Export jobs: rozšířit stávající `/api/exports/*` o filtrace, plánované exporty, expiraci odkazů, notifikace s více konektory a generování XLSX.
+  - Import jobs: rozšířit nově dostupný CSV import o validace, mapování sloupců, konfliktní strategie se zápisem (skip/update/create), audit diffy starých/nových hodnot, podporu XLSX, per-user limity, e-mail/SMS notifikace a napojení na asynchronní frontu importů.
+- **Backup & restore**
+  - Rozšířit stávající modul o pokročilé funkce: incremental/differential snapshoty, cílové storage konektory (SMB/S3), archivaci a čištění starých záloh, export/import pouze nastavení aplikace, CLI nástroje a smoke testy obnovy.
+- **Updates module** ✅ _(baseline delivered 2025-10-08)_
+  - Implementováno: REST API `/api/updates`, perzistence balíčků, výpočet SHA256, volitelná záloha přes `UpdateService` + `BackupService`, extrakce do staging adresáře, parsování `update-manifest.json`, audit, download logů a React stránka „Aktualizace“.
+  - Zbývá: propojit se skutečnou maintenance mode signalizací, file-swap orchestrace (stop web, replace publish output, warm-up), rollback workflow v UI, integrace s All-in-One builderem a smoke testy aktualizačního scénáře.
+- **Connectors catalogue**
+  - Rozšířit nově dostupné REST API a React stránku „Konektory“ o profily pro Database, External SQL, Webhooks, SFTP/FTPS, Storage, Printing, Observability a Zabbix včetně CRUD operací, health-checků, plánovaných ověřování, retry/backoff politik a správy tajemství (aktuální iterace pokrývá SMTP/SMS s testy a LDAP/OIDC jako přehledové záznamy).
+- **Observability**
+  - Expose structured logging, /health, /metrics, OpenTelemetry exporter configuration, correlation IDs in responses, diagnostics export for support.
+
+## 4. Frontend (React + Vite + Tailwind)
+- **App shell**
+  - Implement authentication views, onboarding wizard (9 steps), dark/light theme toggle persisted in localStorage, responsive layout, accessibility considerations.
+- **Feature pages**
+  - Evidence pages for servers, network devices, workstations with tables, filters, scoped data, multi-select actions (batch export, print, retire).
+  - Audit explorer with filtering, highlighting, diff viewer, export.
+  - Labels & printing section with template editor, preview, batch printing workflow, job status list.
+  - Settings subsections (App Configuration, Security & Auth, LDAP/AD Sync, Email, Dictionaries, Roles & Users, Labels & Printing, Reports & Schedules, Import/Export, Maintenance, Observability, Advanced, About & Support, Handover, Updates, Backup & Restore).
+  - Modules page with toggles (GET/POST /api/modules).
+  - Dashboard with counts, recent changes, quick actions.
+  - Help Center integration (embedded manual viewer, contextual "?" tooltips linking to manual chapters).
+- **API integration**
+  - Provide strongly-typed clients (OpenAPI generated or hand-written) with pagination, filters, and consistent error handling.
+  - Implement optimistic UI updates where appropriate and handle async job polling.
+
+## 5. Packaging & Deployment
+- **Installer & builder scripts**
+  - Complete PowerShell installer (installer.ps1) to set up IIS App Pool, file permissions, environment configuration, and health checks.
+  - Provide merge/all-in-one builder supporting MERGE/ALLINONE modes with logging, phase detection, regex fixes, wizard verification, and optional installer automation.
+- **CI/CD**
+  - Author GitHub Actions workflows for build, test (API + web), publish artefacts, generate All-in-One ZIP with SHA256 manifest, and smoke tests.
+- **All-in-One artefact**
+  - Package publish output, API contracts, migrations, installer, documentation, attachments, observability examples, release notes, checksums.
+- **Documentation**
+  - Produce manual.pdf, release notes template updates, user guide, deployment guide, troubleshooting, rollback instructions.
+
+## 6. Testing & Quality
+- **Automated tests**
+  - Unit, integration, and end-to-end tests covering domain logic, API endpoints, RBAC enforcement, background jobs, printing workflows, import/export, backups, updates.
+  - UI tests (Playwright) for key flows including onboarding wizard, settings updates, inventory CRUD, label printing, report scheduling.
+- **Smoke tests**
+  - Scripts verifying /health, login + 2FA, CRUD basics, label rendering, SMTP/LDAP tests post-deployment.
+- **Performance & security**
+  - Add rate limiting, CAPTCHA for login/SSPR, vulnerability scanning, dependency checks, and penetration testing considerations.
+
+## 7. Inputs Required From Stakeholders
+The following information is necessary to implement environment-specific integrations safely:
+1. **SMTP relay details** – host, port, TLS requirements, credentials, from/reply-to policy.
+2. **LDAP/AD topology** – hostnames, base DNs, group naming conventions for role mapping, attribute mapping preferences.
+3. **SMS provider selection** – preferred vendor (Twilio/Vonage/SMPP/HTTP gateway), sender ID policy, compliance requirements.
+4. **Storage locations** – UNC paths or S3 buckets for artefacts, backups, and exports.
+5. **Printing infrastructure** – target printer names or IPs for raw 9100 jobs, supported label sizes/DPI.
+6. **Branding assets** – organization name, logos, color palette, default e-mail templates (CZ/EN), handover PDF branding.
+7. **Security policies** – password complexity rules, session timeout standards, audit retention periods, captcha provider (if any).
+8. **Reporting requirements** – exact report recipients, schedules, filtering thresholds (e.g., warranty expiry days).
+9. **Observability endpoints** – OTEL collector URLs, authentication tokens, log retention policies.
+10. **Support contacts** – helpdesk URLs, diagnostic package recipients, escalation procedures.
+
+Documenting these inputs early will unblock the configuration-driven portions of the build and reduce rework during implementation.
+
+## 8. Recommended execution order
+To turn the blueprint into a production-ready release, iterate through the following milestone-oriented phases. Each phase is
+designed to produce a demonstrable increment that can be validated with automated smoke tests and short stakeholder reviews.
+
+1. **Foundations & Persistence**
+   - Switch to SQL Server, ship the initial migration bundle, and stand up seed data for dictionaries, roles, modules, and feature
+     flags.
+   - Harden the configuration system, secrets storage, and background job infrastructure so subsequent features can rely on
+     durable state and scheduling.
+2. **Identity, RBAC, and Security**
+   - Light up ASP.NET Core Identity, session management, 2FA (TOTP/e-mail), SSPR, CAPTCHA, and policy-based authorization with
+     scoped data filters.
+   - Deliver the first pass of the onboarding wizard to exercise authentication, SMTP test, and LDAP dry-run flows end to end.
+3. **Core Inventory Workflows**
+   - Complete server/network/workstation CRUD, retire/restore, comments, audit diffing, VLAN/IP enforcement, and scoped admin
+     behaviour.
+   - Implement handover PDFs/e-mail notifications, label management with ZPL/PDF rendering, and export/import jobs with dry-run.
+4. **Operations & Integrations**
+   - Finish connectors (SMTP, SMS, LDAP/OIDC complete; add Webhooks, SFTP/FTPS, Storage, Printing, enhanced Observability, Zabbix) with health reporting and
+     secret rotation.
+   - Build the Updates, Backup & Restore, Reports & Schedules, and Observability dashboards/alerting modules plus widgets.
+5. **Frontend completion & UX polish**
+   - Deliver the full React/Vite admin app, dark/light theming, contextual help, manual viewer, and feature-specific pages.
+   - Add Playwright tests and align UI copy with terminology in the specification.
+6. **Packaging, CI/CD, and Release Enablement**
+   - Finalize PowerShell installers, builder/merger scripts, All-in-One ZIP with SHA256, GitHub Actions pipelines, release notes,
+     manual PDFs, and smoke tests ready for acceptance.
+
+## 9. Immediate actions possible without stakeholder input
+While waiting for environment-specific details, the following engineering work can start immediately inside the repository:
+
+- Replace EF Core InMemory with SQL Server LocalDB/SQL Express configuration and generate baseline migrations.
+- Implement ASP.NET Core Identity with built-in local authentication, password policies, and TOTP 2FA using OtpNet.
+- Rozšířit React frontend o onboarding wizard, help centrum a pokročilé inventární filtry/batch akce nad již existujícími stránkami.
+- Build audit logging infrastructure (entity change diffing, history endpoints) and wire it into existing CRUD handlers.
+- Implement label template storage, QuestPDF previews, and ZPL generation utilities with unit tests.
+- Set up Quartz.NET with tables for scheduled jobs and stub processors for LDAP sync, report scheduling, export, and backup jobs.
+- Draft PowerShell installer scaffolding to create IIS App Pool/sites and prepare configuration placeholders.
+
+These deliverables unblock downstream work and prove the end-to-end tooling without requiring external credentials.
+
+## 10. Items waiting on stakeholder input
+Once the engineering baseline above is in place, integrate the environment-specific values listed in Section 7. A consolidated
+tracking table should be maintained in the project wiki (or issue tracker) so that each dependency is assigned an owner and due
+date. During implementation, guard production-only settings behind feature flags and provide sensible development defaults to
+keep local environments functional while inputs are pending.

--- a/docs/status-report.md
+++ b/docs/status-report.md
@@ -1,0 +1,30 @@
+# HW Inventory Platform – Current Status
+
+_Last updated: 2025-10-09T09:00:00Z_
+
+## Implemented Capabilities
+- Monorepo scaffold targeting .NET 8 (API) and React/Vite (admin UI shell) with Tailwind-based dark/light theming.
+- ASP.NET Core backend structured into Domain, Application, Infrastructure, and Api layers with SQL Server persistence, Entity Framework Core migrations, and seeded baseline dictionaries, feature modules, and RBAC role definitions.
+- Identity foundation using ASP.NET Core Identity with TOTP 2FA helpers, policy-based authorization tied to the mandated RBAC roles (including per-user location/department data scoping), audit log entities that capture change diffs, and Quartz.NET background job wiring (initial label print processor).
+- Security integrations covering LDAP/AD connection tests and dry-runs, configurable OpenID Connect sign-in (HTTPS/PKCE enforced), password policy management with history/lockout enforcement, CAPTCHA validation, SMS-backed SSPR flows that revoke active sessions, auditované změny OIDC konfigurace i datových scopů a middleware, který sleduje aktivní relace uživatelů včetně vzdálených odhlášení, společně s React stránkou „Security Settings“ pro správu OIDC/LDAP/SSPR/CAPTCHA/SMS/politik hesel, mapování AD skupin na role, náhled auditních diffů a přehled aktivních relací s možností odhlášení.
+- Security readiness summary API (`/api/security/summary`) a UI přehled, který vizualizuje stav OIDC/LDAP/SSPR/CAPTCHA/SMS/hesel, 2FA adopci a poslední změny, včetně napojení na průvodce prvním spuštěním (blokace „Pokračovat“, dokud nejsou splněny kritické požadavky).
+- Password history storage a reuse prevention (EF Core tabulka `PasswordHistoryEntries`, vlastní `AppUserManager`, `PasswordHistoryValidator`) doplněné o automatizované regresní testy (`HWInventory.Infrastructure.Tests`) pokrývající historii hesel a konfigurátor politik.
+- SMTP konektor s uložením tajemství, auditovanými změnami konfigurace, testovacím odesláním e-mailu a dedikovanou React stránkou „Email (SMTP)“, která zajišťuje úpravu host/port/TLS/přihlašovacích údajů, zobrazuje zdravotní stav a podporuje testování přímo z UI i průvodce prvním spuštěním.
+- Katalog konektorů s REST API a React stránkou „Konektory“ zobrazující stav SMTP/SMS/LDAP/OIDC, podporující přepínání, testy (SMTP/SMS) a rotaci tajemství s auditními záznamy.
+- Observability konfigurace zahrnující log level switch, zapínání /health a /metrics, middleware pro X-Correlation-Id, Prometheus-kompatibilní export metrik a novou React stránku „Observabilita“ využívající API `/api/observability/*`.
+- Maintenance modul „Backup & Restore“ s API `/api/maintenance/*`, Quartz úlohou `BackupJobProcessor`, šifrovanými ZIP archivy (AES-256), SMTP notifikacemi, auditovanými konfiguracemi plánu záloh a React stránkou „Backup & Restore“ v nastavení.
+- Modul „Import/Export“ s API `/api/exports/*` a `/api/imports/*`, službami `ExportService` a `ImportService`, Quartz procesory exportních i importních jobů, CSV generováním inventáře, základním CSV importem (dry-run + placeholder zápis) a rozšířenou React stránkou „Import/Export“ pro spouštění exportů i importů.
+- Modul „Aktualizace“ s API `/api/updates`, službou `UpdateService`, Quartz jobem `UpdatePackageProcessor`, výpočtem SHA256, volitelnou zálohou před nasazením, parsováním `update-manifest.json`, auditními záznamy, downloadem logů a React stránkou „Aktualizace“ v Nastavení.
+- First-run wizard skeleton with a dedicated „Bezpečnostní nastavení“ krok, který agreguje klíčové bezpečnostní formuláře (OIDC/LDAP/SSPR/CAPTCHA/SMS) a nově také SMTP konfiguraci přímo v průvodci onboardingem.
+- Kompletní inventární UI: React stránky „Servery“, „Síťová zařízení“, „Pracovní stanice“ s CRUD formuláři, stránkováním, podporou VLAN/IP polí a vazbou na číselníky, dále „Audit“, „Číselníky“, „Štítky“ (správa šablon, ZPL/PDF náhledy, tiskové úlohy) a „Moduly“ pro přepínání feature flagů.
+- Label rendering services that produce QuestPDF previews and ZPL output, plus REST endpoints for inventory CRUD (servers, network devices, workstations), dictionaries, modules, dashboard summary, audit exploration, and TOTP enrollment.
+- PowerShell installer scaffold that provisions IIS resources and patches connection strings, alongside documentation describing the remaining backlog and execution plan.
+
+## Outstanding Work (High-Level)
+- Rozšířit security UX o pokročilé reportingové widgety na hlavním dashboardu, doplnit e2e/regresní pokrytí pro další scénáře (LDAP sync, SSPR edge cases, captcha rate limiting) a zaintegrovat security metriky do observability pipeline.
+- Complete remaining domain workflows: dokončit importní pipeline (validace, konfliktní logika se zápisem do DB, XLSX renderer, uživatelské mapování sloupců), vylepšení exportů (filtry, expirace odkazů, auditované stažení), reporting & schedules, rozšířené konektory (SFTP/FTPS, webhooks, storage, printing), advanced backup scenarios (incrementální zálohy, archivace, storage konektory), observability dashboards/alerting, and full audit diff surfacing for additional entities.
+- Dovršit React administraci: doplnit onboarding wizard o zbývající kroky/validace, přidat help centrum a kontextovou nápovědu, rozšířit inventární tabulky o hromadné akce/filtry a přidat UI pro plánované reporty a štítkové batch scénáře.
+- Deliver packaging & ops tooling: All-in-One builder, CI/CD pipelines, release notes/manual PDFs, smoke/regression tests, and artefact bundling with checksums.
+- Gather stakeholder inputs for SMTP, LDAP, SMS, storage, printing, branding, security policies, reporting thresholds, observability, and support contacts to configure environment-specific connectors.
+
+See [`docs/implementation-plan.md`](implementation-plan.md) for the detailed backlog and sequencing guidance.

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,0 +1,78 @@
+param(
+    [string]$PublishPath = "publish",
+    [string]$SiteName = "HWInventory",
+    [string]$AppPoolName = "HWInventoryPool",
+    [string]$AppPoolIdentity = "ApplicationPoolIdentity",
+    [string]$SqlConnectionString = "Server=localhost;Database=HWInventory;Trusted_Connection=True;TrustServerCertificate=True",
+    [switch]$SkipIisProvisioning
+)
+
+Import-Module WebAdministration -ErrorAction Stop
+
+function Ensure-Directory {
+    param([string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        Write-Host "[HWInventory] Creating directory $Path" -ForegroundColor Green
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function Update-AppSettings {
+    param([string]$ConfigPath, [string]$ConnectionString)
+
+    $json = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+    if (-not $json.ConnectionStrings) {
+        $json | Add-Member -NotePropertyName ConnectionStrings -NotePropertyValue @{ }
+    }
+
+    $json.ConnectionStrings.DefaultConnection = $ConnectionString
+    $json | ConvertTo-Json -Depth 6 | Out-File $ConfigPath -Encoding UTF8
+    Write-Host "[HWInventory] Updated $ConfigPath with SQL Server connection string" -ForegroundColor Green
+}
+
+function Grant-AppPermissions {
+    param([string]$Path, [string]$Identity)
+
+    Write-Host "[HWInventory] Granting Modify permissions to $Identity on $Path" -ForegroundColor Green
+    icacls $Path /grant "$Identity":(OI)(CI)M | Out-Null
+}
+
+Ensure-Directory -Path $PublishPath
+Ensure-Directory -Path (Join-Path $PublishPath "logs")
+Ensure-Directory -Path (Join-Path $PublishPath "updates")
+
+$webConfigPath = Join-Path $PublishPath "appsettings.Production.json"
+if (-not (Test-Path $webConfigPath)) {
+    $webConfigPath = Join-Path $PublishPath "appsettings.json"
+}
+
+if (Test-Path $webConfigPath) {
+    Update-AppSettings -ConfigPath $webConfigPath -ConnectionString $SqlConnectionString
+} else {
+    Write-Warning "[HWInventory] Unable to locate appsettings file in $PublishPath. Please update the connection string manually."
+}
+
+if (-not $SkipIisProvisioning) {
+    Write-Host "[HWInventory] Configuring IIS application pool $AppPoolName" -ForegroundColor Cyan
+
+    if (-not (Get-Item "IIS:\AppPools\$AppPoolName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\AppPools\$AppPoolName" -Force | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name managedRuntimeVersion -Value ""
+    Set-ItemProperty "IIS:\AppPools\$AppPoolName" -Name processModel.identityType -Value $AppPoolIdentity
+
+    Write-Host "[HWInventory] Ensuring IIS site $SiteName" -ForegroundColor Cyan
+    if (-not (Get-Item "IIS:\Sites\$SiteName" -ErrorAction SilentlyContinue)) {
+        New-Item "IIS:\Sites\$SiteName" -Bindings @{ protocol = "http"; bindingInformation = "*:8080:" } -PhysicalPath $PublishPath | Out-Null
+    }
+
+    Set-ItemProperty "IIS:\Sites\$SiteName" -Name applicationPool -Value $AppPoolName
+
+    Grant-AppPermissions -Path $PublishPath -Identity "IIS AppPool\$AppPoolName"
+    Grant-AppPermissions -Path (Join-Path $PublishPath "logs") -Identity "IIS AppPool\$AppPoolName"
+    Grant-AppPermissions -Path (Join-Path $PublishPath "updates") -Identity "IIS AppPool\$AppPoolName"
+}
+
+Write-Host "[HWInventory] Deployment artifacts staged successfully. Run dotnet ef database update or start the web application to apply migrations." -ForegroundColor Cyan

--- a/src/api/HWInventory.sln
+++ b/src/api/HWInventory.sln
@@ -1,0 +1,45 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Api", "src/HWInventory.Api/HWInventory.Api.csproj", "{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Application", "src/HWInventory.Application/HWInventory.Application.csproj", "{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Domain", "src/HWInventory.Domain/HWInventory.Domain.csproj", "{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Infrastructure", "src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj", "{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HWInventory.Infrastructure.Tests", "tests/HWInventory.Infrastructure.Tests/HWInventory.Infrastructure.Tests.csproj", "{7F4E0B57-DA6B-4F7C-9D0D-4AA5DCE8D9F2}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1D7982A-3E3C-4F4C-8F6D-4A8E86E0AABC}.Release|Any CPU.Build.0 = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FA6D077A-2FB4-46B3-8F45-0E0F5CCF3F6F}.Release|Any CPU.Build.0 = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{178E8F18-0E50-4F0F-8C29-7CE7E4B8EF24}.Release|Any CPU.Build.0 = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{033C6C8E-2F0F-4B3F-A2F8-6E98C1C4024A}.Release|Any CPU.Build.0 = Release|Any CPU
+{7F4E0B57-DA6B-4F7C-9D0D-4AA5DCE8D9F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{7F4E0B57-DA6B-4F7C-9D0D-4AA5DCE8D9F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{7F4E0B57-DA6B-4F7C-9D0D-4AA5DCE8D9F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{7F4E0B57-DA6B-4F7C-9D0D-4AA5DCE8D9F2}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ApiControllerBase.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Produces("application/json")]
+[Route("api/[controller]")]
+public abstract class ApiControllerBase : ControllerBase
+{
+    protected ApiControllerBase(IAppDbContext dbContext)
+    {
+        DbContext = dbContext;
+    }
+
+    protected IAppDbContext DbContext { get; }
+
+    protected record DataScopeContext(bool IsScoped, IReadOnlyCollection<Guid> LocationIds, IReadOnlyCollection<string> DepartmentKeys)
+    {
+        public static DataScopeContext Unrestricted { get; } = new(false, Array.Empty<Guid>(), Array.Empty<string>());
+
+        public bool HasLocationRestrictions => IsScoped && LocationIds.Count > 0;
+
+        public bool HasDepartmentRestrictions => IsScoped && DepartmentKeys.Count > 0;
+    }
+
+    protected string ResolveUserDisplayName()
+    {
+        return User.Identity?.Name ?? User.FindFirstValue(ClaimTypes.Email) ?? "system";
+    }
+
+    protected void StampCreation(AuditableEntity entity)
+    {
+        var actor = ResolveUserDisplayName();
+        entity.CreatedBy = actor;
+        entity.ModifiedBy = actor;
+    }
+
+    protected void StampModification(AuditableEntity entity)
+    {
+        var actor = ResolveUserDisplayName();
+        entity.ModifiedBy = actor;
+    }
+
+    private static readonly JsonSerializerOptions AuditSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    protected void AddAuditLog(string entityType, Guid entityId, string action, string? summary = null, object? changedFields = null)
+    {
+        var actor = ResolveUserDisplayName();
+        var roles = string.Join(",", User.FindAll(ClaimTypes.Role).Select(r => r.Value));
+        var userAgent = Request?.Headers["User-Agent"].ToString();
+        var changedJson = changedFields is null ? null : JsonSerializer.Serialize(changedFields, AuditSerializerOptions);
+
+        var log = new AuditLog
+        {
+            EntityType = entityType,
+            EntityId = entityId,
+            Action = action,
+            PerformedBy = actor,
+            Roles = string.IsNullOrWhiteSpace(roles) ? null : roles,
+            PerformedAtUtc = DateTime.UtcNow,
+            ChangeSummary = summary,
+            ChangedFieldsJson = changedJson,
+            IpAddress = HttpContext?.Connection?.RemoteIpAddress?.ToString(),
+            UserAgent = string.IsNullOrWhiteSpace(userAgent) ? null : userAgent
+        };
+
+        DbContext.AuditLogs.Add(log);
+    }
+
+    protected async Task<DataScopeContext> ResolveDataScopeAsync(CancellationToken cancellationToken = default)
+    {
+        if (User.IsInRole(SystemRoleNames.SuperAdmin))
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdValue, out var userId))
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var scopeRows = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId)
+            .Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey })
+            .ToListAsync(cancellationToken);
+
+        if (scopeRows.Count == 0)
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        var locationIds = new HashSet<Guid>();
+        var departmentKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var row in scopeRows)
+        {
+            if (row.ScopeType == DataScopeTypes.Location && row.LocationId.HasValue)
+            {
+                locationIds.Add(row.LocationId.Value);
+            }
+
+            if (row.ScopeType == DataScopeTypes.Department && !string.IsNullOrWhiteSpace(row.DepartmentKey))
+            {
+                departmentKeys.Add(row.DepartmentKey);
+            }
+        }
+
+        if (locationIds.Count == 0 && departmentKeys.Count == 0)
+        {
+            return DataScopeContext.Unrestricted;
+        }
+
+        return new DataScopeContext(true, locationIds, departmentKeys);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuditController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuditController.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/audit")]
+[Authorize(Policy = AuthorizationPolicies.AuditRead)]
+public class AuditController : ApiControllerBase
+{
+    public AuditController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<AuditLog>>> GetAsync([FromQuery] string? entityType, [FromQuery] string? user, [FromQuery] string? action)
+    {
+        var query = DbContext.AuditLogs.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(entityType))
+        {
+            query = query.Where(x => x.EntityType == entityType);
+        }
+        if (!string.IsNullOrWhiteSpace(user))
+        {
+            query = query.Where(x => x.PerformedBy == user);
+        }
+        if (!string.IsNullOrWhiteSpace(action))
+        {
+            query = query.Where(x => x.Action == action);
+        }
+
+        var items = await query.OrderByDescending(x => x.PerformedAtUtc).Take(500).ToListAsync();
+        return Ok(items);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/AuthController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/AuthController.cs
@@ -1,0 +1,108 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/auth")]
+[ApiController]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+    private readonly ITotpService _totpService;
+
+    public AuthController(UserManager<AppUser> userManager, SignInManager<AppUser> signInManager, ITotpService totpService)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _totpService = totpService;
+    }
+
+    [HttpGet("me")]
+    [Authorize]
+    public async Task<ActionResult<object>> GetProfileAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return Ok(new
+        {
+            user.Id,
+            user.UserName,
+            user.DisplayName,
+            user.Email,
+            Roles = roles,
+            TwoFactorEnabled = user.TwoFactorEnabled,
+            TwoFactorRequired = user.TwoFactorRequired
+        });
+    }
+
+    [HttpPost("totp/setup")]
+    [Authorize]
+    public async Task<ActionResult<object>> BeginTotpSetupAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            user.AuthenticatorKey = _totpService.GenerateSecretKey();
+            await _userManager.UpdateAsync(user);
+        }
+
+        var code = _totpService.GenerateCode(user.AuthenticatorKey);
+        return Ok(new
+        {
+            SecretKey = user.AuthenticatorKey,
+            VerificationCode = code
+        });
+    }
+
+    [HttpPost("totp/verify")]
+    [Authorize]
+    public async Task<ActionResult> CompleteTotpSetupAsync([FromBody] TotpVerificationRequest request)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.AuthenticatorKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "TOTP secret not initialized",
+                Detail = "Call /api/auth/totp/setup before attempting verification."
+            });
+        }
+
+        if (!_totpService.ValidateCode(user.AuthenticatorKey, request.Code))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid verification code",
+                Detail = "The provided TOTP code could not be validated."
+            });
+        }
+
+        user.TwoFactorEnabled = true;
+        await _userManager.UpdateAsync(user);
+        await _userManager.SetTwoFactorEnabledAsync(user, true);
+        await _signInManager.RefreshSignInAsync(user);
+
+        return NoContent();
+    }
+
+    public record TotpVerificationRequest(string Code);
+}

--- a/src/api/src/HWInventory.Api/Controllers/ConnectorsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ConnectorsController.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.SettingsManage)]
+public class ConnectorsController : ApiControllerBase
+{
+    private readonly IConnectorCatalogService _catalogService;
+
+    public ConnectorsController(IAppDbContext dbContext, IConnectorCatalogService catalogService)
+        : base(dbContext)
+    {
+        _catalogService = catalogService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyCollection<ConnectorSummaryResponse>>> GetAsync(CancellationToken cancellationToken)
+    {
+        var connectors = await _catalogService.GetAsync(cancellationToken);
+        var response = connectors.Select(Map).ToList();
+        return Ok(response);
+    }
+
+    [HttpPost("{connectorId:guid}/toggle")]
+    public async Task<ActionResult<ConnectorSummaryResponse>> ToggleAsync(Guid connectorId, [FromQuery] bool enabled, CancellationToken cancellationToken)
+    {
+        var summary = await _catalogService.ToggleAsync(connectorId, enabled, cancellationToken);
+        if (summary is null)
+        {
+            return NotFound();
+        }
+
+        AddAuditLog(
+            entityType: "ConnectorProfile",
+            entityId: connectorId,
+            action: "Update",
+            summary: enabled ? "Connector enabled" : "Connector disabled",
+            changedFields: new { enabled });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(Map(summary));
+    }
+
+    [HttpPost("{connectorId:guid}/rotate-secret")]
+    public async Task<ActionResult<ConnectorSummaryResponse>> RotateSecretsAsync(Guid connectorId, CancellationToken cancellationToken)
+    {
+        var summary = await _catalogService.RotateSecretsAsync(connectorId, cancellationToken);
+        if (summary is null)
+        {
+            return NotFound();
+        }
+
+        AddAuditLog(
+            entityType: "ConnectorProfile",
+            entityId: connectorId,
+            action: "Update",
+            summary: "Connector secret rotation triggered",
+            changedFields: new { rotated = true });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(Map(summary));
+    }
+
+    [HttpPost("{connectorId:guid}/test")]
+    public async Task<ActionResult<ConnectorTestResponse>> TestAsync(Guid connectorId, [FromBody] ConnectorTestRequestDto request, CancellationToken cancellationToken)
+    {
+        var outcome = await _catalogService.TestAsync(connectorId, new ConnectorTestRequest(request.Target), cancellationToken);
+        if (outcome.Summary is not null)
+        {
+            AddAuditLog(
+                entityType: "ConnectorProfile",
+                entityId: connectorId,
+                action: "Test",
+                summary: "Connector test executed",
+                changedFields: new
+                {
+                    outcome.Result.Success,
+                    outcome.Result.Message,
+                    request.Target
+                });
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return Ok(new ConnectorTestResponse(outcome.Result.Success, outcome.Result.Message, outcome.Summary is null ? null : Map(outcome.Summary)));
+    }
+
+    private static ConnectorSummaryResponse Map(ConnectorSummary summary)
+    {
+        return new ConnectorSummaryResponse(
+            summary.Id,
+            summary.Key,
+            summary.Type,
+            summary.Name,
+            summary.Enabled,
+            summary.HealthStatus,
+            summary.LastTestedAtUtc,
+            summary.HasSecret,
+            summary.SupportsToggle,
+            summary.SupportsTest,
+            summary.SupportsRotateSecret,
+            summary.RequiresConfiguration,
+            summary.Description);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DashboardController.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dashboard")]
+[Authorize(Policy = AuthorizationPolicies.DashboardView)]
+public class DashboardController : ApiControllerBase
+{
+    public DashboardController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet("summary")]
+    public async Task<ActionResult<DashboardSummaryResponse>> GetSummaryAsync()
+    {
+        var servers = await DbContext.Servers.CountAsync();
+        var network = await DbContext.NetworkDevices.CountAsync();
+        var workstations = await DbContext.Workstations.CountAsync();
+        var latestChanges = await DbContext.AuditLogs.AsNoTracking()
+            .OrderByDescending(x => x.PerformedAtUtc)
+            .Take(10)
+            .Select(x => new AuditEntryDto(x.EntityType, x.Action, x.PerformedBy, x.PerformedAtUtc))
+            .ToListAsync();
+
+        return Ok(new DashboardSummaryResponse(servers, network, workstations, latestChanges));
+    }
+
+    public record DashboardSummaryResponse(int Servers, int NetworkDevices, int Workstations, IReadOnlyCollection<AuditEntryDto> LatestChanges);
+
+    public record AuditEntryDto(string EntityType, string Action, string PerformedBy, DateTime PerformedAtUtc);
+}

--- a/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/DictionariesController.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/dictionaries")]
+[Authorize(Policy = AuthorizationPolicies.DictionariesManage)]
+public class DictionariesController : ApiControllerBase
+{
+    public DictionariesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<DictionaryEntry>>> GetAsync([FromQuery] string? type)
+    {
+        var query = DbContext.DictionaryEntries.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            query = query.Where(x => x.DictType == type);
+        }
+
+        var result = await query.OrderBy(x => x.DictType).ThenBy(x => x.Order).ThenBy(x => x.Value).ToListAsync();
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> GetByIdAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return entry is null ? NotFound() : Ok(entry);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<DictionaryEntry>> CreateAsync([FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = new DictionaryEntry
+        {
+            DictType = request.DictType,
+            Key = request.Key,
+            Value = request.Value,
+            Description = request.Description,
+            Order = request.Order,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system"
+        };
+
+        DbContext.DictionaryEntries.Add(entry);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entry.Id }, entry);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<DictionaryEntry>> UpdateAsync(Guid id, [FromBody] DictionaryEntryRequestDto request)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        entry.DictType = request.DictType;
+        entry.Key = request.Key;
+        entry.Value = request.Value;
+        entry.Description = request.Description;
+        entry.Order = request.Order;
+        entry.ModifiedAtUtc = DateTime.UtcNow;
+        entry.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync();
+        return Ok(entry);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id)
+    {
+        var entry = await DbContext.DictionaryEntries.FirstOrDefaultAsync(x => x.Id == id);
+        if (entry is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.DictionaryEntries.Remove(entry);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/EmailController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/EmailController.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/settings/email")]
+public class EmailController : ApiControllerBase
+{
+    private readonly IEmailConnectorStore _store;
+
+    public EmailController(IAppDbContext dbContext, IEmailConnectorStore store) : base(dbContext)
+    {
+        _store = store;
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.SecurityManage)]
+    public async Task<ActionResult<EmailConnectorModel?>> GetAsync(CancellationToken cancellationToken)
+    {
+        var model = await _store.GetAsync(cancellationToken);
+        return Ok(model);
+    }
+
+    [HttpPut]
+    [Authorize(Policy = AuthorizationPolicies.SecurityManage)]
+    public async Task<ActionResult<EmailConnectorModel>> SaveAsync([FromBody] EmailConnectorUpdate update, CancellationToken cancellationToken)
+    {
+        var before = await _store.GetAsync(cancellationToken);
+        var result = await _store.SaveAsync(update, cancellationToken);
+
+        AddAuditLog(
+            "Settings.Email",
+            result.Id,
+            "Update",
+            "SMTP configuration updated",
+            new
+            {
+                Alias = result.Alias,
+                Enabled = result.Enabled,
+                Host = result.Host,
+                Port = result.Port,
+                UseTls = result.UseTls,
+                Username = result.Username,
+                FromAddress = result.FromAddress,
+                ReplyToAddress = result.ReplyToAddress,
+                PreviousEnabled = before?.Enabled,
+                PreviousHost = before?.Host,
+                PreviousPort = before?.Port,
+                PreviousUseTls = before?.UseTls,
+                PreviousUsername = before?.Username,
+                PreviousFromAddress = before?.FromAddress,
+                PreviousReplyToAddress = before?.ReplyToAddress
+            });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost("test")]
+    [Authorize(Policy = AuthorizationPolicies.SecurityManage)]
+    public async Task<ActionResult<EmailTestResult>> SendTestAsync([FromBody] EmailTestRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _store.SendTestAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        AddAuditLog(
+            "Settings.Email",
+            Guid.Empty,
+            "Test",
+            $"SMTP test e-mail sent to {request.Recipient}");
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(result);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ExportsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ExportsController.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.ImportExportManage)]
+[Route("api/exports")]
+public class ExportsController : ApiControllerBase
+{
+    private readonly IExportService _exportService;
+
+    public ExportsController(IAppDbContext dbContext, IExportService exportService)
+        : base(dbContext)
+    {
+        _exportService = exportService;
+    }
+
+    [HttpGet("history")]
+    public async Task<ActionResult> GetHistoryAsync([FromQuery] int page = 1, [FromQuery] int size = 20, CancellationToken cancellationToken = default)
+    {
+        size = Math.Clamp(size, 1, 100);
+        var history = await _exportService.ListHistoryAsync(page, size, cancellationToken);
+        return Ok(history.Select(Map));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ExportResponseDto>> QueueExportAsync([FromBody] ExportRequestDto request, CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<ExportScope>(request.Scope, true, out var scope))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný rozsah exportu",
+                Detail = "Zadaný rozsah exportu není podporován.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (!Enum.TryParse<ExportFormat>(request.Format, true, out var format))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný formát",
+                Detail = "Formát exportu musí být CSV nebo XLSX.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí cílová cesta",
+                Detail = "Je nutné zadat složku, do které se export uloží.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var job = await _exportService.QueueExportAsync(new ExportRequest(
+            scope,
+            format,
+            request.StoragePath,
+            request.FilterJson,
+            request.SendEmail,
+            request.EmailRecipients),
+            cancellationToken);
+
+        AddAuditLog("Exports", job.Id, "Create", "Zařazení exportu", job);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return AcceptedAtAction(nameof(GetExportAsync), new { id = job.Id }, Map(job));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ExportResponseDto>> GetExportAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var job = await _exportService.GetAsync(id, cancellationToken);
+        if (job is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(Map(job));
+    }
+
+    [HttpGet("{id:guid}/artifact")]
+    public async Task<ActionResult> DownloadAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var job = await _exportService.GetAsync(id, cancellationToken);
+        if (job is null)
+        {
+            return NotFound();
+        }
+
+        if (string.IsNullOrWhiteSpace(job.ArtifactPath) || !System.IO.File.Exists(job.ArtifactPath))
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = "Artefakt nenalezen",
+                Detail = "Soubor exportu není k dispozici nebo již expiroval.",
+                Status = StatusCodes.Status404NotFound
+            });
+        }
+
+        var fileName = Path.GetFileName(job.ArtifactPath);
+        var mimeType = job.Format.Equals("xlsx", StringComparison.OrdinalIgnoreCase)
+            ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            : "text/csv";
+
+        var stream = new FileStream(job.ArtifactPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return File(stream, mimeType, fileName);
+    }
+
+    private static ExportResponseDto Map(ExportJobModel model)
+    {
+        return new ExportResponseDto
+        {
+            Id = model.Id,
+            Scope = model.Scope,
+            Format = model.Format,
+            StoragePath = model.StoragePath,
+            FileName = model.FileName,
+            Status = model.Status,
+            FileSizeBytes = model.FileSizeBytes,
+            CreatedAtUtc = model.CreatedAtUtc,
+            CompletedAtUtc = model.CompletedAtUtc,
+            ExpiresAtUtc = model.ExpiresAtUtc,
+            CreatedBy = model.CreatedBy,
+            FailureReason = model.FailureReason,
+            SendEmail = model.SendEmail,
+            EmailRecipients = model.EmailRecipients,
+            ArtifactPath = model.ArtifactPath
+        };
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ImportsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ImportsController.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.ImportExportManage)]
+[ApiController]
+[Route("api/imports")]
+public class ImportsController : ApiControllerBase
+{
+    private readonly IImportService _importService;
+
+    public ImportsController(IImportService importService)
+    {
+        _importService = importService;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ImportJobResponse>> QueueImport([FromBody] QueueImportRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var model = await _importService.QueueImportAsync(
+            new ImportRequest(
+                request.Scope,
+                request.Format,
+                request.ConflictStrategy,
+                request.DryRun,
+                request.StoragePath,
+                request.FileName,
+                request.ContentBase64,
+                request.SendEmail,
+                request.EmailRecipients,
+                request.MappingJson),
+            HttpContext.RequestAborted);
+
+        return CreatedAtAction(nameof(GetJob), new { id = model.Id }, ImportJobResponse.FromModel(model));
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ImportJobResponse>>> List([FromQuery] int page = 1, [FromQuery] int size = 50)
+    {
+        var models = await _importService.ListHistoryAsync(page, size, HttpContext.RequestAborted);
+        var response = new List<ImportJobResponse>();
+        foreach (var model in models)
+        {
+            response.Add(ImportJobResponse.FromModel(model));
+        }
+
+        return Ok(response);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ImportJobResponse>> GetJob(Guid id)
+    {
+        var model = await _importService.GetAsync(id, HttpContext.RequestAborted);
+        if (model is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ImportJobResponse.FromModel(model));
+    }
+
+    [HttpGet("{id:guid}/log")]
+    public async Task<IActionResult> DownloadLog(Guid id)
+    {
+        var model = await _importService.GetAsync(id, HttpContext.RequestAborted);
+        if (model is null || string.IsNullOrWhiteSpace(model.ResultLog))
+        {
+            return NotFound();
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(model.ResultLog);
+        return File(bytes, "text/plain", $"import-{id}.log");
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/LabelsController.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/labels")]
+[Authorize(Policy = AuthorizationPolicies.LabelsManage)]
+public class LabelsController : ApiControllerBase
+{
+    private readonly ILabelRenderingService _labelRenderingService;
+
+    public LabelsController(IAppDbContext dbContext, ILabelRenderingService labelRenderingService) : base(dbContext)
+    {
+        _labelRenderingService = labelRenderingService;
+    }
+
+    [HttpGet("templates")]
+    public async Task<ActionResult<IEnumerable<LabelTemplate>>> GetTemplatesAsync()
+    {
+        var templates = await DbContext.LabelTemplates.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(templates);
+    }
+
+    [HttpPost("templates")]
+    public async Task<ActionResult<LabelTemplate>> CreateTemplateAsync([FromBody] LabelTemplate request)
+    {
+        request.Id = Guid.NewGuid();
+        request.CreatedAtUtc = DateTime.UtcNow;
+        request.CreatedBy = User.Identity?.Name ?? "system";
+        DbContext.LabelTemplates.Add(request);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetTemplateByIdAsync), new { id = request.Id }, request);
+    }
+
+    [HttpGet("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> GetTemplateByIdAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        return template is null ? NotFound() : Ok(template);
+    }
+
+    [HttpPut("templates/{id:guid}")]
+    public async Task<ActionResult<LabelTemplate>> UpdateTemplateAsync(Guid id, [FromBody] LabelTemplate request)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        template.Name = request.Name;
+        template.Code = request.Code;
+        template.Format = request.Format;
+        template.Payload = request.Payload;
+        template.Description = request.Description;
+        template.ModifiedAtUtc = DateTime.UtcNow;
+        template.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(template);
+    }
+
+    [HttpDelete("templates/{id:guid}")]
+    public async Task<IActionResult> DeleteTemplateAsync(Guid id)
+    {
+        var template = await DbContext.LabelTemplates.FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        DbContext.LabelTemplates.Remove(template);
+        await DbContext.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("templates/{id:guid}/render/pdf")]
+    public async Task<IActionResult> RenderPdfAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var pdf = _labelRenderingService.RenderPdf(template, data);
+        return File(pdf, "application/pdf", $"{template.Code}.pdf");
+    }
+
+    [HttpPost("templates/{id:guid}/render/zpl")]
+    public async Task<IActionResult> RenderZplAsync(Guid id, [FromBody] LabelRenderRequest? request)
+    {
+        var template = await DbContext.LabelTemplates.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (template is null)
+        {
+            return NotFound();
+        }
+
+        var data = request?.Data ?? new Dictionary<string, string>();
+        var zpl = _labelRenderingService.RenderZpl(template, data);
+        return Ok(new { zpl });
+    }
+
+    [HttpPost("print-jobs")]
+    public async Task<ActionResult<LabelPrintJob>> CreatePrintJobAsync([FromBody] CreatePrintJobRequest request)
+    {
+        var job = new LabelPrintJob
+        {
+            Target = request.Target,
+            Format = request.Format,
+            JobStatus = "Queued",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = User.Identity?.Name ?? "system",
+            Items = request.Items.Select(item => new LabelPrintJobItem
+            {
+                AssetId = item.AssetId,
+                AssetType = item.AssetType,
+                Copies = item.Copies
+            }).ToList()
+        };
+
+        DbContext.LabelPrintJobs.Add(job);
+        await DbContext.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetPrintJobByIdAsync), new { id = job.Id }, job);
+    }
+
+    [HttpGet("print-jobs")]
+    public async Task<ActionResult<IEnumerable<LabelPrintJob>>> GetPrintJobsAsync()
+    {
+        var jobs = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items)
+            .OrderByDescending(x => x.CreatedAtUtc).Take(100).ToListAsync();
+        return Ok(jobs);
+    }
+
+    [HttpGet("print-jobs/{id:guid}")]
+    public async Task<ActionResult<LabelPrintJob>> GetPrintJobByIdAsync(Guid id)
+    {
+        var job = await DbContext.LabelPrintJobs.AsNoTracking().Include(x => x.Items).FirstOrDefaultAsync(x => x.Id == id);
+        return job is null ? NotFound() : Ok(job);
+    }
+
+    public record CreatePrintJobRequest(string Target, string Format, IReadOnlyCollection<PrintJobItemDto> Items);
+
+    public record PrintJobItemDto(Guid AssetId, string AssetType, int Copies);
+
+    public record LabelRenderRequest(Dictionary<string, string>? Data);
+}

--- a/src/api/src/HWInventory.Api/Controllers/MaintenanceController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/MaintenanceController.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.MaintenanceManage)]
+[Route("api/maintenance")]
+public class MaintenanceController : ApiControllerBase
+{
+    private readonly IBackupService _backupService;
+    private readonly IBackupConfigurationStore _scheduleStore;
+
+    public MaintenanceController(IAppDbContext dbContext, IBackupService backupService, IBackupConfigurationStore scheduleStore)
+        : base(dbContext)
+    {
+        _backupService = backupService;
+        _scheduleStore = scheduleStore;
+    }
+
+    [HttpGet("backups/history")]
+    public async Task<ActionResult> GetHistoryAsync([FromQuery] int page = 1, [FromQuery] int size = 20, CancellationToken cancellationToken = default)
+    {
+        size = Math.Clamp(size, 1, 100);
+        var history = await _backupService.ListHistoryAsync(page, size, cancellationToken);
+        return Ok(history.Select(Map));
+    }
+
+    [HttpPost("backups")]
+    public async Task<ActionResult<BackupResponseDto>> QueueBackupAsync([FromBody] BackupRequestDto request, CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<BackupScope>(request.Scope, true, out var scope))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný rozsah",
+                Detail = "Zvolený rozsah zálohy není podporován.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí cesta",
+                Detail = "Je nutné zadat cílovou cestu pro uložení zálohy.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (request.EncryptionEnabled && request.Password != request.PasswordConfirmation)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Potvrzení hesla nesouhlasí",
+                Detail = "Zadané heslo a potvrzení se liší.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var job = await _backupService.QueueBackupAsync(new BackupRequest(
+            scope,
+            request.StoragePath,
+            request.EncryptionEnabled,
+            request.EncryptionEnabled ? request.Password : null,
+            null,
+            request.SendEmail,
+            request.EmailRecipients,
+            request.IntegrityCheckEnabled,
+            false),
+            cancellationToken);
+
+        AddAuditLog("Maintenance.Backup", job.Id, "Create", "Založena nová záloha", job);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return AcceptedAtAction(nameof(GetBackupAsync), new { id = job.Id }, Map(job));
+    }
+
+    [HttpGet("backups/{id:guid}")]
+    public async Task<ActionResult<BackupResponseDto>> GetBackupAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var job = await _backupService.GetAsync(id, cancellationToken);
+        if (job is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(Map(job));
+    }
+
+    [HttpPost("backups/{id:guid}/restore")]
+    public async Task<ActionResult> RestoreAsync(Guid id, [FromBody] RestoreRequestDto request, CancellationToken cancellationToken)
+    {
+        var result = await _backupService.RestoreAsync(id, new RestoreRequest(request.Password, request.PerformIntegrityTest), cancellationToken);
+        AddAuditLog("Maintenance.Backup", id, "Restore", "Obnova zálohy", result);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        if (!result.Success)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Obnova selhala",
+                Detail = result.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        return Ok(new { message = result.Message });
+    }
+
+    [HttpPost("backups/{id:guid}/test")]
+    public async Task<ActionResult> TestIntegrityAsync(Guid id, [FromBody] IntegrityTestRequestDto request, CancellationToken cancellationToken)
+    {
+        var result = await _backupService.TestIntegrityAsync(id, request.Password, cancellationToken);
+        AddAuditLog("Maintenance.Backup", id, "IntegrityTest", "Ověření integrity zálohy", result);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        if (!result.Success)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Test integrity selhal",
+                Detail = result.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        return Ok(new { message = result.Message, passed = result.Passed });
+    }
+
+    [HttpGet("schedule")]
+    public async Task<ActionResult<BackupScheduleResponseDto>> GetScheduleAsync(CancellationToken cancellationToken)
+    {
+        var schedule = await _scheduleStore.GetAsync(cancellationToken);
+        return Ok(Map(schedule));
+    }
+
+    [HttpPut("schedule")]
+    public async Task<ActionResult<BackupScheduleResponseDto>> UpdateScheduleAsync([FromBody] BackupScheduleRequestDto request, CancellationToken cancellationToken)
+    {
+        if (request.EncryptionEnabled && request.Password != request.PasswordConfirmation && !request.RotatePassword)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Potvrzení hesla nesouhlasí",
+                Detail = "Zadané heslo a potvrzení se liší.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí cesta",
+                Detail = "Je nutné zadat cílovou cestu pro zálohy.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (!TimeSpan.TryParse(request.ExecutionTimeUtc, out var executionTime))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný čas",
+                Detail = "Čas spuštění musí být ve formátu HH:mm.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var schedule = await _scheduleStore.SaveAsync(new BackupScheduleUpdate(
+            request.Enabled,
+            request.Frequency,
+            request.DayOfWeek,
+            request.DayOfMonth,
+            executionTime,
+            request.Scope,
+            request.StoragePath,
+            request.EncryptionEnabled,
+            request.RotatePassword ? request.Password : request.EncryptionEnabled ? request.Password : null,
+            request.RotatePassword,
+            request.SendEmail,
+            request.EmailRecipients,
+            request.IntegrityCheckEnabled),
+            cancellationToken);
+
+        AddAuditLog("Maintenance.BackupSchedule", Guid.Empty, "Update", "Aktualizace plánu záloh", schedule);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(Map(schedule));
+    }
+
+    private static BackupResponseDto Map(BackupJobModel model)
+    {
+        return new BackupResponseDto
+        {
+            Id = model.Id,
+            Scope = model.Scope,
+            FileName = model.FileName,
+            StoragePath = model.StoragePath,
+            EncryptionEnabled = model.EncryptionEnabled,
+            SendEmail = model.SendEmail,
+            IntegrityCheckEnabled = model.IntegrityCheckEnabled,
+            IsAutomatic = model.IsAutomatic,
+            Status = model.Status,
+            FileSizeBytes = model.FileSizeBytes,
+            CompletedAtUtc = model.CompletedAtUtc,
+            IntegrityPassed = model.IntegrityPassed,
+            CreatedAtUtc = model.CreatedAtUtc,
+            CreatedBy = model.CreatedBy,
+            FailureReason = model.FailureReason
+        };
+    }
+
+    private static BackupScheduleResponseDto Map(BackupScheduleModel model)
+    {
+        return new BackupScheduleResponseDto
+        {
+            Enabled = model.Enabled,
+            Frequency = model.Frequency,
+            DayOfWeek = model.DayOfWeek,
+            DayOfMonth = model.DayOfMonth,
+            ExecutionTimeUtc = model.ExecutionTimeUtc.ToString("hh\:mm"),
+            Scope = model.Scope,
+            StoragePath = model.StoragePath,
+            EncryptionEnabled = model.EncryptionEnabled,
+            HasStoredPassword = model.HasStoredPassword,
+            SendEmail = model.SendEmail,
+            EmailRecipients = model.EmailRecipients,
+            IntegrityCheckEnabled = model.IntegrityCheckEnabled,
+            LastRunAtUtc = model.LastRunAtUtc,
+            NextRunAtUtc = model.NextRunAtUtc
+        };
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ModulesController.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/modules")]
+[Authorize(Policy = AuthorizationPolicies.ModulesManage)]
+public class ModulesController : ApiControllerBase
+{
+    public ModulesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<FeatureModule>>> GetAsync()
+    {
+        var modules = await DbContext.FeatureModules.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+        return Ok(modules);
+    }
+
+    [HttpPost("{key}/toggle")]
+    public async Task<IActionResult> ToggleAsync(string key, [FromQuery] bool? enabled, [FromBody] FeatureModuleToggleRequest? body)
+    {
+        var module = await DbContext.FeatureModules.FirstOrDefaultAsync(x => x.Key == key);
+        if (module is null)
+        {
+            return NotFound();
+        }
+
+        var newState = enabled ?? body?.Enabled ?? !module.Enabled;
+        module.Enabled = newState;
+        module.ModifiedAtUtc = DateTime.UtcNow;
+        module.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync();
+        return Ok(module);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/NetworkDevicesController.cs
@@ -1,0 +1,240 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/network-devices")]
+public class NetworkDevicesController : ApiControllerBase
+{
+    public NetworkDevicesController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<PagedResult<NetworkDevice>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.NetworkDevices.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("network-devices", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<NetworkDevice>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkRead)]
+    public async Task<ActionResult<NetworkDevice>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> CreateAsync([FromBody] NetworkDeviceRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.NetworkDevices.Add(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<ActionResult<NetworkDevice>> UpdateAsync(Guid id, [FromBody] NetworkDeviceRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RetireAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.NetworkManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.NetworkDevices.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        DbContext.NetworkDevices.Remove(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private static NetworkDevice Map(NetworkDeviceRequestDto request)
+    {
+        return new NetworkDevice
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            DeviceTypeId = request.DeviceTypeId,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(NetworkDevice entity, NetworkDeviceRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.DeviceTypeId = request.DeviceTypeId;
+        entity.Manufacturer = request.Manufacturer;
+        entity.Model = request.Model;
+        entity.LocationId = request.LocationId;
+        entity.RackPosition = request.RackPosition;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.SupportUntil = request.SupportUntil;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/ObservabilityController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ObservabilityController.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using HWInventory.Infrastructure.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.ObservabilityManage)]
+[Route("api/observability")]
+public class ObservabilityController : ApiControllerBase
+{
+    private readonly IObservabilityConfigurationStore _store;
+    private readonly IObservabilityRuntime _runtime;
+    private readonly IRequestMetricsCollector _metricsCollector;
+
+    public ObservabilityController(
+        IAppDbContext dbContext,
+        IObservabilityConfigurationStore store,
+        IObservabilityRuntime runtime,
+        IRequestMetricsCollector metricsCollector)
+        : base(dbContext)
+    {
+        _store = store;
+        _runtime = runtime;
+        _metricsCollector = metricsCollector;
+    }
+
+    [HttpGet("config")]
+    public async Task<ActionResult<ObservabilityConfigurationResponse>> GetConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _store.GetAsync(cancellationToken);
+        return Ok(Map(configuration));
+    }
+
+    [HttpPut("config")]
+    public async Task<ActionResult<ObservabilityConfigurationResponse>> UpdateConfigurationAsync(
+        [FromBody] ObservabilityConfigurationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<LogLevel>(request.LogLevel, true, out var parsedLevel))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná hodnota",
+                Detail = "Zadaná hodnota log levelu není podporována.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var previous = await _store.GetAsync(cancellationToken);
+        var update = new ObservabilityConfigurationUpdate(
+            parsedLevel.ToString(),
+            request.HealthEndpointEnabled,
+            request.MetricsEndpointEnabled,
+            request.CorrelationIdsEnabled,
+            request.IncludeTraceIdentifier,
+            request.OtelExporterEnabled,
+            string.IsNullOrWhiteSpace(request.OtelEndpoint) ? null : request.OtelEndpoint,
+            string.IsNullOrWhiteSpace(request.OtelAuthToken) ? null : request.OtelAuthToken,
+            request.RotateOtelAuthToken || !string.IsNullOrWhiteSpace(request.OtelAuthToken),
+            string.IsNullOrWhiteSpace(request.ResourceAttributes) ? null : request.ResourceAttributes);
+
+        var updated = await _store.SaveAsync(update, cancellationToken);
+        _runtime.Invalidate();
+        ObservabilityLogging.ApplyMinimumLevel(parsedLevel);
+
+        AddAuditLog(
+            "Settings.Observability",
+            Guid.Empty,
+            "Update",
+            "Aktualizace observability konfigurace",
+            new
+            {
+                Before = previous,
+                After = updated
+            });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(Map(updated));
+    }
+
+    [HttpGet("metrics/preview")]
+    public ActionResult<string> GetMetricsPreview()
+    {
+        var snapshot = _metricsCollector.ExportSnapshot();
+        return Content(snapshot, "text/plain");
+    }
+
+    private static ObservabilityConfigurationResponse Map(ObservabilityConfigurationModel model)
+    {
+        return new ObservabilityConfigurationResponse
+        {
+            LogLevel = model.LogLevel,
+            HealthEndpointEnabled = model.HealthEndpointEnabled,
+            MetricsEndpointEnabled = model.MetricsEndpointEnabled,
+            CorrelationIdsEnabled = model.CorrelationIdsEnabled,
+            IncludeTraceIdentifier = model.IncludeTraceIdentifier,
+            OtelExporterEnabled = model.OtelExporterEnabled,
+            OtelEndpoint = model.OtelEndpoint,
+            HasOtelAuthToken = model.HasOtelAuthToken,
+            ResourceAttributes = model.ResourceAttributes
+        };
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/SecurityController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/SecurityController.cs
@@ -1,0 +1,1093 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.SecurityManage)]
+public class SecurityController : ApiControllerBase
+{
+    private readonly ILdapSyncService _ldapSyncService;
+    private readonly ILdapConfigurationStore _ldapConfigurationStore;
+    private readonly IExternalIdentityService _externalIdentityService;
+    private readonly ISessionTracker _sessionTracker;
+    private readonly ISsprConfigurationStore _ssprConfigurationStore;
+    private readonly ICaptchaConfigurationStore _captchaConfigurationStore;
+    private readonly ISmsConnectorStore _smsConnectorStore;
+    private readonly IPasswordPolicyConfigurationStore _passwordPolicyConfigurationStore;
+
+    public SecurityController(
+        IAppDbContext dbContext,
+        ILdapSyncService ldapSyncService,
+        ILdapConfigurationStore ldapConfigurationStore,
+        IExternalIdentityService externalIdentityService,
+        ISessionTracker sessionTracker,
+        ISsprConfigurationStore ssprConfigurationStore,
+        ICaptchaConfigurationStore captchaConfigurationStore,
+        ISmsConnectorStore smsConnectorStore,
+        IPasswordPolicyConfigurationStore passwordPolicyConfigurationStore) : base(dbContext)
+    {
+        _ldapSyncService = ldapSyncService;
+        _ldapConfigurationStore = ldapConfigurationStore;
+        _externalIdentityService = externalIdentityService;
+        _sessionTracker = sessionTracker;
+        _ssprConfigurationStore = ssprConfigurationStore;
+        _captchaConfigurationStore = captchaConfigurationStore;
+        _smsConnectorStore = smsConnectorStore;
+        _passwordPolicyConfigurationStore = passwordPolicyConfigurationStore;
+    }
+
+    [HttpGet("oidc")]
+    public async Task<ActionResult<OidcConfiguration?>> GetOidcAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("oidc")]
+    public async Task<ActionResult> ConfigureOidcAsync([FromBody] OidcConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+
+        if (request.Enabled)
+        {
+            if (string.IsNullOrWhiteSpace(request.Authority) || !Uri.TryCreate(request.Authority, UriKind.Absolute, out var authorityUri) || authorityUri.Scheme != Uri.UriSchemeHttps)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Neplatná adresa OIDC",
+                    Detail = "Authority musí být platná HTTPS URL adresa."
+                });
+            }
+
+            if (string.IsNullOrWhiteSpace(request.ClientId))
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Chybí ClientId",
+                    Detail = "Pro aktivaci OIDC je vyžadován identifikátor klienta."
+                });
+            }
+
+            var responseType = string.IsNullOrWhiteSpace(request.ResponseType) ? "code" : request.ResponseType.Trim();
+            if (!string.Equals(responseType, "code", StringComparison.OrdinalIgnoreCase))
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Nepodporovaný response type",
+                    Detail = "Podporována je pouze autorizace s response_type=code."
+                });
+            }
+
+            if (request.Scopes is not null && !request.Scopes.Contains("openid", StringComparer.OrdinalIgnoreCase))
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Chybějící scope",
+                    Detail = "Scope 'openid' je pro OIDC povinný."
+                });
+            }
+
+            if (!request.UsePkce)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "PKCE je povinné",
+                    Detail = "Pro bezpečné přihlášení musí být povoleno PKCE."
+                });
+            }
+        }
+
+        var configuration = new OidcConfiguration(
+            request.Enabled,
+            request.Authority,
+            request.ClientId,
+            request.ClientSecret,
+            request.ResponseType,
+            request.Scopes ?? Array.Empty<string>(),
+            request.ClaimMappings ?? new Dictionary<string, string>(),
+            request.UsePkce);
+
+        await _externalIdentityService.ConfigureOidcAsync(configuration, cancellationToken);
+
+        var previousSnapshot = previous is null ? null : CreateOidcSnapshot(previous);
+        var currentSnapshot = CreateOidcSnapshot(configuration);
+        if (previousSnapshot is null || !previousSnapshot.Equals(currentSnapshot))
+        {
+            var auditBefore = previous is null ? null : CreateOidcAuditPayload(previous);
+            var auditAfter = CreateOidcAuditPayload(configuration);
+            var summary = configuration.Enabled
+                ? "Aktualizace nastavení OIDC"
+                : "Deaktivace OIDC přihlášení";
+
+            AddAuditLog(
+                "Security.OIDC",
+                Guid.Empty,
+                "Update",
+                summary,
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("summary")]
+    public async Task<ActionResult<SecuritySummaryResponse>> GetSecuritySummaryAsync(CancellationToken cancellationToken)
+    {
+        var oidc = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+        var ldap = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        var sspr = await _ssprConfigurationStore.GetAsync(cancellationToken);
+        var captcha = await _captchaConfigurationStore.GetAsync(cancellationToken);
+        var sms = await _smsConnectorStore.GetAsync(cancellationToken);
+        var passwordPolicy = await _passwordPolicyConfigurationStore.GetAsync(cancellationToken);
+
+        var users = await DbContext.Users.AsNoTracking().ToListAsync(cancellationToken);
+        var totalUsers = users.Count;
+        var twoFactorUsers = users.Count(x => x.TwoFactorEnabled);
+        var lockedOutUsers = users.Count(x => x.LockoutEnd.HasValue && x.LockoutEnd.Value > DateTimeOffset.UtcNow);
+
+        var oidcEnabled = oidc?.Enabled == true;
+        var ldapEnabled = ldap.Enabled;
+        var smsEnabled = sms?.Enabled == true;
+        var criticalReady = passwordPolicy.Enabled
+            && (oidcEnabled || ldapEnabled)
+            && sspr.Enabled
+            && sspr.RequireTwoFactor
+            && captcha.Enabled
+            && smsEnabled;
+
+        var summary = new SecuritySummaryResponse(
+            oidcEnabled,
+            ldapEnabled,
+            sspr.Enabled,
+            captcha.Enabled,
+            smsEnabled,
+            passwordPolicy.Enabled,
+            totalUsers,
+            twoFactorUsers,
+            lockedOutUsers,
+            ResolveLatestChange("Security.Oidc"),
+            ResolveLatestChange("Security.Ldap"),
+            ResolveLatestChange("Security.PasswordPolicy"),
+            ResolveLatestChange("Security.SSPR"),
+            criticalReady);
+
+        return Ok(summary);
+    }
+
+    private SecurityChangeMetadata ResolveLatestChange(string section)
+    {
+        var settings = DbContext.Settings.AsNoTracking().Where(x => x.Section == section);
+        var latest = settings
+            .OrderByDescending(x => x.ModifiedAtUtc ?? x.CreatedAtUtc)
+            .Select(x => new { x.ModifiedAtUtc, x.CreatedAtUtc, x.ModifiedBy, x.CreatedBy })
+            .FirstOrDefault();
+
+        if (latest is null)
+        {
+            return new SecurityChangeMetadata(null, null);
+        }
+
+        var timestamp = latest.ModifiedAtUtc ?? latest.CreatedAtUtc;
+        var actor = latest.ModifiedBy ?? latest.CreatedBy;
+        return new SecurityChangeMetadata(timestamp, actor);
+    }
+
+    [HttpGet("ldap/config")]
+    public async Task<ActionResult<LdapConfigurationModel>> GetLdapConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("ldap/config")]
+    public async Task<ActionResult> ConfigureLdapAsync([FromBody] LdapConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        var update = new LdapConfigurationUpdate(
+            request.Enabled,
+            request.Host,
+            request.Port,
+            request.UseSsl,
+            request.BindDn,
+            request.Password,
+            request.ResetPassword,
+            request.IgnoreCertificateErrors,
+            request.UsersBaseDn,
+            request.UsersFilter,
+            request.AttributeMap ?? Array.Empty<string>());
+
+        var updated = await _ldapConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!LdapConfigsEqual(previous, updated))
+        {
+            var auditBefore = CreateLdapAuditPayload(previous);
+            var auditAfter = CreateLdapAuditPayload(updated);
+
+            AddAuditLog(
+                "Security.LDAP",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení LDAP/AD",
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost("ldap/test")]
+    public async Task<ActionResult<LdapConnectionTestResult>> TestLdapAsync([FromBody] LdapConnectionOptions options, CancellationToken cancellationToken)
+    {
+        var result = await _ldapSyncService.TestConnectionAsync(options, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost("ldap/dry-run")]
+    public async Task<ActionResult<LdapDryRunResult>> DryRunLdapAsync([FromBody] LdapDryRunRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ldapSyncService.DryRunAsync(request, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpGet("sspr/config")]
+    public async Task<ActionResult<SsprConfigurationModel>> GetSsprConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _ssprConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("sspr/config")]
+    public async Task<ActionResult> ConfigureSsprAsync([FromBody] SsprConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _ssprConfigurationStore.GetAsync(cancellationToken);
+        var update = new SsprConfigurationUpdate(
+            request.Enabled,
+            request.RequireTwoFactor,
+            request.RequireCaptcha,
+            request.RequireSmsOtp,
+            request.TokenExpiryMinutes,
+            request.ThrottleWindowMinutes,
+            request.MaxRequestsPerWindow,
+            request.SmsConnectorKey);
+
+        var updated = await _ssprConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!SsprConfigsEqual(previous, updated))
+        {
+            var auditBefore = CreateSsprAuditPayload(previous);
+            var auditAfter = CreateSsprAuditPayload(updated);
+
+            AddAuditLog(
+                "Security.SSPR",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení SSPR",
+                new { Before = auditBefore, After = auditAfter });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("password-policy")]
+    public async Task<ActionResult<PasswordPolicyModel>> GetPasswordPolicyAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _passwordPolicyConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("password-policy")]
+    public async Task<ActionResult> ConfigurePasswordPolicyAsync([FromBody] PasswordPolicyRequest request, CancellationToken cancellationToken)
+    {
+        if (request.MinimumLength < 6)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Příliš krátké heslo",
+                Detail = "Minimální délka hesla musí být alespoň 6 znaků."
+            });
+        }
+
+        if (request.LockoutAttempts < 1)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný limit pokusů",
+                Detail = "Počet pokusů pro uzamknutí musí být kladné číslo."
+            });
+        }
+
+        if (request.LockoutDurationMinutes < 1)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná doba uzamčení",
+                Detail = "Doba uzamčení musí být alespoň 1 minuta."
+            });
+        }
+
+        if (request.ExpirationDays < 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná expirace",
+                Detail = "Expirace hesla nemůže být záporná."
+            });
+        }
+
+        if (request.HistoryCount < 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná historie",
+                Detail = "Počet uchovaných hesel nemůže být záporný."
+            });
+        }
+
+        var previous = await _passwordPolicyConfigurationStore.GetAsync(cancellationToken);
+        var update = new PasswordPolicyUpdate(
+            request.Enabled,
+            request.MinimumLength,
+            request.RequireUppercase,
+            request.RequireLowercase,
+            request.RequireDigit,
+            request.RequireNonAlphanumeric,
+            request.ExpirationDays,
+            request.HistoryCount,
+            request.LockoutAttempts,
+            request.LockoutDurationMinutes);
+
+        var updated = await _passwordPolicyConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!PasswordPoliciesEqual(previous, updated))
+        {
+            AddAuditLog(
+                "Security.PasswordPolicy",
+                Guid.Empty,
+                "Update",
+                "Aktualizace politiky hesel",
+                new { Before = previous, After = updated });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("captcha/config")]
+    public async Task<ActionResult<CaptchaConfigurationModel>> GetCaptchaConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await _captchaConfigurationStore.GetAsync(cancellationToken);
+        return Ok(configuration);
+    }
+
+    [HttpPost("captcha/config")]
+    public async Task<ActionResult> ConfigureCaptchaAsync([FromBody] CaptchaConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        var previous = await _captchaConfigurationStore.GetAsync(cancellationToken);
+        var update = new CaptchaConfigurationUpdate(
+            request.Enabled,
+            request.SiteKey,
+            request.Secret,
+            request.RotateSecret,
+            request.VerificationEndpoint,
+            request.BypassToken);
+
+        var updated = await _captchaConfigurationStore.SaveAsync(update, cancellationToken);
+
+        if (!CaptchaConfigsEqual(previous, updated))
+        {
+            AddAuditLog(
+                "Security.Captcha",
+                Guid.Empty,
+                "Update",
+                "Aktualizace nastavení CAPTCHA",
+                new { Before = previous, After = updated });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("sms/config")]
+    public async Task<ActionResult<SmsConnectorModel?>> GetSmsConnectorAsync(CancellationToken cancellationToken)
+    {
+        var connector = await _smsConnectorStore.GetAsync(cancellationToken);
+        return Ok(connector);
+    }
+
+    [HttpPost("sms/config")]
+    public async Task<ActionResult<SmsConnectorModel>> ConfigureSmsAsync([FromBody] SmsConnectorRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Endpoint))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí endpoint",
+                Detail = "Je nutné zadat URL endpointu SMS konektoru."
+            });
+        }
+
+        var update = new SmsConnectorUpdate(
+            request.Alias,
+            request.Enabled,
+            request.Endpoint,
+            request.Sender,
+            request.Region,
+            request.Secret,
+            request.RotateSecret);
+
+        var previous = await _smsConnectorStore.GetAsync(cancellationToken);
+        var result = await _smsConnectorStore.SaveAsync(update, cancellationToken);
+
+        if (previous is null || !SmsConfigsEqual(previous, result) || request.RotateSecret)
+        {
+            AddAuditLog(
+                "Security.SMS",
+                result.Id ?? Guid.Empty,
+                "Update",
+                "Aktualizace SMS konektoru",
+                new
+                {
+                    Before = previous,
+                    After = result,
+                    RotatedSecret = request.RotateSecret
+                });
+
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("ldap/role-mappings")]
+    public async Task<ActionResult<IEnumerable<LdapRoleMappingResponse>>> GetLdapRoleMappingsAsync(CancellationToken cancellationToken)
+    {
+        var mappings = await DbContext.LdapRoleMappings
+            .Where(x => x.Status == EntityStatus.Active)
+            .OrderBy(x => x.GroupName)
+            .Select(x => new LdapRoleMappingResponse(x.Id, x.GroupName, x.RoleName))
+            .ToListAsync(cancellationToken);
+
+        return Ok(mappings);
+    }
+
+    [HttpPost("ldap/role-mappings")]
+    public async Task<ActionResult<LdapRoleMappingResponse>> CreateLdapRoleMappingAsync([FromBody] LdapRoleMappingRequest request, CancellationToken cancellationToken)
+    {
+        var normalizedGroup = request.GroupName?.Trim();
+        var normalizedRole = request.RoleName?.Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizedGroup) || string.IsNullOrWhiteSpace(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná data",
+                Detail = "Je nutné zadat skupinu i roli."
+            });
+        }
+
+        if (!IsSupportedRole(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá role",
+                Detail = "Zadaná role není podporována."
+            });
+        }
+
+        var exists = await DbContext.LdapRoleMappings.AnyAsync(x =>
+            x.Status == EntityStatus.Active &&
+            x.GroupName.Equals(normalizedGroup, StringComparison.OrdinalIgnoreCase) &&
+            x.RoleName.Equals(normalizedRole, StringComparison.OrdinalIgnoreCase), cancellationToken);
+
+        if (exists)
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "Mapování již existuje",
+                Detail = "Kombinace skupiny a role je již definována."
+            });
+        }
+
+        var mapping = new LdapRoleMapping
+        {
+            GroupName = normalizedGroup,
+            RoleName = normalizedRole,
+            Status = EntityStatus.Active
+        };
+
+        StampCreation(mapping);
+        DbContext.LdapRoleMappings.Add(mapping);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Create",
+            "Vytvořeno mapování AD skupiny na roli",
+            new { mapping.GroupName, mapping.RoleName });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new LdapRoleMappingResponse(mapping.Id, mapping.GroupName, mapping.RoleName));
+    }
+
+    [HttpPut("ldap/role-mappings/{id:guid}")]
+    public async Task<ActionResult<LdapRoleMappingResponse>> UpdateLdapRoleMappingAsync(Guid id, [FromBody] LdapRoleMappingRequest request, CancellationToken cancellationToken)
+    {
+        var mapping = await DbContext.LdapRoleMappings.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (mapping is null)
+        {
+            return NotFound();
+        }
+
+        var normalizedGroup = request.GroupName?.Trim();
+        var normalizedRole = request.RoleName?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedGroup) || string.IsNullOrWhiteSpace(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná data",
+                Detail = "Je nutné zadat skupinu i roli."
+            });
+        }
+
+        if (!IsSupportedRole(normalizedRole))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá role",
+                Detail = "Zadaná role není podporována."
+            });
+        }
+
+        var before = new { mapping.GroupName, mapping.RoleName, mapping.Status };
+
+        mapping.GroupName = normalizedGroup;
+        mapping.RoleName = normalizedRole;
+        mapping.Status = EntityStatus.Active;
+        StampModification(mapping);
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Update",
+            "Aktualizováno mapování AD skupiny",
+            new { Before = before, After = new { mapping.GroupName, mapping.RoleName, mapping.Status } });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new LdapRoleMappingResponse(mapping.Id, mapping.GroupName, mapping.RoleName));
+    }
+
+    [HttpDelete("ldap/role-mappings/{id:guid}")]
+    public async Task<ActionResult> DeleteLdapRoleMappingAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var mapping = await DbContext.LdapRoleMappings.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (mapping is null)
+        {
+            return NotFound();
+        }
+
+        if (mapping.Status == EntityStatus.Retired)
+        {
+            return NoContent();
+        }
+
+        var before = new { mapping.GroupName, mapping.RoleName, mapping.Status };
+        mapping.Status = EntityStatus.Retired;
+        StampModification(mapping);
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        AddAuditLog(
+            "Security.LdapRoleMapping",
+            mapping.Id,
+            "Delete",
+            "Mapování AD skupiny deaktivováno",
+            new { Before = before, After = new { mapping.GroupName, mapping.RoleName, mapping.Status } });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpGet("users/{userId:guid}/scopes")]
+    public async Task<ActionResult<IEnumerable<DataScopeResponse>>> GetScopesAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var scopes = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId && x.Status == EntityStatus.Active)
+            .Select(x => new DataScopeResponse(x.Id, x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToListAsync(cancellationToken);
+
+        return Ok(scopes);
+    }
+
+    [HttpPut("users/{userId:guid}/scopes")]
+    public async Task<ActionResult<IEnumerable<DataScopeResponse>>> UpdateScopesAsync(Guid userId, [FromBody] IEnumerable<DataScopeRequest> scopes, CancellationToken cancellationToken)
+    {
+        var requested = scopes?.ToList() ?? new List<DataScopeRequest>();
+        var validScopeTypes = new[] { DataScopeTypes.Location, DataScopeTypes.Department };
+        if (requested.Any(scope => !validScopeTypes.Contains(scope.ScopeType, StringComparer.OrdinalIgnoreCase)))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid scope type",
+                Detail = "ScopeType must be either Location or Department."
+            });
+        }
+
+        var normalizedRequests = requested.Select(Normalize).ToList();
+        foreach (var normalized in normalizedRequests)
+        {
+            if (normalized.ScopeType == DataScopeTypes.Location && normalized.LocationId is null)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Missing location",
+                    Detail = "Location scopes must include LocationId."
+                });
+            }
+
+            if (normalized.ScopeType == DataScopeTypes.Department && string.IsNullOrWhiteSpace(normalized.DepartmentKey))
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Missing department",
+                    Detail = "Department scopes must include DepartmentKey."
+                });
+            }
+        }
+
+        var existing = await DbContext.DataScopes.Where(x => x.AppUserId == userId).ToListAsync(cancellationToken);
+        var beforeActive = existing
+            .Where(x => x.Status == EntityStatus.Active)
+            .Select(x => new ScopeSnapshot(x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToList();
+
+        foreach (var row in existing)
+        {
+            var match = normalizedRequests.FirstOrDefault(r => r.ScopeType.Equals(row.ScopeType, StringComparison.OrdinalIgnoreCase) &&
+                Nullable.Equals(r.LocationId, row.LocationId) &&
+                string.Equals(r.DepartmentKey, row.DepartmentKey, StringComparison.OrdinalIgnoreCase));
+
+            if (match is null)
+            {
+                if (row.Status != EntityStatus.Retired)
+                {
+                    StampModification(row);
+                    row.Status = EntityStatus.Retired;
+                }
+            }
+            else if (row.Status != EntityStatus.Active)
+            {
+                StampModification(row);
+                row.Status = EntityStatus.Active;
+            }
+        }
+
+        foreach (var normalized in normalizedRequests)
+        {
+            var hasMatch = existing.Any(row => row.ScopeType.Equals(normalized.ScopeType, StringComparison.OrdinalIgnoreCase) &&
+                Nullable.Equals(row.LocationId, normalized.LocationId) &&
+                string.Equals(row.DepartmentKey, normalized.DepartmentKey, StringComparison.OrdinalIgnoreCase));
+
+            if (!hasMatch)
+            {
+                var scope = new DataScope
+                {
+                    AppUserId = userId,
+                    ScopeType = normalized.ScopeType,
+                    LocationId = normalized.LocationId,
+                    DepartmentKey = normalized.DepartmentKey,
+                    Status = EntityStatus.Active
+                };
+
+                StampCreation(scope);
+                DbContext.DataScopes.Add(scope);
+            }
+        }
+
+        var afterActive = normalizedRequests
+            .Select(x => new ScopeSnapshot(x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToList();
+
+        if (!ScopeSetsEqual(beforeActive, afterActive))
+        {
+            var beforeAudit = beforeActive.Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey }).ToList();
+            var afterAudit = afterActive.Select(x => new { x.ScopeType, x.LocationId, x.DepartmentKey }).ToList();
+            var summary = $"Aktualizovány datové scope uživatele {userId}";
+
+            AddAuditLog(
+                "Security.DataScopes",
+                userId,
+                "Update",
+                summary,
+                new { Before = beforeAudit, After = afterAudit });
+        }
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        var updated = await DbContext.DataScopes
+            .Where(x => x.AppUserId == userId && x.Status == EntityStatus.Active)
+            .Select(x => new DataScopeResponse(x.Id, x.ScopeType, x.LocationId, x.DepartmentKey))
+            .ToListAsync(cancellationToken);
+
+        return Ok(updated);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpGet("users/{userId:guid}/sessions")]
+    public async Task<ActionResult<IEnumerable<UserSessionDto>>> GetSessionsAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var sessions = await _sessionTracker.GetActiveSessionsAsync(userId, cancellationToken);
+        return Ok(sessions);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpGet("users")]
+    public async Task<ActionResult<IEnumerable<UserSummary>>> SearchUsersAsync([FromQuery] string? query, CancellationToken cancellationToken)
+    {
+        var normalized = query?.Trim();
+
+        var usersQuery = DbContext.Users
+            .Where(x => x.Status == EntityStatus.Active);
+
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            var likePattern = $"%{normalized}%";
+            usersQuery = usersQuery.Where(x =>
+                EF.Functions.Like(x.DisplayName, likePattern) ||
+                (x.Email != null && EF.Functions.Like(x.Email, likePattern)) ||
+                (x.UserName != null && EF.Functions.Like(x.UserName, likePattern)));
+        }
+
+        var results = await usersQuery
+            .OrderBy(x => x.DisplayName)
+            .ThenBy(x => x.Email)
+            .Take(20)
+            .Select(x => new UserSummary(
+                x.Id,
+                string.IsNullOrWhiteSpace(x.DisplayName) ? (x.UserName ?? x.Email ?? string.Empty) : x.DisplayName,
+                x.Email ?? string.Empty,
+                x.UserName ?? string.Empty))
+            .ToListAsync(cancellationToken);
+
+        return Ok(results);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpPost("sessions/{sessionId:guid}/revoke")]
+    public async Task<ActionResult> RevokeSessionAsync(Guid sessionId, [FromBody] SessionRevokeRequest request, CancellationToken cancellationToken)
+    {
+        var actor = ResolveUserDisplayName();
+        await _sessionTracker.RevokeAsync(sessionId, actor, request?.Reason, cancellationToken);
+
+        AddAuditLog(
+            "Security.Session",
+            sessionId,
+            "Revoke",
+            $"Sezení odhlášeno administrátorem {actor}",
+            new { SessionId = sessionId, Reason = request?.Reason });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.SessionsManage)]
+    [HttpPost("users/{userId:guid}/sessions/revoke-all")]
+    public async Task<ActionResult> RevokeAllSessionsAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var actor = ResolveUserDisplayName();
+        await _sessionTracker.RevokeAllAsync(userId, actor, cancellationToken);
+
+        AddAuditLog(
+            "Security.Session",
+            userId,
+            "RevokeAll",
+            $"Hromadné odhlášení uživatele {userId}",
+            new { UserId = userId });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    public record OidcConfigurationRequest(
+        bool Enabled,
+        string Authority,
+        string ClientId,
+        string? ClientSecret,
+        string? ResponseType,
+        IReadOnlyCollection<string>? Scopes,
+        IReadOnlyDictionary<string, string>? ClaimMappings,
+        bool UsePkce);
+
+    public record PasswordPolicyRequest(
+        bool Enabled,
+        int MinimumLength,
+        bool RequireUppercase,
+        bool RequireLowercase,
+        bool RequireDigit,
+        bool RequireNonAlphanumeric,
+        int ExpirationDays,
+        int HistoryCount,
+        int LockoutAttempts,
+        int LockoutDurationMinutes);
+
+    public record DataScopeRequest(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    public record DataScopeResponse(Guid Id, string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    public record SessionRevokeRequest(string? Reason);
+
+    public record UserSummary(Guid Id, string DisplayName, string Email, string UserName);
+
+    public record LdapConfigurationRequest(
+        bool Enabled,
+        string Host,
+        int Port,
+        bool UseSsl,
+        string BindDn,
+        string? Password,
+        bool ResetPassword,
+        bool IgnoreCertificateErrors,
+        string UsersBaseDn,
+        string? UsersFilter,
+        IReadOnlyCollection<string>? AttributeMap);
+
+    public record SsprConfigurationRequest(
+        bool Enabled,
+        bool RequireTwoFactor,
+        bool RequireCaptcha,
+        bool RequireSmsOtp,
+        int TokenExpiryMinutes,
+        int ThrottleWindowMinutes,
+        int MaxRequestsPerWindow,
+        string? SmsConnectorKey);
+
+    public record CaptchaConfigurationRequest(
+        bool Enabled,
+        string SiteKey,
+        string VerificationEndpoint,
+        string? Secret,
+        bool RotateSecret,
+        string? BypassToken);
+
+    public record SmsConnectorRequest(
+        string Alias,
+        bool Enabled,
+        string Endpoint,
+        string? Sender,
+        string? Region,
+        string? Secret,
+        bool RotateSecret);
+
+    public record LdapRoleMappingRequest(string GroupName, string RoleName);
+
+    public record LdapRoleMappingResponse(Guid Id, string GroupName, string RoleName);
+
+    private static NormalizedScope Normalize(DataScopeRequest request)
+    {
+        var scopeType = request.ScopeType.Equals(DataScopeTypes.Department, StringComparison.OrdinalIgnoreCase)
+            ? DataScopeTypes.Department
+            : DataScopeTypes.Location;
+
+        var locationId = scopeType == DataScopeTypes.Location ? request.LocationId : null;
+        var departmentKey = scopeType == DataScopeTypes.Department ? request.DepartmentKey : null;
+
+        return new NormalizedScope(scopeType, locationId, departmentKey);
+    }
+
+    private static bool CaptchaConfigsEqual(CaptchaConfigurationModel previous, CaptchaConfigurationModel current)
+    {
+        return previous.Enabled == current.Enabled &&
+            string.Equals(previous.SiteKey, current.SiteKey, StringComparison.Ordinal) &&
+            previous.HasSecret == current.HasSecret &&
+            string.Equals(previous.VerificationEndpoint, current.VerificationEndpoint, StringComparison.Ordinal) &&
+            string.Equals(previous.BypassToken, current.BypassToken, StringComparison.Ordinal);
+    }
+
+    private static bool SmsConfigsEqual(SmsConnectorModel before, SmsConnectorModel current)
+    {
+        return string.Equals(before.Alias, current.Alias, StringComparison.Ordinal) &&
+            before.Enabled == current.Enabled &&
+            string.Equals(before.Endpoint, current.Endpoint, StringComparison.Ordinal) &&
+            string.Equals(before.Sender ?? string.Empty, current.Sender ?? string.Empty, StringComparison.Ordinal) &&
+            string.Equals(before.Region ?? string.Empty, current.Region ?? string.Empty, StringComparison.Ordinal) &&
+            before.HasSecret == current.HasSecret;
+    }
+
+    private static readonly string[] SupportedRoles =
+    {
+        SystemRoleNames.SuperAdmin,
+        SystemRoleNames.ServerAdmin,
+        SystemRoleNames.NetworkAdmin,
+        SystemRoleNames.AppAdmin,
+        SystemRoleNames.Helpdesk,
+        SystemRoleNames.HelpdeskRead
+    };
+
+    private static bool IsSupportedRole(string roleName)
+    {
+        return SupportedRoles.Any(r => r.Equals(roleName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static OidcSnapshot CreateOidcSnapshot(OidcConfiguration configuration)
+    {
+        var scopeSignature = string.Join("|", configuration.Scopes.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+        var claimSignature = string.Join("|", configuration.ClaimMappings
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+
+        return new OidcSnapshot(
+            configuration.Enabled,
+            configuration.Authority,
+            configuration.ClientId,
+            !string.IsNullOrWhiteSpace(configuration.ClientSecret),
+            configuration.ResponseType ?? "code",
+            scopeSignature,
+            claimSignature,
+            configuration.UsePkce);
+    }
+
+    private static object CreateOidcAuditPayload(OidcConfiguration configuration) => new
+    {
+        configuration.Enabled,
+        configuration.Authority,
+        configuration.ClientId,
+        ClientSecretSet = !string.IsNullOrWhiteSpace(configuration.ClientSecret),
+        ResponseType = configuration.ResponseType,
+        Scopes = configuration.Scopes,
+        ClaimMappings = configuration.ClaimMappings,
+        configuration.UsePkce
+    };
+
+    private static bool ScopeSetsEqual(IReadOnlyCollection<ScopeSnapshot> before, IReadOnlyCollection<ScopeSnapshot> after)
+    {
+        if (before.Count != after.Count)
+        {
+            return false;
+        }
+
+        var beforeKeys = new HashSet<string>(before.Select(CreateScopeKey), StringComparer.OrdinalIgnoreCase);
+        var afterKeys = new HashSet<string>(after.Select(CreateScopeKey), StringComparer.OrdinalIgnoreCase);
+        return beforeKeys.SetEquals(afterKeys);
+    }
+
+    private static string CreateScopeKey(ScopeSnapshot scope)
+    {
+        var normalizedType = scope.ScopeType.Equals(DataScopeTypes.Department, StringComparison.OrdinalIgnoreCase)
+            ? DataScopeTypes.Department
+            : DataScopeTypes.Location;
+        var location = scope.LocationId?.ToString() ?? string.Empty;
+        var department = scope.DepartmentKey?.Trim().ToLowerInvariant() ?? string.Empty;
+        return $"{normalizedType}|{location}|{department}";
+    }
+
+    private record NormalizedScope(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    private record OidcSnapshot(bool Enabled, string Authority, string ClientId, bool ClientSecretSet, string ResponseType, string ScopeSignature, string ClaimSignature, bool UsePkce);
+
+    private record ScopeSnapshot(string ScopeType, Guid? LocationId, string? DepartmentKey);
+
+    private static bool LdapConfigsEqual(LdapConfigurationModel before, LdapConfigurationModel after)
+    {
+        return before.Enabled == after.Enabled
+            && string.Equals(before.Host, after.Host, StringComparison.OrdinalIgnoreCase)
+            && before.Port == after.Port
+            && before.UseSsl == after.UseSsl
+            && string.Equals(before.BindDn, after.BindDn, StringComparison.Ordinal)
+            && before.HasPassword == after.HasPassword
+            && before.IgnoreCertificateErrors == after.IgnoreCertificateErrors
+            && string.Equals(before.UsersBaseDn, after.UsersBaseDn, StringComparison.Ordinal)
+            && string.Equals(before.UsersFilter ?? string.Empty, after.UsersFilter ?? string.Empty, StringComparison.Ordinal)
+            && before.AttributeMap.SequenceEqual(after.AttributeMap ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool SsprConfigsEqual(SsprConfigurationModel before, SsprConfigurationModel after)
+    {
+        return before.Enabled == after.Enabled
+            && before.RequireTwoFactor == after.RequireTwoFactor
+            && before.RequireCaptcha == after.RequireCaptcha
+            && before.RequireSmsOtp == after.RequireSmsOtp
+            && before.TokenExpiryMinutes == after.TokenExpiryMinutes
+            && before.ThrottleWindowMinutes == after.ThrottleWindowMinutes
+            && before.MaxRequestsPerWindow == after.MaxRequestsPerWindow
+            && string.Equals(before.SmsConnectorKey ?? string.Empty, after.SmsConnectorKey ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool PasswordPoliciesEqual(PasswordPolicyModel before, PasswordPolicyModel after)
+    {
+        return before.Enabled == after.Enabled
+            && before.MinimumLength == after.MinimumLength
+            && before.RequireUppercase == after.RequireUppercase
+            && before.RequireLowercase == after.RequireLowercase
+            && before.RequireDigit == after.RequireDigit
+            && before.RequireNonAlphanumeric == after.RequireNonAlphanumeric
+            && before.ExpirationDays == after.ExpirationDays
+            && before.HistoryCount == after.HistoryCount
+            && before.LockoutAttempts == after.LockoutAttempts
+            && before.LockoutDurationMinutes == after.LockoutDurationMinutes;
+    }
+
+    private static object CreateLdapAuditPayload(LdapConfigurationModel model) => new
+    {
+        model.Enabled,
+        model.Host,
+        model.Port,
+        model.UseSsl,
+        model.BindDn,
+        PasswordSet = model.HasPassword,
+        model.IgnoreCertificateErrors,
+        model.UsersBaseDn,
+        model.UsersFilter,
+        AttributeMap = model.AttributeMap
+    };
+
+    private static object CreateSsprAuditPayload(SsprConfigurationModel model) => new
+    {
+        model.Enabled,
+        model.RequireTwoFactor,
+        model.RequireCaptcha,
+        model.RequireSmsOtp,
+        model.TokenExpiryMinutes,
+        model.ThrottleWindowMinutes,
+        model.MaxRequestsPerWindow,
+        model.SmsConnectorKey
+    };
+
+    public record SecuritySummaryResponse(
+        bool OidcEnabled,
+        bool LdapEnabled,
+        bool SsprEnabled,
+        bool CaptchaEnabled,
+        bool SmsEnabled,
+        bool PasswordPolicyEnabled,
+        int TotalUsers,
+        int TwoFactorUsers,
+        int LockedOutUsers,
+        SecurityChangeMetadata OidcLastChange,
+        SecurityChangeMetadata LdapLastChange,
+        SecurityChangeMetadata PasswordPolicyLastChange,
+        SecurityChangeMetadata SsprLastChange,
+        bool CriticalReady);
+
+    public record SecurityChangeMetadata(DateTime? TimestampUtc, string? Actor);
+}

--- a/src/api/src/HWInventory.Api/Controllers/ServersController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/ServersController.cs
@@ -1,0 +1,262 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+public class ServersController : ApiControllerBase
+{
+    public ServersController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<PagedResult<Server>>> GetServersAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.Servers.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = GeneratePaginationLinksStatic("servers", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Server>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersRead)]
+    public async Task<ActionResult<Server>> GetServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        return Ok(server);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> CreateServerAsync([FromBody] ServerRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        var server = MapServer(request);
+        server.CreatedAtUtc = DateTime.UtcNow;
+        server.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Servers.Add(server);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetServerAsync), new { id = server.Id }, server);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<ActionResult<Server>> UpdateServerAsync(Guid id, [FromBody] ServerRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        UpdateServer(server, request);
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(server);
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RetireServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        server.Status = EntityStatus.Retired;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> RestoreServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        server.Status = EntityStatus.Active;
+        server.ModifiedAtUtc = DateTime.UtcNow;
+        server.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.ServersManage)]
+    public async Task<IActionResult> DeleteServerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var server = await DbContext.Servers.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (server is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(server.LocationId))
+        {
+            return Forbid();
+        }
+
+        DbContext.Servers.Remove(server);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    internal static string GeneratePaginationLinksStatic(string route, int page, int size, int total)
+    {
+        var links = new List<string>();
+        var lastPage = (int)Math.Ceiling(total / (double)size);
+        if (page > 1)
+        {
+            links.Add($"</api/{route}?page=1&size={size}>; rel=\"first\"");
+            links.Add($"</api/{route}?page={page - 1}&size={size}>; rel=\"prev\"");
+        }
+        if (page < lastPage)
+        {
+            links.Add($"</api/{route}?page={page + 1}&size={size}>; rel=\"next\"");
+            links.Add($"</api/{route}?page={lastPage}&size={size}>; rel=\"last\"");
+        }
+        return string.Join(", ", links);
+    }
+
+    private static Server MapServer(ServerRequestDto request)
+    {
+        return new Server
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            Manufacturer = request.Manufacturer,
+            Model = request.Model,
+            EnvironmentId = request.EnvironmentId,
+            WsusPriorityId = request.WsusPriorityId,
+            OperatingSystemId = request.OperatingSystemId,
+            ServerRoleId = request.ServerRoleId,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            LocationId = request.LocationId,
+            RackPosition = request.RackPosition,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments
+                .Select(x => new NetworkEndpoint { Label = x.Label, VlanId = x.VlanId, IpAddress = x.IpAddress })
+                .ToList()
+        };
+    }
+
+    private static void UpdateServer(Server server, ServerRequestDto request)
+    {
+        server.Name = request.Name;
+        server.InventoryNumber = request.InventoryNumber;
+        server.Manufacturer = request.Manufacturer;
+        server.Model = request.Model;
+        server.EnvironmentId = request.EnvironmentId;
+        server.WsusPriorityId = request.WsusPriorityId;
+        server.OperatingSystemId = request.OperatingSystemId;
+        server.ServerRoleId = request.ServerRoleId;
+        server.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        server.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        server.LocationId = request.LocationId;
+        server.RackPosition = request.RackPosition;
+        server.PurchasedAt = request.PurchasedAt;
+        server.SupportUntil = request.SupportUntil;
+        server.Notes = request.Notes;
+
+        server.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            server.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/SsprController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/SsprController.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[AllowAnonymous]
+[Route("api/security/sspr")]
+[ApiController]
+public class SsprController : ControllerBase
+{
+    private readonly ISsprService _ssprService;
+
+    public SsprController(ISsprService ssprService)
+    {
+        _ssprService = ssprService;
+    }
+
+    [HttpPost("request")]
+    public async Task<ActionResult<PasswordResetRequestResult>> RequestAsync([FromBody] PasswordResetRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ssprService.RequestResetAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpPost("complete")]
+    public async Task<ActionResult<PasswordResetCompletionResult>> CompleteAsync([FromBody] PasswordResetCompletionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _ssprService.CompleteResetAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            return BadRequest(result);
+        }
+
+        return Ok(result);
+    }
+}

--- a/src/api/src/HWInventory.Api/Controllers/UpdatesController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/UpdatesController.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HWInventory.Api.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.UpdatesManage)]
+[Route("api/updates")]
+public class UpdatesController : ApiControllerBase
+{
+    private readonly IUpdateService _updateService;
+
+    public UpdatesController(IAppDbContext dbContext, IUpdateService updateService)
+        : base(dbContext)
+    {
+        _updateService = updateService;
+    }
+
+    [HttpGet("history")]
+    public async Task<ActionResult<IEnumerable<UpdatePackageResponseDto>>> GetHistoryAsync([FromQuery] int page = 1, [FromQuery] int size = 20, CancellationToken cancellationToken = default)
+    {
+        size = Math.Clamp(size, 1, 100);
+        var history = await _updateService.ListHistoryAsync(page, size, cancellationToken);
+        Response.Headers["X-Total-Count"] = history.Count.ToString();
+        return Ok(history.Select(Map));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<UpdatePackageResponseDto>> GetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var package = await _updateService.GetAsync(id, cancellationToken);
+        if (package is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(Map(package));
+    }
+
+    [HttpGet("{id:guid}/log")]
+    public async Task<ActionResult> DownloadLogAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var log = await _updateService.GetLogAsync(id, cancellationToken);
+        if (log is null)
+        {
+            return NotFound();
+        }
+
+        return File(log, "text/plain", $"update-{id:N}.log");
+    }
+
+    [HttpPost]
+    [RequestSizeLimit(1024L * 1024 * 512)]
+    public async Task<ActionResult<UpdatePackageResponseDto>> UploadAsync([FromForm] UpdatePackageUploadRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Package is null || request.Package.Length == 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Chybí soubor",
+                Detail = "Je nutné nahrát ZIP nebo PKG soubor s aktualizací.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (!request.ConfirmedBackupAvailable && !request.CreateBackupBeforeInstall)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Potvrzení zálohy",
+                Detail = "Před spuštěním aktualizace musíte potvrdit, že existuje záloha, nebo zapnout volbu vytvoření zálohy.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var allowedExtensions = new[] { ".zip", ".pkg" };
+        if (!allowedExtensions.Contains(Path.GetExtension(request.Package.FileName ?? string.Empty), StringComparer.OrdinalIgnoreCase))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Nepodporovaný formát",
+                Detail = "Aktualizační balíček musí být ve formátu .zip nebo .pkg.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        await using var memoryStream = new MemoryStream();
+        await request.Package.CopyToAsync(memoryStream, cancellationToken);
+        var contentBase64 = Convert.ToBase64String(memoryStream.ToArray());
+
+        var storagePath = Path.Combine(AppContext.BaseDirectory, "updates");
+        Directory.CreateDirectory(storagePath);
+
+        var package = await _updateService.QueuePackageAsync(new UpdatePackageRequest(
+            request.Package.FileName ?? "update.zip",
+            storagePath,
+            contentBase64,
+            request.Version,
+            request.PreserveDatabaseConfiguration,
+            request.CreateBackupBeforeInstall,
+            string.IsNullOrWhiteSpace(request.BackupStoragePath) ? null : Path.GetFullPath(request.BackupStoragePath),
+            request.PerformIntegrityCheck,
+            request.ConfirmedBackupAvailable,
+            request.Notes),
+            cancellationToken);
+
+        AddAuditLog("Maintenance.Updates", package.Id, "Upload", "Nahrán aktualizační balíček", new
+        {
+            package.Version,
+            package.FileName,
+            package.Status
+        });
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return AcceptedAtAction(nameof(GetAsync), new { id = package.Id }, Map(package));
+    }
+
+    private static UpdatePackageResponseDto Map(UpdatePackageModel model) => new(
+        model.Id,
+        model.Version,
+        model.FileName,
+        model.Status,
+        model.Sha256,
+        model.PreserveDatabaseConfiguration,
+        model.CreateBackupBeforeInstall,
+        model.PerformIntegrityCheck,
+        model.ConfirmedBackupAvailable,
+        model.Notes,
+        model.CreatedAtUtc,
+        model.CompletedAtUtc,
+        model.CreatedBy,
+        model.FailureReason,
+        model.ManifestJson,
+        model.LogPath);
+}

--- a/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
+++ b/src/api/src/HWInventory.Api/Controllers/WorkstationsController.cs
@@ -1,0 +1,348 @@
+using System.Linq;
+using HWInventory.Api.Models;
+using HWInventory.Application.Abstractions;
+using HWInventory.Application.Common;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Api.Controllers;
+
+[Route("api/workstations")]
+public class WorkstationsController : ApiControllerBase
+{
+    public WorkstationsController(IAppDbContext dbContext) : base(dbContext)
+    {
+    }
+
+    [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<PagedResult<Workstation>>> GetAsync([FromQuery] int page = 1, [FromQuery] int size = 50, CancellationToken cancellationToken = default)
+    {
+        page = Math.Max(page, 1);
+        size = Math.Clamp(size, 1, 200);
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+
+        var query = DbContext.Workstations.AsNoTracking().OrderBy(x => x.Name);
+        if (scope.HasLocationRestrictions)
+        {
+            var allowedLocations = scope.LocationIds.ToArray();
+            query = query.Where(x => allowedLocations.Contains(x.LocationId));
+        }
+
+        if (scope.HasDepartmentRestrictions)
+        {
+            var allowedDepartments = scope.DepartmentKeys.ToArray();
+            query = query.Where(x => x.OwnerDepartment != null && allowedDepartments.Contains(x.OwnerDepartment));
+        }
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * size).Take(size).ToListAsync(cancellationToken);
+
+        Response.Headers["X-Total-Count"] = total.ToString();
+        var links = ServersController.GeneratePaginationLinksStatic("workstations", page, size, total);
+        if (!string.IsNullOrEmpty(links))
+        {
+            Response.Headers["Link"] = links;
+        }
+
+        return Ok(new PagedResult<Workstation>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = page,
+            PageSize = size
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsRead)]
+    public async Task<ActionResult<Workstation>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> CreateAsync([FromBody] WorkstationRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.OwnerDepartment) && !scope.DepartmentKeys.Contains(request.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        var entity = Map(request);
+        entity.CreatedAtUtc = DateTime.UtcNow;
+        entity.CreatedBy = User.Identity?.Name ?? "system";
+
+        DbContext.Workstations.Add(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = entity.Id }, entity);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult<Workstation>> UpdateAsync(Guid id, [FromBody] WorkstationRequestDto request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.Include(x => x.NetworkAssignments).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.OwnerDepartment) && !scope.DepartmentKeys.Contains(request.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        Update(entity, request);
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return Ok(entity);
+    }
+
+    [HttpPost("{id:guid}/handover")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<ActionResult> HandoverAsync(Guid id, [FromBody] HandoverRequest request, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(request.NewLocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(request.NewOwnerDepartment) && !scope.DepartmentKeys.Contains(request.NewOwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.OwnerId = request.NewOwnerId;
+        entity.OwnerDisplayName = request.NewOwnerDisplayName;
+        entity.OwnerDepartment = request.NewOwnerDepartment;
+        entity.LocationId = request.NewLocationId;
+        entity.LocationNote = request.NewLocationNote;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/retire")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RetireAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Retired;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/restore")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> RestoreAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        entity.Status = EntityStatus.Active;
+        entity.ModifiedAtUtc = DateTime.UtcNow;
+        entity.ModifiedBy = User.Identity?.Name ?? "system";
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = AuthorizationPolicies.WorkstationsManage)]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Workstations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var scope = await ResolveDataScopeAsync(cancellationToken);
+        if (scope.HasLocationRestrictions && !scope.LocationIds.Contains(entity.LocationId))
+        {
+            return Forbid();
+        }
+
+        if (scope.HasDepartmentRestrictions && !string.IsNullOrEmpty(entity.OwnerDepartment) && !scope.DepartmentKeys.Contains(entity.OwnerDepartment, StringComparer.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        DbContext.Workstations.Remove(entity);
+        await DbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private static Workstation Map(WorkstationRequestDto request)
+    {
+        return new Workstation
+        {
+            Name = request.Name,
+            InventoryNumber = request.InventoryNumber,
+            OperatingSystemId = request.OperatingSystemId,
+            WorkstationTypeId = request.WorkstationTypeId,
+            OwnerId = request.OwnerId,
+            OwnerDisplayName = request.OwnerDisplayName,
+            OwnerDepartment = request.OwnerDepartment,
+            LocationId = request.LocationId,
+            LocationNote = request.LocationNote,
+            Cpu = request.Cpu,
+            Ram = request.Ram,
+            Storage = request.Storage,
+            MacAddress = request.MacAddress,
+            PurchasedAt = request.PurchasedAt,
+            SupportUntil = request.SupportUntil,
+            PrimaryAdministratorId = request.PrimaryAdministratorId,
+            SecondaryAdministratorId = request.SecondaryAdministratorId,
+            Notes = request.Notes,
+            NetworkAssignments = request.NetworkAssignments.Select(x => new NetworkEndpoint
+            {
+                Label = x.Label,
+                VlanId = x.VlanId,
+                IpAddress = x.IpAddress
+            }).ToList()
+        };
+    }
+
+    private static void Update(Workstation entity, WorkstationRequestDto request)
+    {
+        entity.Name = request.Name;
+        entity.InventoryNumber = request.InventoryNumber;
+        entity.OperatingSystemId = request.OperatingSystemId;
+        entity.WorkstationTypeId = request.WorkstationTypeId;
+        entity.OwnerId = request.OwnerId;
+        entity.OwnerDisplayName = request.OwnerDisplayName;
+        entity.OwnerDepartment = request.OwnerDepartment;
+        entity.LocationId = request.LocationId;
+        entity.LocationNote = request.LocationNote;
+        entity.Cpu = request.Cpu;
+        entity.Ram = request.Ram;
+        entity.Storage = request.Storage;
+        entity.MacAddress = request.MacAddress;
+        entity.PurchasedAt = request.PurchasedAt;
+        entity.SupportUntil = request.SupportUntil;
+        entity.PrimaryAdministratorId = request.PrimaryAdministratorId;
+        entity.SecondaryAdministratorId = request.SecondaryAdministratorId;
+        entity.Notes = request.Notes;
+
+        entity.NetworkAssignments.Clear();
+        foreach (var assignment in request.NetworkAssignments)
+        {
+            entity.NetworkAssignments.Add(new NetworkEndpoint
+            {
+                Label = assignment.Label,
+                VlanId = assignment.VlanId,
+                IpAddress = assignment.IpAddress
+            });
+        }
+    }
+
+    public record HandoverRequest(
+        Guid? NewOwnerId,
+        string? NewOwnerDisplayName,
+        string? NewOwnerDepartment,
+        Guid NewLocationId,
+        string? NewLocationNote,
+        Guid? NewAdminId,
+        IReadOnlyCollection<string>? Emails,
+        string? Comment);
+}

--- a/src/api/src/HWInventory.Api/HWInventory.Api.csproj
+++ b/src/api/src/HWInventory.Api/HWInventory.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Infrastructure/HWInventory.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/src/api/src/HWInventory.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace HWInventory.Api.Middleware;
+
+public class CorrelationIdMiddleware
+{
+    private const string HeaderName = "X-Correlation-Id";
+
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IObservabilityRuntime runtime)
+    {
+        var configuration = await runtime.GetAsync(context.RequestAborted);
+        if (!configuration.CorrelationIdsEnabled)
+        {
+            await _next(context);
+            return;
+        }
+
+        var correlationId = ResolveCorrelationId(context);
+        context.Items[HeaderName] = correlationId;
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers[HeaderName] = correlationId;
+            if (configuration.IncludeTraceIdentifier)
+            {
+                context.Response.Headers["trace-id"] = context.TraceIdentifier;
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await _next(context);
+    }
+
+    private static string ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(HeaderName, out var values))
+        {
+            var value = values.ToString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return Guid.NewGuid().ToString();
+    }
+}
+
+public static class CorrelationIdMiddlewareExtensions
+{
+    public static IApplicationBuilder UseCorrelationIds(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<CorrelationIdMiddleware>();
+    }
+}

--- a/src/api/src/HWInventory.Api/Middleware/RequestMetricsMiddleware.cs
+++ b/src/api/src/HWInventory.Api/Middleware/RequestMetricsMiddleware.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace HWInventory.Api.Middleware;
+
+public class RequestMetricsMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public RequestMetricsMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IObservabilityRuntime runtime, IRequestMetricsCollector collector)
+    {
+        var configuration = await runtime.GetAsync(context.RequestAborted);
+        if (!configuration.MetricsEndpointEnabled)
+        {
+            await _next(context);
+            return;
+        }
+
+        collector.IncrementActive();
+        var stopwatch = Stopwatch.StartNew();
+        var statusCode = 200;
+
+        try
+        {
+            await _next(context);
+            statusCode = context.Response.StatusCode == 0 ? 200 : context.Response.StatusCode;
+        }
+        catch
+        {
+            statusCode = StatusCodes.Status500InternalServerError;
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            collector.Record(context.Request.Method ?? "UNKNOWN", statusCode, stopwatch.Elapsed);
+        }
+    }
+}
+
+public static class RequestMetricsMiddlewareExtensions
+{
+    public static IApplicationBuilder UseRequestMetrics(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<RequestMetricsMiddleware>();
+    }
+}

--- a/src/api/src/HWInventory.Api/Middleware/SessionTrackingMiddleware.cs
+++ b/src/api/src/HWInventory.Api/Middleware/SessionTrackingMiddleware.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace HWInventory.Api.Middleware;
+
+public class SessionTrackingMiddleware
+{
+    private const string SessionCookieName = "HWInventory.SessionId";
+    private readonly RequestDelegate _next;
+
+    public SessionTrackingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ISessionTracker sessionTracker)
+    {
+        if (context.User?.Identity?.IsAuthenticated == true)
+        {
+            var userIdClaim = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (Guid.TryParse(userIdClaim, out var userId))
+            {
+                var actor = context.User.Identity?.Name ?? context.User.FindFirstValue(ClaimTypes.Email) ?? "system";
+
+                if (!context.Request.Cookies.TryGetValue(SessionCookieName, out var sessionIdentifier) || string.IsNullOrWhiteSpace(sessionIdentifier))
+                {
+                    sessionIdentifier = Guid.NewGuid().ToString("N");
+                    context.Response.Cookies.Append(SessionCookieName, sessionIdentifier, new CookieOptions
+                    {
+                        HttpOnly = true,
+                        Secure = true,
+                        SameSite = SameSiteMode.Strict,
+                        IsEssential = true,
+                        Expires = DateTimeOffset.UtcNow.AddDays(7)
+                    });
+
+                    await sessionTracker.RegisterAsync(new RegisterSessionRequest(
+                        userId,
+                        sessionIdentifier,
+                        actor,
+                        context.Connection.RemoteIpAddress?.ToString(),
+                        context.Request.Headers.UserAgent.ToString()),
+                        context.RequestAborted);
+                }
+                else
+                {
+                    var active = await sessionTracker.TouchAsync(sessionIdentifier, context.RequestAborted);
+                    if (!active)
+                    {
+                        context.Response.Cookies.Delete(SessionCookieName);
+                        await context.SignOutAsync();
+                        return;
+                    }
+                }
+            }
+        }
+
+        await _next(context);
+    }
+}
+
+public static class SessionTrackingMiddlewareExtensions
+{
+    public static IApplicationBuilder UseSessionTracking(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<SessionTrackingMiddleware>();
+    }
+}

--- a/src/api/src/HWInventory.Api/Models/ConnectorSummaryResponse.cs
+++ b/src/api/src/HWInventory.Api/Models/ConnectorSummaryResponse.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace HWInventory.Api.Models;
+
+public record ConnectorSummaryResponse(
+    Guid? Id,
+    string Key,
+    string Type,
+    string Name,
+    bool Enabled,
+    string? HealthStatus,
+    DateTime? LastTestedAtUtc,
+    bool HasSecret,
+    bool SupportsToggle,
+    bool SupportsTest,
+    bool SupportsRotateSecret,
+    bool RequiresConfiguration,
+    string? Description);

--- a/src/api/src/HWInventory.Api/Models/ConnectorTestModels.cs
+++ b/src/api/src/HWInventory.Api/Models/ConnectorTestModels.cs
@@ -1,0 +1,5 @@
+namespace HWInventory.Api.Models;
+
+public record ConnectorTestRequestDto(string? Target);
+
+public record ConnectorTestResponse(bool Success, string Message, ConnectorSummaryResponse? Connector);

--- a/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/DictionaryEntryRequestDto.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Api.Models;
+
+public record DictionaryEntryRequestDto(
+    string DictType,
+    string Key,
+    string Value,
+    string? Description,
+    int Order);

--- a/src/api/src/HWInventory.Api/Models/ExportModels.cs
+++ b/src/api/src/HWInventory.Api/Models/ExportModels.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace HWInventory.Api.Models;
+
+public class ExportRequestDto
+{
+    public string Scope { get; set; } = "Servers";
+    public string Format { get; set; } = "Csv";
+    public string StoragePath { get; set; } = string.Empty;
+    public string? FilterJson { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+}
+
+public class ExportResponseDto
+{
+    public Guid Id { get; set; }
+    public string Scope { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string StoragePath { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public long? FileSizeBytes { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public DateTime? ExpiresAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public string? FailureReason { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+    public string? ArtifactPath { get; set; }
+}

--- a/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
+++ b/src/api/src/HWInventory.Api/Models/FeatureModuleToggleRequest.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record FeatureModuleToggleRequest(bool Enabled);

--- a/src/api/src/HWInventory.Api/Models/ImportModels.cs
+++ b/src/api/src/HWInventory.Api/Models/ImportModels.cs
@@ -1,0 +1,82 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Api.Models;
+
+public class QueueImportRequest
+{
+    [Required]
+    public ImportScope Scope { get; set; }
+
+    [Required]
+    public ImportFormat Format { get; set; }
+
+    [Required]
+    public ImportConflictStrategy ConflictStrategy { get; set; }
+
+    public bool DryRun { get; set; } = true;
+
+    [Required]
+    [StringLength(1024)]
+    public string StoragePath { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(256)]
+    public string FileName { get; set; } = string.Empty;
+
+    [Required]
+    public string ContentBase64 { get; set; } = string.Empty;
+
+    public bool SendEmail { get; set; }
+
+    [StringLength(512)]
+    public string? EmailRecipients { get; set; }
+
+    [StringLength(2048)]
+    public string? MappingJson { get; set; }
+}
+
+public record ImportJobResponse(
+    Guid Id,
+    string Scope,
+    string Format,
+    string Status,
+    string ConflictStrategy,
+    bool DryRun,
+    string StoragePath,
+    string OriginalFileName,
+    DateTime CreatedAtUtc,
+    DateTime? CompletedAtUtc,
+    string CreatedBy,
+    string? FailureReason,
+    long? ProcessedRows,
+    long? CreatedRows,
+    long? UpdatedRows,
+    long? SkippedRows,
+    string? ResultLog,
+    bool SendEmail,
+    string? EmailRecipients)
+{
+    public static ImportJobResponse FromModel(ImportJobModel model) => new(
+        model.Id,
+        model.Scope,
+        model.Format,
+        model.Status,
+        model.ConflictStrategy,
+        model.DryRun,
+        model.StoragePath,
+        model.OriginalFileName,
+        model.CreatedAtUtc,
+        model.CompletedAtUtc,
+        model.CreatedBy,
+        model.FailureReason,
+        model.ProcessedRows,
+        model.CreatedRows,
+        model.UpdatedRows,
+        model.SkippedRows,
+        model.ResultLog,
+        model.SendEmail,
+        model.EmailRecipients);
+}

--- a/src/api/src/HWInventory.Api/Models/MaintenanceModels.cs
+++ b/src/api/src/HWInventory.Api/Models/MaintenanceModels.cs
@@ -1,0 +1,91 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace HWInventory.Api.Models;
+
+public class BackupRequestDto
+{
+    [Required]
+    public string Scope { get; set; } = "Full";
+
+    [Required]
+    public string StoragePath { get; set; } = string.Empty;
+
+    public bool EncryptionEnabled { get; set; }
+
+    public string? Password { get; set; }
+
+    public string? PasswordConfirmation { get; set; }
+
+    public bool SendEmail { get; set; }
+
+    public string? EmailRecipients { get; set; }
+
+    public bool IntegrityCheckEnabled { get; set; } = true;
+}
+
+public class BackupResponseDto
+{
+    public Guid Id { get; set; }
+    public string Scope { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string StoragePath { get; set; } = string.Empty;
+    public bool EncryptionEnabled { get; set; }
+    public bool SendEmail { get; set; }
+    public bool IntegrityCheckEnabled { get; set; }
+    public bool IsAutomatic { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public long? FileSizeBytes { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public bool? IntegrityPassed { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public string? FailureReason { get; set; }
+}
+
+public class RestoreRequestDto
+{
+    public string? Password { get; set; }
+    public bool PerformIntegrityTest { get; set; }
+}
+
+public class IntegrityTestRequestDto
+{
+    public string? Password { get; set; }
+}
+
+public class BackupScheduleResponseDto
+{
+    public bool Enabled { get; set; }
+    public string Frequency { get; set; } = "Daily";
+    public int? DayOfWeek { get; set; }
+    public int? DayOfMonth { get; set; }
+    public string ExecutionTimeUtc { get; set; } = "01:00";
+    public string Scope { get; set; } = "Full";
+    public string StoragePath { get; set; } = string.Empty;
+    public bool EncryptionEnabled { get; set; }
+    public bool HasStoredPassword { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+    public bool IntegrityCheckEnabled { get; set; }
+    public DateTime? LastRunAtUtc { get; set; }
+    public DateTime? NextRunAtUtc { get; set; }
+}
+
+public class BackupScheduleRequestDto
+{
+    public bool Enabled { get; set; }
+    public string Frequency { get; set; } = "Daily";
+    public int? DayOfWeek { get; set; }
+    public int? DayOfMonth { get; set; }
+    public string ExecutionTimeUtc { get; set; } = "01:00";
+    public string Scope { get; set; } = "Full";
+    public string StoragePath { get; set; } = string.Empty;
+    public bool EncryptionEnabled { get; set; }
+    public string? Password { get; set; }
+    public string? PasswordConfirmation { get; set; }
+    public bool RotatePassword { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+    public bool IntegrityCheckEnabled { get; set; } = true;
+}

--- a/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkDeviceRequestDto.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkDeviceRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid DeviceTypeId,
+    string Manufacturer,
+    string Model,
+    Guid LocationId,
+    string? RackPosition,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
+++ b/src/api/src/HWInventory.Api/Models/NetworkEndpointDto.cs
@@ -1,0 +1,3 @@
+namespace HWInventory.Api.Models;
+
+public record NetworkEndpointDto(string Label, Guid? VlanId, string? IpAddress);

--- a/src/api/src/HWInventory.Api/Models/ObservabilityModels.cs
+++ b/src/api/src/HWInventory.Api/Models/ObservabilityModels.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HWInventory.Api.Models;
+
+public class ObservabilityConfigurationResponse
+{
+    public string LogLevel { get; set; } = "Information";
+    public bool HealthEndpointEnabled { get; set; }
+    public bool MetricsEndpointEnabled { get; set; }
+    public bool CorrelationIdsEnabled { get; set; }
+    public bool IncludeTraceIdentifier { get; set; }
+    public bool OtelExporterEnabled { get; set; }
+    public string? OtelEndpoint { get; set; }
+    public bool HasOtelAuthToken { get; set; }
+    public string? ResourceAttributes { get; set; }
+}
+
+public class ObservabilityConfigurationRequest
+{
+    [Required]
+    public string LogLevel { get; set; } = "Information";
+
+    public bool HealthEndpointEnabled { get; set; }
+
+    public bool MetricsEndpointEnabled { get; set; }
+
+    public bool CorrelationIdsEnabled { get; set; }
+
+    public bool IncludeTraceIdentifier { get; set; }
+
+    public bool OtelExporterEnabled { get; set; }
+
+    public string? OtelEndpoint { get; set; }
+
+    public string? OtelAuthToken { get; set; }
+
+    public bool RotateOtelAuthToken { get; set; }
+
+    public string? ResourceAttributes { get; set; }
+}

--- a/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/ServerRequestDto.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Api.Models;
+
+public record ServerRequestDto(
+    string Name,
+    string InventoryNumber,
+    string Manufacturer,
+    string Model,
+    Guid EnvironmentId,
+    Guid WsusPriorityId,
+    Guid OperatingSystemId,
+    Guid ServerRoleId,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    Guid LocationId,
+    string? RackPosition,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Models/UpdateModels.cs
+++ b/src/api/src/HWInventory.Api/Models/UpdateModels.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace HWInventory.Api.Models;
+
+public class UpdatePackageUploadRequest
+{
+    public IFormFile? Package { get; set; }
+    public string? Version { get; set; }
+    public bool PreserveDatabaseConfiguration { get; set; } = true;
+    public bool CreateBackupBeforeInstall { get; set; } = true;
+    public string? BackupStoragePath { get; set; }
+    public bool PerformIntegrityCheck { get; set; } = true;
+    public bool ConfirmedBackupAvailable { get; set; }
+    public string? Notes { get; set; }
+}
+
+public record UpdatePackageResponseDto(
+    Guid Id,
+    string Version,
+    string FileName,
+    string Status,
+    string Sha256,
+    bool PreserveDatabaseConfiguration,
+    bool CreateBackupBeforeInstall,
+    bool PerformIntegrityCheck,
+    bool ConfirmedBackupAvailable,
+    string? Notes,
+    DateTime CreatedAtUtc,
+    DateTime? CompletedAtUtc,
+    string CreatedBy,
+    string? FailureReason,
+    string? ManifestJson,
+    string? LogPath);

--- a/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
+++ b/src/api/src/HWInventory.Api/Models/WorkstationRequestDto.cs
@@ -1,0 +1,22 @@
+namespace HWInventory.Api.Models;
+
+public record WorkstationRequestDto(
+    string Name,
+    string InventoryNumber,
+    Guid OperatingSystemId,
+    Guid WorkstationTypeId,
+    Guid? OwnerId,
+    string? OwnerDisplayName,
+    string? OwnerDepartment,
+    Guid LocationId,
+    string? LocationNote,
+    string Cpu,
+    string Ram,
+    string Storage,
+    string MacAddress,
+    DateTime? PurchasedAt,
+    DateTime? SupportUntil,
+    Guid? PrimaryAdministratorId,
+    Guid? SecondaryAdministratorId,
+    string? Notes,
+    IReadOnlyCollection<NetworkEndpointDto> NetworkAssignments);

--- a/src/api/src/HWInventory.Api/Program.cs
+++ b/src/api/src/HWInventory.Api/Program.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Serialization;
+using HWInventory.Api.Middleware;
+using HWInventory.Application.Abstractions;
+using HWInventory.Infrastructure;
+using HWInventory.Infrastructure.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using QuestPDF.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+QuestPDF.Settings.License = LicenseType.Community;
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Logging.AddFilter((_, _, level) => level >= ObservabilityLogging.MinimumLevel);
+builder.Services.AddHealthChecks();
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status400BadRequest));
+    options.Filters.Add(new ProducesResponseTypeAttribute(typeof(ProblemDetails), StatusCodes.Status404NotFound));
+}).AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("default", policy =>
+    {
+        policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin();
+    });
+});
+
+var app = builder.Build();
+
+await app.InitializeDatabaseAsync();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors("default");
+app.UseRouting();
+app.UseCorrelationIds();
+app.UseRequestMetrics();
+app.UseAuthentication();
+app.UseSessionTracking();
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapGet("/health", async ([FromServices] IObservabilityRuntime runtime, CancellationToken cancellationToken) =>
+    {
+        var configuration = await runtime.GetAsync(cancellationToken);
+        if (!configuration.HealthEndpointEnabled)
+        {
+            return Results.StatusCode(StatusCodes.Status404NotFound);
+        }
+
+        return Results.Ok(new { status = "Healthy" });
+    })
+    .WithMetadata(new AllowAnonymousAttribute());
+
+app.MapGet("/metrics", async ([FromServices] IObservabilityRuntime runtime, [FromServices] IRequestMetricsCollector collector, CancellationToken cancellationToken) =>
+    {
+        var configuration = await runtime.GetAsync(cancellationToken);
+        if (!configuration.MetricsEndpointEnabled)
+        {
+            return Results.StatusCode(StatusCodes.Status404NotFound);
+        }
+
+        var snapshot = collector.ExportSnapshot();
+        return Results.Text(snapshot, "text/plain");
+    })
+    .WithMetadata(new AllowAnonymousAttribute());
+
+await app.RunAsync();

--- a/src/api/src/HWInventory.Api/appsettings.Development.json
+++ b/src/api/src/HWInventory.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/api/src/HWInventory.Api/appsettings.json
+++ b/src/api/src/HWInventory.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IAppDbContext.cs
@@ -1,0 +1,31 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IAppDbContext
+{
+    DbSet<Server> Servers { get; }
+    DbSet<NetworkDevice> NetworkDevices { get; }
+    DbSet<Workstation> Workstations { get; }
+    DbSet<DictionaryEntry> DictionaryEntries { get; }
+    DbSet<AuditLog> AuditLogs { get; }
+    DbSet<LabelTemplate> LabelTemplates { get; }
+    DbSet<LabelPrintJob> LabelPrintJobs { get; }
+    DbSet<AppUser> Users { get; }
+    DbSet<AppRole> Roles { get; }
+    DbSet<DataScope> DataScopes { get; }
+    DbSet<FeatureModule> FeatureModules { get; }
+    DbSet<AppSetting> Settings { get; }
+    DbSet<ConnectorProfile> ConnectorProfiles { get; }
+    DbSet<LdapRoleMapping> LdapRoleMappings { get; }
+    DbSet<UserSession> UserSessions { get; }
+    DbSet<PasswordResetToken> PasswordResetTokens { get; }
+    DbSet<PasswordHistoryEntry> PasswordHistoryEntries { get; }
+    DbSet<BackupJob> BackupJobs { get; }
+    DbSet<BackupSchedule> BackupSchedules { get; }
+    DbSet<ExportJob> ExportJobs { get; }
+    DbSet<ImportJob> ImportJobs { get; }
+    DbSet<UpdatePackage> UpdatePackages { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IBackupConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IBackupConfigurationStore.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IBackupConfigurationStore
+{
+    Task<BackupScheduleModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<BackupScheduleModel> SaveAsync(BackupScheduleUpdate update, CancellationToken cancellationToken = default);
+    Task<BackupScheduleTriggerResult> TryMarkTriggeredAsync(DateTime utcNow, CancellationToken cancellationToken = default);
+}
+
+public record BackupScheduleModel(
+    bool Enabled,
+    string Frequency,
+    int? DayOfWeek,
+    int? DayOfMonth,
+    TimeSpan ExecutionTimeUtc,
+    string Scope,
+    string StoragePath,
+    bool EncryptionEnabled,
+    bool HasStoredPassword,
+    bool SendEmail,
+    string? EmailRecipients,
+    bool IntegrityCheckEnabled,
+    DateTime? LastRunAtUtc,
+    DateTime? NextRunAtUtc);
+
+public record BackupScheduleUpdate(
+    bool Enabled,
+    string Frequency,
+    int? DayOfWeek,
+    int? DayOfMonth,
+    TimeSpan ExecutionTimeUtc,
+    string Scope,
+    string StoragePath,
+    bool EncryptionEnabled,
+    string? Password,
+    bool RotatePassword,
+    bool SendEmail,
+    string? EmailRecipients,
+    bool IntegrityCheckEnabled);
+
+public record BackupScheduleTriggerResult(bool Triggered, BackupScheduleModel? Schedule, string? ProtectedSecret);

--- a/src/api/src/HWInventory.Application/Abstractions/IBackupService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IBackupService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IBackupService
+{
+    Task<BackupJobModel> QueueBackupAsync(BackupRequest request, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<BackupJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default);
+    Task<BackupJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<RestoreResult> RestoreAsync(Guid jobId, RestoreRequest request, CancellationToken cancellationToken = default);
+    Task<IntegrityTestResult> TestIntegrityAsync(Guid jobId, string? password, CancellationToken cancellationToken = default);
+    Task QueueScheduledBackupIfDueAsync(CancellationToken cancellationToken = default);
+    Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default);
+}
+
+public record BackupRequest(
+    BackupScope Scope,
+    string StoragePath,
+    bool EncryptionEnabled,
+    string? Password,
+    string? ProtectedSecret,
+    bool SendEmail,
+    string? EmailRecipients,
+    bool IntegrityCheckEnabled,
+    bool IsAutomatic);
+
+public record RestoreRequest(string? Password, bool PerformIntegrityTest);
+
+public record BackupJobModel(
+    Guid Id,
+    string Scope,
+    string FileName,
+    string StoragePath,
+    bool EncryptionEnabled,
+    bool SendEmail,
+    bool IntegrityCheckEnabled,
+    bool IsAutomatic,
+    string Status,
+    long? FileSizeBytes,
+    DateTime? CompletedAtUtc,
+    bool? IntegrityPassed,
+    DateTime CreatedAtUtc,
+    string CreatedBy,
+    string? FailureReason);
+
+public record RestoreResult(bool Success, string Message);
+
+public record IntegrityTestResult(bool Success, string Message, bool? Passed);

--- a/src/api/src/HWInventory.Application/Abstractions/ICaptchaConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ICaptchaConfigurationStore.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ICaptchaConfigurationStore
+{
+    Task<CaptchaConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<CaptchaConfigurationModel> SaveAsync(CaptchaConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record CaptchaConfigurationModel(
+    bool Enabled,
+    string SiteKey,
+    bool HasSecret,
+    string VerificationEndpoint,
+    string? BypassToken);
+
+public record CaptchaConfigurationUpdate(
+    bool Enabled,
+    string SiteKey,
+    string? Secret,
+    bool RotateSecret,
+    string VerificationEndpoint,
+    string? BypassToken);

--- a/src/api/src/HWInventory.Application/Abstractions/ICaptchaValidator.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ICaptchaValidator.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ICaptchaValidator
+{
+    Task<bool> ValidateAsync(string token, CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IConnectorCatalogService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IConnectorCatalogService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IConnectorCatalogService
+{
+    Task<IReadOnlyCollection<ConnectorSummary>> GetAsync(CancellationToken cancellationToken = default);
+    Task<ConnectorSummary?> ToggleAsync(Guid connectorId, bool enabled, CancellationToken cancellationToken = default);
+    Task<ConnectorSummary?> RotateSecretsAsync(Guid connectorId, CancellationToken cancellationToken = default);
+    Task<ConnectorTestOutcome> TestAsync(Guid connectorId, ConnectorTestRequest request, CancellationToken cancellationToken = default);
+}
+
+public record ConnectorSummary(
+    Guid? Id,
+    string Key,
+    string Type,
+    string Name,
+    bool Enabled,
+    string? HealthStatus,
+    DateTime? LastTestedAtUtc,
+    bool HasSecret,
+    bool SupportsToggle,
+    bool SupportsTest,
+    bool SupportsRotateSecret,
+    bool RequiresConfiguration,
+    string? Description);
+
+public record ConnectorTestRequest(string? Target);
+
+public record ConnectorTestOutcome(ConnectorTestResult Result, ConnectorSummary? Summary);
+
+public record ConnectorTestResult(bool Success, string Message);

--- a/src/api/src/HWInventory.Application/Abstractions/IEmailConnectorStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IEmailConnectorStore.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IEmailConnectorStore
+{
+    Task<EmailConnectorModel?> GetAsync(CancellationToken cancellationToken = default);
+    Task<EmailConnectorModel> SaveAsync(EmailConnectorUpdate update, CancellationToken cancellationToken = default);
+    Task<EmailTestResult> SendTestAsync(EmailTestRequest request, CancellationToken cancellationToken = default);
+}
+
+public record EmailConnectorModel(
+    Guid Id,
+    string Alias,
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseTls,
+    string? Username,
+    bool HasPassword,
+    string? FromAddress,
+    string? ReplyToAddress,
+    string? HealthStatus,
+    DateTime? LastTestedAtUtc);
+
+public record EmailConnectorUpdate(
+    string Alias,
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseTls,
+    string? Username,
+    string? FromAddress,
+    string? ReplyToAddress,
+    bool RotateSecret,
+    string? Password);
+
+public record EmailTestRequest(string Recipient, string Subject, string Body);
+
+public record EmailTestResult(bool Success, string Message);

--- a/src/api/src/HWInventory.Application/Abstractions/IExportService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IExportService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IExportService
+{
+    Task<ExportJobModel> QueueExportAsync(ExportRequest request, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ExportJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default);
+    Task<ExportJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default);
+}
+
+public record ExportRequest(
+    ExportScope Scope,
+    ExportFormat Format,
+    string StoragePath,
+    string? FilterJson,
+    bool SendEmail,
+    string? EmailRecipients);
+
+public record ExportJobModel(
+    Guid Id,
+    string Scope,
+    string Format,
+    string StoragePath,
+    string FileName,
+    string Status,
+    long? FileSizeBytes,
+    DateTime CreatedAtUtc,
+    DateTime? CompletedAtUtc,
+    DateTime? ExpiresAtUtc,
+    string CreatedBy,
+    string? FailureReason,
+    bool SendEmail,
+    string? EmailRecipients,
+    string? ArtifactPath);

--- a/src/api/src/HWInventory.Application/Abstractions/IExternalIdentityService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IExternalIdentityService.cs
@@ -1,0 +1,17 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface IExternalIdentityService
+{
+    Task ConfigureOidcAsync(OidcConfiguration configuration, CancellationToken cancellationToken = default);
+    Task<OidcConfiguration?> GetConfigurationAsync(CancellationToken cancellationToken = default);
+}
+
+public record OidcConfiguration(
+    bool Enabled,
+    string Authority,
+    string ClientId,
+    string? ClientSecret,
+    string? ResponseType,
+    IReadOnlyCollection<string> Scopes,
+    IReadOnlyDictionary<string, string> ClaimMappings,
+    bool UsePkce);

--- a/src/api/src/HWInventory.Application/Abstractions/IImportService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IImportService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IImportService
+{
+    Task<ImportJobModel> QueueImportAsync(ImportRequest request, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ImportJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default);
+    Task<ImportJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default);
+}
+
+public record ImportRequest(
+    ImportScope Scope,
+    ImportFormat Format,
+    ImportConflictStrategy ConflictStrategy,
+    bool DryRun,
+    string StoragePath,
+    string FileName,
+    string ContentBase64,
+    bool SendEmail,
+    string? EmailRecipients,
+    string? MappingJson);
+
+public record ImportJobModel(
+    Guid Id,
+    string Scope,
+    string Format,
+    string Status,
+    string ConflictStrategy,
+    bool DryRun,
+    string StoragePath,
+    string OriginalFileName,
+    DateTime CreatedAtUtc,
+    DateTime? CompletedAtUtc,
+    string CreatedBy,
+    string? FailureReason,
+    long? ProcessedRows,
+    long? CreatedRows,
+    long? UpdatedRows,
+    long? SkippedRows,
+    string? ResultLog,
+    bool SendEmail,
+    string? EmailRecipients);

--- a/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILabelRenderingService.cs
@@ -1,0 +1,9 @@
+using HWInventory.Domain.Entities;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ILabelRenderingService
+{
+    string RenderZpl(LabelTemplate template, IDictionary<string, string> data);
+    byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ILdapConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILdapConfigurationStore.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ILdapConfigurationStore
+{
+    Task<LdapConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<LdapConfigurationModel> SaveAsync(LdapConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record LdapConfigurationModel(
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    bool HasPassword,
+    bool IgnoreCertificateErrors,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap);
+
+public record LdapConfigurationUpdate(
+    bool Enabled,
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    string? Password,
+    bool ResetPassword,
+    bool IgnoreCertificateErrors,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap);

--- a/src/api/src/HWInventory.Application/Abstractions/ILdapSyncService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ILdapSyncService.cs
@@ -1,0 +1,32 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ILdapSyncService
+{
+    Task<LdapConnectionTestResult> TestConnectionAsync(LdapConnectionOptions options, CancellationToken cancellationToken = default);
+    Task<LdapDryRunResult> DryRunAsync(LdapDryRunRequest request, CancellationToken cancellationToken = default);
+}
+
+public record LdapConnectionOptions(
+    string Host,
+    int Port,
+    bool UseSsl,
+    string BindDn,
+    string? Password,
+    bool IgnoreCertificateErrors);
+
+public record LdapDryRunRequest(
+    LdapConnectionOptions Connection,
+    string UsersBaseDn,
+    string? UsersFilter,
+    IReadOnlyCollection<string> AttributeMap,
+    int ResultLimit);
+
+public record LdapConnectionTestResult(bool Success, string Message, IReadOnlyDictionary<string, string>? Diagnostics);
+
+public record LdapDryRunResult(
+    IReadOnlyCollection<LdapDryRunUser> Users,
+    int ResultCount,
+    bool Truncated,
+    string? Notes);
+
+public record LdapDryRunUser(string DistinguishedName, IReadOnlyDictionary<string, string?> Attributes);

--- a/src/api/src/HWInventory.Application/Abstractions/IObservabilityConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IObservabilityConfigurationStore.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IObservabilityConfigurationStore
+{
+    Task<ObservabilityConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<ObservabilityConfigurationModel> SaveAsync(ObservabilityConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record ObservabilityConfigurationModel(
+    string LogLevel,
+    bool HealthEndpointEnabled,
+    bool MetricsEndpointEnabled,
+    bool CorrelationIdsEnabled,
+    bool IncludeTraceIdentifier,
+    bool OtelExporterEnabled,
+    string? OtelEndpoint,
+    bool HasOtelAuthToken,
+    string? ResourceAttributes);
+
+public record ObservabilityConfigurationUpdate(
+    string LogLevel,
+    bool HealthEndpointEnabled,
+    bool MetricsEndpointEnabled,
+    bool CorrelationIdsEnabled,
+    bool IncludeTraceIdentifier,
+    bool OtelExporterEnabled,
+    string? OtelEndpoint,
+    string? OtelAuthToken,
+    bool RotateOtelAuthToken,
+    string? ResourceAttributes);

--- a/src/api/src/HWInventory.Application/Abstractions/IObservabilityRuntime.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IObservabilityRuntime.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IObservabilityRuntime
+{
+    Task<ObservabilityConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    void Invalidate();
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IPasswordHistoryService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IPasswordHistoryService.cs
@@ -1,0 +1,10 @@
+using HWInventory.Domain.Entities;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IPasswordHistoryService
+{
+    Task RecordAsync(AppUser user, CancellationToken cancellationToken = default);
+
+    Task<bool> IsReusedAsync(AppUser user, string password, CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IPasswordPolicyConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IPasswordPolicyConfigurationStore.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IPasswordPolicyConfigurationStore
+{
+    Task<PasswordPolicyModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<PasswordPolicyModel> SaveAsync(PasswordPolicyUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record PasswordPolicyModel(
+    bool Enabled,
+    int MinimumLength,
+    bool RequireUppercase,
+    bool RequireLowercase,
+    bool RequireDigit,
+    bool RequireNonAlphanumeric,
+    int ExpirationDays,
+    int HistoryCount,
+    int LockoutAttempts,
+    int LockoutDurationMinutes);
+
+public record PasswordPolicyUpdate(
+    bool Enabled,
+    int MinimumLength,
+    bool RequireUppercase,
+    bool RequireLowercase,
+    bool RequireDigit,
+    bool RequireNonAlphanumeric,
+    int ExpirationDays,
+    int HistoryCount,
+    int LockoutAttempts,
+    int LockoutDurationMinutes);

--- a/src/api/src/HWInventory.Application/Abstractions/IRequestMetricsCollector.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IRequestMetricsCollector.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IRequestMetricsCollector
+{
+    void IncrementActive();
+    void Record(string method, int statusCode, TimeSpan duration);
+    string ExportSnapshot();
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ISecretProtector.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISecretProtector.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISecretProtector
+{
+    string Protect(string secret);
+    string Unprotect(string protectedSecret);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ISessionTracker.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISessionTracker.cs
@@ -1,0 +1,14 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISessionTracker
+{
+    Task<UserSessionDto> RegisterAsync(RegisterSessionRequest request, CancellationToken cancellationToken = default);
+    Task<bool> TouchAsync(string sessionIdentifier, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<UserSessionDto>> GetActiveSessionsAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task RevokeAsync(Guid sessionId, string performedBy, string? reason, CancellationToken cancellationToken = default);
+    Task RevokeAllAsync(Guid userId, string performedBy, CancellationToken cancellationToken = default);
+}
+
+public record RegisterSessionRequest(Guid UserId, string SessionIdentifier, string PerformedBy, string? IpAddress, string? UserAgent);
+
+public record UserSessionDto(Guid Id, string SessionIdentifier, DateTime IssuedAtUtc, DateTime LastSeenAtUtc, string? IpAddress, string? UserAgent, bool IsRevoked);

--- a/src/api/src/HWInventory.Application/Abstractions/ISmsConnectorStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISmsConnectorStore.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ISmsConnectorStore
+{
+    Task<SmsConnectorModel?> GetAsync(CancellationToken cancellationToken = default);
+    Task<SmsConnectorModel> SaveAsync(SmsConnectorUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record SmsConnectorModel(
+    Guid? Id,
+    string Alias,
+    bool Enabled,
+    string Endpoint,
+    string? Sender,
+    string? Region,
+    bool HasSecret,
+    string? HealthStatus,
+    DateTime? LastTestedAtUtc);
+
+public record SmsConnectorUpdate(
+    string Alias,
+    bool Enabled,
+    string Endpoint,
+    string? Sender,
+    string? Region,
+    string? Secret,
+    bool RotateSecret);

--- a/src/api/src/HWInventory.Application/Abstractions/ISmsGateway.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISmsGateway.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISmsGateway
+{
+    Task SendAsync(string destination, string message, CancellationToken cancellationToken = default);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/ISsprConfigurationStore.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISsprConfigurationStore.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface ISsprConfigurationStore
+{
+    Task<SsprConfigurationModel> GetAsync(CancellationToken cancellationToken = default);
+    Task<SsprConfigurationModel> SaveAsync(SsprConfigurationUpdate update, CancellationToken cancellationToken = default);
+}
+
+public record SsprConfigurationModel(
+    bool Enabled,
+    bool RequireTwoFactor,
+    bool RequireCaptcha,
+    bool RequireSmsOtp,
+    int TokenExpiryMinutes,
+    int ThrottleWindowMinutes,
+    int MaxRequestsPerWindow,
+    string? SmsConnectorKey);
+
+public record SsprConfigurationUpdate(
+    bool Enabled,
+    bool RequireTwoFactor,
+    bool RequireCaptcha,
+    bool RequireSmsOtp,
+    int TokenExpiryMinutes,
+    int ThrottleWindowMinutes,
+    int MaxRequestsPerWindow,
+    string? SmsConnectorKey);

--- a/src/api/src/HWInventory.Application/Abstractions/ISsprService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ISsprService.cs
@@ -1,0 +1,24 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ISsprService
+{
+    Task<PasswordResetRequestResult> RequestResetAsync(PasswordResetRequest request, CancellationToken cancellationToken = default);
+    Task<PasswordResetCompletionResult> CompleteResetAsync(PasswordResetCompletionRequest request, CancellationToken cancellationToken = default);
+}
+
+public record PasswordResetRequest(
+    string UsernameOrEmail,
+    string CaptchaToken,
+    string DeliveryMethod,
+    string? DeliveryDestination,
+    bool RequireSmsOtp);
+
+public record PasswordResetRequestResult(bool Success, string Message, Guid? Token, bool SmsOtpIssued);
+
+public record PasswordResetCompletionRequest(
+    Guid Token,
+    string CaptchaToken,
+    string? SmsCode,
+    string NewPassword);
+
+public record PasswordResetCompletionResult(bool Success, string Message);

--- a/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/ITotpService.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Abstractions;
+
+public interface ITotpService
+{
+    string GenerateSecretKey();
+    string GenerateCode(string secretKey);
+    bool ValidateCode(string secretKey, string code);
+}

--- a/src/api/src/HWInventory.Application/Abstractions/IUpdateService.cs
+++ b/src/api/src/HWInventory.Application/Abstractions/IUpdateService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HWInventory.Application.Abstractions;
+
+public interface IUpdateService
+{
+    Task<UpdatePackageModel> QueuePackageAsync(UpdatePackageRequest request, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<UpdatePackageModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default);
+    Task<UpdatePackageModel?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<byte[]?> GetLogAsync(Guid id, CancellationToken cancellationToken = default);
+    Task ProcessPendingPackagesAsync(CancellationToken cancellationToken = default);
+}
+
+public record UpdatePackageRequest(
+    string FileName,
+    string StoragePath,
+    string ContentBase64,
+    string? Version,
+    bool PreserveDatabaseConfiguration,
+    bool CreateBackupBeforeInstall,
+    string? BackupStoragePath,
+    bool PerformIntegrityCheck,
+    bool ConfirmedBackupAvailable,
+    string? Notes);
+
+public record UpdatePackageModel(
+    Guid Id,
+    string Version,
+    string FileName,
+    string Status,
+    string Sha256,
+    string StoragePath,
+    string StagingPath,
+    bool PreserveDatabaseConfiguration,
+    bool CreateBackupBeforeInstall,
+    bool PerformIntegrityCheck,
+    bool ConfirmedBackupAvailable,
+    string? Notes,
+    DateTime CreatedAtUtc,
+    DateTime? CompletedAtUtc,
+    string CreatedBy,
+    string? FailureReason,
+    string? ManifestJson,
+    string? LogPath);

--- a/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
+++ b/src/api/src/HWInventory.Application/Common/FilterDescriptor.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Application.Common;
+
+public class FilterDescriptor
+{
+    public string Field { get; init; } = string.Empty;
+    public string Operator { get; init; } = string.Empty;
+    public string? Value { get; init; }
+}

--- a/src/api/src/HWInventory.Application/Common/PagedResult.cs
+++ b/src/api/src/HWInventory.Application/Common/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Application.Common;
+
+public class PagedResult<T>
+{
+    public IReadOnlyCollection<T> Items { get; init; } = Array.Empty<T>();
+    public int TotalCount { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/api/src/HWInventory.Application/HWInventory.Application.csproj
+++ b/src/api/src/HWInventory.Application/HWInventory.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Entities/AppRole.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppRole.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppRole : IdentityRole<Guid>
+{
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppSetting.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class AppSetting : AuditableEntity
+{
+    public string Section { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public bool IsSecret { get; set; }
+    public bool IsMasked => IsSecret && !string.IsNullOrEmpty(Value);
+}

--- a/src/api/src/HWInventory.Domain/Entities/AppUser.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AppUser.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Domain.Entities;
+
+public class AppUser : IdentityUser<Guid>
+{
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsDomainAccount { get; set; }
+    public bool TwoFactorRequired { get; set; }
+    public string? Department { get; set; }
+    public string? AuthenticatorKey { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+    public ICollection<DataScope> DataScopes { get; set; } = new List<DataScope>();
+    public ICollection<UserSession> Sessions { get; set; } = new List<UserSession>();
+    public ICollection<PasswordResetToken> PasswordResetTokens { get; set; } = new List<PasswordResetToken>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+namespace HWInventory.Domain.Entities;
+
+public class AuditLog : BaseEntity
+{
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string PerformedBy { get; set; } = string.Empty;
+    public string? Roles { get; set; }
+    public DateTime PerformedAtUtc { get; set; }
+    public string? ChangeSummary { get; set; }
+    public string? ChangedFieldsJson { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/AuditableEntity.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAtUtc { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime? ModifiedAtUtc { get; set; }
+    public string? ModifiedBy { get; set; }
+    public EntityStatus Status { get; set; } = EntityStatus.Active;
+}

--- a/src/api/src/HWInventory.Domain/Entities/BackupJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BackupJob.cs
@@ -1,0 +1,24 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class BackupJob : AuditableEntity
+{
+    public BackupScope Scope { get; set; }
+    public bool IncludeDictionariesOnly => Scope == BackupScope.Dictionaries;
+    public string StoragePath { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public bool EncryptionEnabled { get; set; }
+    public string? ProtectedEncryptionSecret { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+    public bool IntegrityCheckEnabled { get; set; }
+    public BackupJobStatus JobStatus { get; set; } = BackupJobStatus.Pending;
+    public long? FileSizeBytes { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public bool? IntegrityPassed { get; set; }
+    public DateTime? IntegrityCheckedAtUtc { get; set; }
+    public string? ArtifactPath { get; set; }
+    public string? FailureReason { get; set; }
+    public bool IsAutomatic { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/BackupSchedule.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BackupSchedule.cs
@@ -1,0 +1,19 @@
+namespace HWInventory.Domain.Entities;
+
+public class BackupSchedule : BaseEntity
+{
+    public bool Enabled { get; set; }
+    public string Frequency { get; set; } = "Daily";
+    public int? DayOfWeek { get; set; }
+    public int? DayOfMonth { get; set; }
+    public TimeSpan ExecutionTimeUtc { get; set; } = TimeSpan.FromHours(1);
+    public string Scope { get; set; } = "Full";
+    public string StoragePath { get; set; } = string.Empty;
+    public bool EncryptionEnabled { get; set; }
+    public string? ProtectedEncryptionSecret { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+    public bool IntegrityCheckEnabled { get; set; }
+    public DateTime? LastRunAtUtc { get; set; }
+    public DateTime? NextRunAtUtc { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
+++ b/src/api/src/HWInventory.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,6 @@
+namespace HWInventory.Domain.Entities;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorProfile.cs
@@ -1,0 +1,12 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorProfile : AuditableEntity
+{
+    public string Type { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public bool Enabled { get; set; }
+    public string? ConfigurationJson { get; set; }
+    public string? HealthStatus { get; set; }
+    public DateTime? LastTestedAtUtc { get; set; }
+    public ICollection<ConnectorSecret> Secrets { get; set; } = new List<ConnectorSecret>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ConnectorSecret.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class ConnectorSecret : BaseEntity
+{
+    public Guid ConnectorProfileId { get; set; }
+    public ConnectorProfile ConnectorProfile { get; set; } = default!;
+    public string Key { get; set; } = string.Empty;
+    public string SecretReference { get; set; } = string.Empty;
+    public DateTime? RotatedAtUtc { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/DataScope.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DataScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class DataScope : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid? LocationId { get; set; }
+    public string? DepartmentKey { get; set; }
+    public string ScopeType { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
+++ b/src/api/src/HWInventory.Domain/Entities/DictionaryEntry.cs
@@ -1,0 +1,12 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class DictionaryEntry : AuditableEntity
+{
+    public string DictType { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public int Order { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/ExportJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ExportJob.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class ExportJob : AuditableEntity
+{
+    public ExportScope Scope { get; set; }
+    public ExportFormat Format { get; set; }
+    public string StoragePath { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string? FilterJson { get; set; }
+    public ExportJobStatus JobStatus { get; set; } = ExportJobStatus.Pending;
+    public long? FileSizeBytes { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public DateTime? ExpiresAtUtc { get; set; }
+    public string? FailureReason { get; set; }
+    public string? ArtifactPath { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
+++ b/src/api/src/HWInventory.Domain/Entities/FeatureModule.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class FeatureModule : AuditableEntity
+{
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public bool Enabled { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/ImportJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/ImportJob.cs
@@ -1,0 +1,25 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class ImportJob : AuditableEntity
+{
+    public ImportScope Scope { get; set; }
+    public ImportFormat Format { get; set; }
+    public ImportJobStatus JobStatus { get; set; } = ImportJobStatus.Pending;
+    public ImportConflictStrategy ConflictStrategy { get; set; } = ImportConflictStrategy.Skip;
+    public bool DryRun { get; set; }
+    public string StoragePath { get; set; } = string.Empty;
+    public string OriginalFileName { get; set; } = string.Empty;
+    public string StoredFilePath { get; set; } = string.Empty;
+    public string? MappingJson { get; set; }
+    public string? ResultLog { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public string? FailureReason { get; set; }
+    public long? ProcessedRows { get; set; }
+    public long? CreatedRows { get; set; }
+    public long? UpdatedRows { get; set; }
+    public long? SkippedRows { get; set; }
+    public bool SendEmail { get; set; }
+    public string? EmailRecipients { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJob.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJob : AuditableEntity
+{
+    public string Target { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string JobStatus { get; set; } = "Pending";
+    public string? ArtifactPath { get; set; }
+    public ICollection<LabelPrintJobItem> Items { get; set; } = new List<LabelPrintJobItem>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelPrintJobItem.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelPrintJobItem : BaseEntity
+{
+    public Guid LabelPrintJobId { get; set; }
+    public Guid AssetId { get; set; }
+    public string AssetType { get; set; } = string.Empty;
+    public int Copies { get; set; } = 1;
+}

--- a/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LabelTemplate.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Entities;
+
+public class LabelTemplate : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Format { get; set; } = "ZPL";
+    public string Payload { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/LdapRoleMapping.cs
+++ b/src/api/src/HWInventory.Domain/Entities/LdapRoleMapping.cs
@@ -1,0 +1,9 @@
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class LdapRoleMapping : AuditableEntity
+{
+    public string GroupName { get; set; } = string.Empty;
+    public string RoleName { get; set; } = SystemRoleNames.AppAdmin;
+}

--- a/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
+++ b/src/api/src/HWInventory.Domain/Entities/NetworkDevice.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class NetworkDevice : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid DeviceTypeId { get; set; }
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/PasswordHistoryEntry.cs
+++ b/src/api/src/HWInventory.Domain/Entities/PasswordHistoryEntry.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace HWInventory.Domain.Entities;
+
+public class PasswordHistoryEntry : BaseEntity
+{
+    public Guid UserId { get; set; }
+
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+        = DateTime.UtcNow;
+
+    public AppUser? User { get; set; }
+        = null!;
+}

--- a/src/api/src/HWInventory.Domain/Entities/PasswordResetToken.cs
+++ b/src/api/src/HWInventory.Domain/Entities/PasswordResetToken.cs
@@ -1,0 +1,17 @@
+namespace HWInventory.Domain.Entities;
+
+public class PasswordResetToken : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public Guid Token { get; set; }
+    public string DeliveryMethod { get; set; } = string.Empty;
+    public string? DeliveryAddress { get; set; }
+    public DateTime ExpiresAtUtc { get; set; }
+    public DateTime? ConsumedAtUtc { get; set; }
+    public string? CaptchaToken { get; set; }
+    public string IdentityToken { get; set; } = string.Empty;
+    public string? SmsCodeHash { get; set; }
+    public bool RequiresSmsVerification { get; set; }
+    public string Status { get; set; } = string.Empty;
+}

--- a/src/api/src/HWInventory.Domain/Entities/Server.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Server.cs
@@ -1,0 +1,24 @@
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Server : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public Guid EnvironmentId { get; set; }
+    public Guid WsusPriorityId { get; set; }
+    public Guid OperatingSystemId { get; set; }
+    public Guid ServerRoleId { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public Guid LocationId { get; set; }
+    public string? RackPosition { get; set; }
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Entities/UpdatePackage.cs
+++ b/src/api/src/HWInventory.Domain/Entities/UpdatePackage.cs
@@ -1,0 +1,24 @@
+using System;
+using HWInventory.Domain.Enums;
+
+namespace HWInventory.Domain.Entities;
+
+public class UpdatePackage : AuditableEntity
+{
+    public string Version { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string StoredPath { get; set; } = string.Empty;
+    public string StagingPath { get; set; } = string.Empty;
+    public string Sha256 { get; set; } = string.Empty;
+    public string? ManifestJson { get; set; }
+    public UpdatePackageStatus UpdateStatus { get; set; } = UpdatePackageStatus.Pending;
+    public bool PreserveDatabaseConfiguration { get; set; }
+    public bool CreateBackupBeforeInstall { get; set; }
+    public string? BackupStoragePath { get; set; }
+    public bool PerformIntegrityCheck { get; set; }
+    public bool ConfirmedBackupAvailable { get; set; }
+    public string? Notes { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public string? FailureReason { get; set; }
+    public string? LogPath { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/UserSession.cs
+++ b/src/api/src/HWInventory.Domain/Entities/UserSession.cs
@@ -1,0 +1,16 @@
+namespace HWInventory.Domain.Entities;
+
+public class UserSession : AuditableEntity
+{
+    public Guid AppUserId { get; set; }
+    public AppUser AppUser { get; set; } = default!;
+    public string SessionIdentifier { get; set; } = string.Empty;
+    public DateTime IssuedAtUtc { get; set; }
+    public DateTime LastSeenAtUtc { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+    public bool IsRevoked { get; set; }
+    public DateTime? RevokedAtUtc { get; set; }
+    public string? RevokedBy { get; set; }
+    public string? TerminationReason { get; set; }
+}

--- a/src/api/src/HWInventory.Domain/Entities/Workstation.cs
+++ b/src/api/src/HWInventory.Domain/Entities/Workstation.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.ValueObjects;
+
+namespace HWInventory.Domain.Entities;
+
+public class Workstation : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string InventoryNumber { get; set; } = string.Empty;
+    public Guid OperatingSystemId { get; set; }
+    public Guid WorkstationTypeId { get; set; }
+    public Guid? OwnerId { get; set; }
+    public string? OwnerDisplayName { get; set; }
+    public string? OwnerDepartment { get; set; }
+    public Guid LocationId { get; set; }
+    public string? LocationNote { get; set; }
+    public string Cpu { get; set; } = string.Empty;
+    public string Ram { get; set; } = string.Empty;
+    public string Storage { get; set; } = string.Empty;
+    public string MacAddress { get; set; } = string.Empty;
+    public DateTime? PurchasedAt { get; set; }
+    public DateTime? SupportUntil { get; set; }
+    public Guid? PrimaryAdministratorId { get; set; }
+    public Guid? SecondaryAdministratorId { get; set; }
+    public string? Notes { get; set; }
+    public ICollection<NetworkEndpoint> NetworkAssignments { get; set; } = new List<NetworkEndpoint>();
+}

--- a/src/api/src/HWInventory.Domain/Enums/BackupJobStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/BackupJobStatus.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Enums;
+
+public enum BackupJobStatus
+{
+    Pending = 0,
+    Running = 1,
+    Completed = 2,
+    Failed = 3
+}

--- a/src/api/src/HWInventory.Domain/Enums/BackupScope.cs
+++ b/src/api/src/HWInventory.Domain/Enums/BackupScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Enums;
+
+public enum BackupScope
+{
+    Full = 0,
+    Servers = 1,
+    NetworkDevices = 2,
+    Workstations = 3,
+    Dictionaries = 4
+}

--- a/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/EntityStatus.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum EntityStatus
+{
+    Active = 1,
+    Retired = 2
+}

--- a/src/api/src/HWInventory.Domain/Enums/ExportFormat.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ExportFormat.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ExportFormat
+{
+    Csv = 0,
+    Xlsx = 1
+}

--- a/src/api/src/HWInventory.Domain/Enums/ExportJobStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ExportJobStatus.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ExportJobStatus
+{
+    Pending = 0,
+    Running = 1,
+    Completed = 2,
+    Failed = 3,
+    Expired = 4
+}

--- a/src/api/src/HWInventory.Domain/Enums/ExportScope.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ExportScope.cs
@@ -1,0 +1,10 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ExportScope
+{
+    Servers = 0,
+    NetworkDevices = 1,
+    Workstations = 2,
+    Dictionaries = 3,
+    AuditLogs = 4
+}

--- a/src/api/src/HWInventory.Domain/Enums/ImportConflictStrategy.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ImportConflictStrategy.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ImportConflictStrategy
+{
+    Skip = 1,
+    Update = 2,
+    CreateNew = 3
+}

--- a/src/api/src/HWInventory.Domain/Enums/ImportFormat.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ImportFormat.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ImportFormat
+{
+    Csv = 1,
+    Xlsx = 2
+}

--- a/src/api/src/HWInventory.Domain/Enums/ImportJobStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ImportJobStatus.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ImportJobStatus
+{
+    Pending = 1,
+    Running = 2,
+    Completed = 3,
+    Failed = 4
+}

--- a/src/api/src/HWInventory.Domain/Enums/ImportScope.cs
+++ b/src/api/src/HWInventory.Domain/Enums/ImportScope.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Enums;
+
+public enum ImportScope
+{
+    Servers = 1,
+    NetworkDevices = 2,
+    Workstations = 3,
+    Dictionaries = 4
+}

--- a/src/api/src/HWInventory.Domain/Enums/PasswordResetStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/PasswordResetStatus.cs
@@ -1,0 +1,9 @@
+namespace HWInventory.Domain.Enums;
+
+public static class PasswordResetStatus
+{
+    public const string Pending = "Pending";
+    public const string Completed = "Completed";
+    public const string Expired = "Expired";
+    public const string Revoked = "Revoked";
+}

--- a/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
+++ b/src/api/src/HWInventory.Domain/Enums/SystemRoleNames.cs
@@ -1,0 +1,11 @@
+namespace HWInventory.Domain.Enums;
+
+public static class SystemRoleNames
+{
+    public const string SuperAdmin = "SuperAdmin";
+    public const string ServerAdmin = "SRV Administrator";
+    public const string NetworkAdmin = "NET Administrator";
+    public const string AppAdmin = "Aplikační admin";
+    public const string Helpdesk = "Helpdesk";
+    public const string HelpdeskRead = "Helpdesk Read";
+}

--- a/src/api/src/HWInventory.Domain/Enums/UpdatePackageStatus.cs
+++ b/src/api/src/HWInventory.Domain/Enums/UpdatePackageStatus.cs
@@ -1,0 +1,11 @@
+namespace HWInventory.Domain.Enums;
+
+public enum UpdatePackageStatus
+{
+    Pending = 0,
+    Validating = 1,
+    Running = 2,
+    Completed = 3,
+    Failed = 4,
+    Cancelled = 5
+}

--- a/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
+++ b/src/api/src/HWInventory.Domain/HWInventory.Domain.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
+++ b/src/api/src/HWInventory.Domain/Security/AuthorizationPolicies.cs
@@ -1,0 +1,25 @@
+namespace HWInventory.Domain.Security;
+
+public static class AuthorizationPolicies
+{
+    public const string ServersRead = "Servers.Read";
+    public const string ServersManage = "Servers.Manage";
+
+    public const string NetworkRead = "Network.Read";
+    public const string NetworkManage = "Network.Manage";
+
+    public const string WorkstationsRead = "Workstations.Read";
+    public const string WorkstationsManage = "Workstations.Manage";
+
+    public const string DictionariesManage = "Dictionaries.Manage";
+    public const string AuditRead = "Audit.Read";
+    public const string LabelsManage = "Labels.Manage";
+    public const string ModulesManage = "Modules.Manage";
+    public const string DashboardView = "Dashboard.View";
+    public const string SecurityManage = "Security.Manage";
+    public const string SessionsManage = "Security.Sessions.Manage";
+    public const string ObservabilityManage = "Observability.Manage";
+    public const string MaintenanceManage = "Maintenance.Manage";
+    public const string UpdatesManage = "Updates.Manage";
+    public const string ImportExportManage = "ImportExport.Manage";
+}

--- a/src/api/src/HWInventory.Domain/Security/DataScopeTypes.cs
+++ b/src/api/src/HWInventory.Domain/Security/DataScopeTypes.cs
@@ -1,0 +1,7 @@
+namespace HWInventory.Domain.Security;
+
+public static class DataScopeTypes
+{
+    public const string Location = "Location";
+    public const string Department = "Department";
+}

--- a/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
+++ b/src/api/src/HWInventory.Domain/ValueObjects/NetworkEndpoint.cs
@@ -1,0 +1,8 @@
+namespace HWInventory.Domain.ValueObjects;
+
+public class NetworkEndpoint
+{
+    public string Label { get; set; } = string.Empty;
+    public Guid? VlanId { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/src/api/src/HWInventory.Infrastructure/Connectors/ConnectorCatalogService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Connectors/ConnectorCatalogService.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Connectors;
+
+public class ConnectorCatalogService : IConnectorCatalogService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IAppDbContext _dbContext;
+    private readonly IEmailConnectorStore _emailConnectorStore;
+    private readonly ILdapConfigurationStore _ldapConfigurationStore;
+    private readonly IExternalIdentityService _externalIdentityService;
+    private readonly ISmsGateway _smsGateway;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ConnectorCatalogService> _logger;
+
+    public ConnectorCatalogService(
+        IAppDbContext dbContext,
+        IEmailConnectorStore emailConnectorStore,
+        ILdapConfigurationStore ldapConfigurationStore,
+        IExternalIdentityService externalIdentityService,
+        ISmsGateway smsGateway,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ConnectorCatalogService> logger)
+    {
+        _dbContext = dbContext;
+        _emailConnectorStore = emailConnectorStore;
+        _ldapConfigurationStore = ldapConfigurationStore;
+        _externalIdentityService = externalIdentityService;
+        _smsGateway = smsGateway;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyCollection<ConnectorSummary>> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var summaries = new List<ConnectorSummary>();
+
+        var connectors = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .OrderBy(x => x.Type)
+            .ThenBy(x => x.Alias)
+            .ToListAsync(cancellationToken);
+
+        summaries.AddRange(connectors.Select(MapConnector));
+
+        var ldapConfig = await _ldapConfigurationStore.GetAsync(cancellationToken);
+        summaries.Add(MapLdap(ldapConfig));
+
+        var oidcConfig = await _externalIdentityService.GetConfigurationAsync(cancellationToken);
+        summaries.Add(MapOidc(oidcConfig));
+
+        return summaries;
+    }
+
+    public async Task<ConnectorSummary?> ToggleAsync(Guid connectorId, bool enabled, CancellationToken cancellationToken = default)
+    {
+        var connector = await LoadConnectorAsync(connectorId, includeSecrets: false, cancellationToken);
+        if (connector is null)
+        {
+            return null;
+        }
+
+        connector.Enabled = enabled;
+        connector.ModifiedBy = ResolveActor();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return MapConnector(connector);
+    }
+
+    public async Task<ConnectorSummary?> RotateSecretsAsync(Guid connectorId, CancellationToken cancellationToken = default)
+    {
+        var connector = await LoadConnectorAsync(connectorId, includeSecrets: true, cancellationToken);
+        if (connector is null)
+        {
+            return null;
+        }
+
+        if (connector.Secrets.Count == 0)
+        {
+            return MapConnector(connector);
+        }
+
+        connector.Secrets.Clear();
+        connector.ModifiedBy = ResolveActor();
+        connector.HealthStatus = "Secret rotation required";
+        connector.LastTestedAtUtc = null;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return MapConnector(connector);
+    }
+
+    public async Task<ConnectorTestOutcome> TestAsync(Guid connectorId, ConnectorTestRequest request, CancellationToken cancellationToken = default)
+    {
+        var connector = await LoadConnectorAsync(connectorId, includeSecrets: true, cancellationToken);
+        if (connector is null)
+        {
+            return new ConnectorTestOutcome(new ConnectorTestResult(false, "Connector not found."), null);
+        }
+
+        if (!connector.Enabled)
+        {
+            return new ConnectorTestOutcome(new ConnectorTestResult(false, "Connector is disabled."), MapConnector(connector));
+        }
+
+        switch (connector.Type.ToUpperInvariant())
+        {
+            case "SMTP":
+                return await ExecuteSmtpTestAsync(connector, request, cancellationToken);
+            case "SMS":
+                return await ExecuteSmsTestAsync(connector, request, cancellationToken);
+            default:
+                return new ConnectorTestOutcome(
+                    new ConnectorTestResult(false, $"Testing is not implemented for connector type '{connector.Type}'."),
+                    MapConnector(connector));
+        }
+    }
+
+    private async Task<ConnectorTestOutcome> ExecuteSmtpTestAsync(ConnectorProfile connector, ConnectorTestRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Target))
+        {
+            return new ConnectorTestOutcome(new ConnectorTestResult(false, "Recipient e-mail address is required."), MapConnector(connector));
+        }
+
+        var subject = "HW Inventory SMTP test";
+        var body = $"This is an automated SMTP connectivity test triggered at {DateTime.UtcNow.ToString("u", CultureInfo.InvariantCulture)}.";
+        var result = await _emailConnectorStore.SendTestAsync(new EmailTestRequest(request.Target!, subject, body), cancellationToken);
+
+        var refreshed = await LoadConnectorAsync(connector.Id, includeSecrets: true, cancellationToken);
+        return new ConnectorTestOutcome(new ConnectorTestResult(result.Success, result.Message), refreshed is null ? null : MapConnector(refreshed));
+    }
+
+    private async Task<ConnectorTestOutcome> ExecuteSmsTestAsync(ConnectorProfile connector, ConnectorTestRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Target))
+        {
+            return new ConnectorTestOutcome(new ConnectorTestResult(false, "Destination phone number is required."), MapConnector(connector));
+        }
+
+        try
+        {
+            var message = $"HW Inventory SMS test @ {DateTime.UtcNow.ToString("u", CultureInfo.InvariantCulture)}";
+            await _smsGateway.SendAsync(request.Target!, message, cancellationToken);
+            connector.HealthStatus = "Test dispatched";
+            connector.LastTestedAtUtc = DateTime.UtcNow;
+            connector.ModifiedBy = ResolveActor();
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new ConnectorTestOutcome(new ConnectorTestResult(true, "SMS test dispatched."), MapConnector(connector));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SMS connector test failed for {ConnectorId}", connector.Id);
+            connector.HealthStatus = "Test failed";
+            connector.LastTestedAtUtc = DateTime.UtcNow;
+            connector.ModifiedBy = ResolveActor();
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new ConnectorTestOutcome(new ConnectorTestResult(false, "SMS test failed. See logs for details."), MapConnector(connector));
+        }
+    }
+
+    private ConnectorSummary MapConnector(ConnectorProfile profile)
+    {
+        var configuration = ParseConfiguration(profile.ConfigurationJson);
+        var description = profile.Type.ToUpperInvariant() switch
+        {
+            "SMTP" => DescribeSmtp(configuration),
+            "SMS" => DescribeSms(configuration),
+            "SFTP" or "FTPS" => configuration.TryGetValue("endpoint", out var endpoint) ? endpoint : null,
+            "WEBHOOK" or "WEBHOOKS" => configuration.TryGetValue("url", out var url) ? url : null,
+            "STORAGE" => configuration.TryGetValue("path", out var path) ? path : null,
+            _ => configuration.TryGetValue("endpoint", out var generic) ? generic : null
+        };
+
+        var requiresConfiguration = profile.Type.ToUpperInvariant() switch
+        {
+            "SMTP" => !configuration.TryGetValue("host", out var host) || string.IsNullOrWhiteSpace(host),
+            "SMS" => !configuration.TryGetValue("endpoint", out var endpoint) || string.IsNullOrWhiteSpace(endpoint),
+            _ => string.IsNullOrWhiteSpace(profile.ConfigurationJson)
+        };
+
+        return new ConnectorSummary(
+            profile.Id,
+            $"connector:{profile.Id}",
+            profile.Type,
+            profile.Alias,
+            profile.Enabled,
+            profile.HealthStatus,
+            profile.LastTestedAtUtc,
+            profile.Secrets.Any(),
+            supportsToggle: true,
+            supportsTest: SupportsTest(profile.Type),
+            supportsRotateSecret: profile.Secrets.Any() || SupportsSecretRotation(profile.Type),
+            requiresConfiguration,
+            description);
+    }
+
+    private ConnectorSummary MapLdap(LdapConfigurationModel configuration)
+    {
+        var description = string.IsNullOrWhiteSpace(configuration.Host)
+            ? "LDAP server host is not configured"
+            : $"{configuration.Host}:{configuration.Port}";
+
+        return new ConnectorSummary(
+            null,
+            "connector:ldap",
+            "LDAP",
+            "LDAP / Active Directory",
+            configuration.Enabled,
+            null,
+            null,
+            configuration.HasPassword,
+            supportsToggle: false,
+            supportsTest: false,
+            supportsRotateSecret: false,
+            string.IsNullOrWhiteSpace(configuration.Host),
+            description);
+    }
+
+    private ConnectorSummary MapOidc(OidcConfiguration? configuration)
+    {
+        if (configuration is null)
+        {
+            return new ConnectorSummary(
+                null,
+                "connector:oidc",
+                "OIDC",
+                "OpenID Connect",
+                false,
+                null,
+                null,
+                false,
+                supportsToggle: false,
+                supportsTest: false,
+                supportsRotateSecret: false,
+                true,
+                "OIDC has not been configured");
+        }
+
+        var description = string.IsNullOrWhiteSpace(configuration.Authority)
+            ? "OIDC authority missing"
+            : configuration.Authority;
+
+        return new ConnectorSummary(
+            null,
+            "connector:oidc",
+            "OIDC",
+            "OpenID Connect",
+            configuration.Enabled,
+            null,
+            null,
+            !string.IsNullOrWhiteSpace(configuration.ClientSecret),
+            supportsToggle: false,
+            supportsTest: false,
+            supportsRotateSecret: false,
+            string.IsNullOrWhiteSpace(configuration.Authority),
+            description);
+    }
+
+    private async Task<ConnectorProfile?> LoadConnectorAsync(Guid connectorId, bool includeSecrets, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.ConnectorProfiles.AsQueryable();
+        if (includeSecrets)
+        {
+            query = query.Include(x => x.Secrets);
+        }
+
+        return await query.FirstOrDefaultAsync(x => x.Id == connectorId, cancellationToken);
+    }
+
+    private static Dictionary<string, string?> ParseConfiguration(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string?>>(json, SerializerOptions)
+                ?? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string? DescribeSmtp(IReadOnlyDictionary<string, string?> configuration)
+    {
+        configuration.TryGetValue("host", out var host);
+        configuration.TryGetValue("port", out var port);
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return "SMTP host not configured";
+        }
+
+        return string.IsNullOrWhiteSpace(port) ? host : $"{host}:{port}";
+    }
+
+    private static string? DescribeSms(IReadOnlyDictionary<string, string?> configuration)
+    {
+        configuration.TryGetValue("endpoint", out var endpoint);
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return "SMS endpoint not configured";
+        }
+
+        configuration.TryGetValue("sender", out var sender);
+        return string.IsNullOrWhiteSpace(sender) ? endpoint : $"{endpoint} (sender {sender})";
+    }
+
+    private static bool SupportsTest(string type)
+    {
+        return type.Equals("SMTP", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("SMS", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool SupportsSecretRotation(string type)
+    {
+        return type.Equals("SMTP", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("SMS", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("SFTP", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("FTPS", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("STORAGE", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("PRINTING", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
+++ b/src/api/src/HWInventory.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using HWInventory.Domain.Security;
+using HWInventory.Infrastructure.Jobs;
+using HWInventory.Infrastructure.Labels;
+using HWInventory.Infrastructure.Persistence;
+using HWInventory.Infrastructure.Connectors;
+using HWInventory.Infrastructure.Security;
+using HWInventory.Infrastructure.Observability;
+using HWInventory.Infrastructure.Maintenance;
+using HWInventory.Infrastructure.ImportExport;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Quartz;
+
+namespace HWInventory.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = "Server=(localdb)\\MSSQLLocalDB;Database=HWInventory;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True";
+        }
+
+        services.AddDbContext<AppDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.EnableRetryOnFailure();
+                sql.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName);
+            });
+        });
+
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+        services.AddDataProtection();
+
+        var identityBuilder = services.AddIdentityCore<AppUser>(options =>
+        {
+            options.Password.RequireDigit = true;
+            options.Password.RequireLowercase = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequireNonAlphanumeric = true;
+            options.Password.RequiredLength = 12;
+            options.SignIn.RequireConfirmedAccount = false;
+            options.User.RequireUniqueEmail = true;
+            options.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
+        });
+
+        identityBuilder = new IdentityBuilder(identityBuilder.UserType, typeof(AppRole), identityBuilder.Services);
+        identityBuilder.AddRoles<AppRole>();
+        identityBuilder.AddEntityFrameworkStores<AppDbContext>();
+        identityBuilder.AddDefaultTokenProviders();
+        identityBuilder.AddSignInManager();
+        identityBuilder.AddPasswordValidator<PasswordHistoryValidator>();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+            options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
+        }).AddIdentityCookies().AddOpenIdConnect("oidc", options =>
+        {
+            options.SignInScheme = IdentityConstants.ExternalScheme;
+            options.ResponseType = "code";
+            options.CallbackPath = "/signin-oidc";
+            options.SaveTokens = true;
+            options.UsePkce = true;
+            options.RequireHttpsMetadata = true;
+            options.GetClaimsFromUserInfoEndpoint = true;
+            options.Scope.Clear();
+            options.Scope.Add("openid");
+            options.Scope.Add("profile");
+            options.Scope.Add("email");
+        });
+
+        services.AddOptions<OpenIdConnectOptions>("oidc").Configure<IServiceProvider>((options, serviceProvider) =>
+        {
+            using var scope = serviceProvider.CreateScope();
+            var identityService = scope.ServiceProvider.GetRequiredService<IExternalIdentityService>();
+            var configuration = identityService.GetConfigurationAsync().GetAwaiter().GetResult();
+
+            if (configuration is null || !configuration.Enabled)
+            {
+                options.Authority = "https://placeholder";
+                options.ClientId = "placeholder";
+                options.ClientSecret = string.Empty;
+                options.DisableTelemetry = true;
+                options.Events ??= new OpenIdConnectEvents();
+                options.Events.OnRedirectToIdentityProvider = context =>
+                {
+                    context.HandleResponse();
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    return Task.CompletedTask;
+                };
+                return;
+            }
+
+            options.Authority = configuration.Authority;
+            options.ClientId = configuration.ClientId;
+            options.ClientSecret = configuration.ClientSecret;
+            options.ResponseType = configuration.ResponseType ?? "code";
+            options.UsePkce = configuration.UsePkce;
+            options.Scope.Clear();
+            foreach (var scopeValue in configuration.Scopes)
+            {
+                options.Scope.Add(scopeValue);
+            }
+
+            options.TokenValidationParameters.NameClaimType = configuration.ClaimMappings.TryGetValue("name", out var nameClaim)
+                ? nameClaim
+                : "name";
+            options.TokenValidationParameters.RoleClaimType = "role";
+            options.TokenValidationParameters.ValidateIssuer = true;
+            options.TokenValidationParameters.ValidateAudience = true;
+            options.RequireHttpsMetadata = true;
+
+            options.ClaimActions.DeleteClaim("name");
+            options.ClaimActions.DeleteClaim("email");
+            options.ClaimActions.MapJsonKey("name", configuration.ClaimMappings.TryGetValue("name", out var nameClaim) ? nameClaim : "name");
+            options.ClaimActions.MapJsonKey("email", configuration.ClaimMappings.TryGetValue("email", out var emailClaim) ? emailClaim : "email");
+        });
+
+        services.ConfigureApplicationCookie(options =>
+        {
+            options.Cookie.Name = "HWInventory.Auth";
+            options.SlidingExpiration = true;
+            options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+            options.LoginPath = "/signin";
+            options.LogoutPath = "/signout";
+        });
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(AuthorizationPolicies.ServersRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.AppAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.ServersManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.AppAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.NetworkManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk, SystemRoleNames.HelpdeskRead));
+
+            options.AddPolicy(AuthorizationPolicies.WorkstationsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.DictionariesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.AuditRead, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.ServerAdmin, SystemRoleNames.NetworkAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.LabelsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin, SystemRoleNames.Helpdesk));
+
+            options.AddPolicy(AuthorizationPolicies.ModulesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.DashboardView, policy =>
+                policy.RequireRole(
+                    SystemRoleNames.SuperAdmin,
+                    SystemRoleNames.ServerAdmin,
+                    SystemRoleNames.NetworkAdmin,
+                    SystemRoleNames.AppAdmin,
+                    SystemRoleNames.Helpdesk,
+                    SystemRoleNames.HelpdeskRead));
+
+            options.AddPolicy(AuthorizationPolicies.SecurityManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.SessionsManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+
+            options.AddPolicy(AuthorizationPolicies.ObservabilityManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+            options.AddPolicy(AuthorizationPolicies.MaintenanceManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+            options.AddPolicy(AuthorizationPolicies.UpdatesManage, policy =>
+                policy.RequireRole(SystemRoleNames.SuperAdmin));
+            options.AddPolicy(AuthorizationPolicies.ImportExportManage, policy =>
+                policy.RequireRole(
+                    SystemRoleNames.SuperAdmin,
+                    SystemRoleNames.ServerAdmin,
+                    SystemRoleNames.NetworkAdmin,
+                    SystemRoleNames.AppAdmin,
+                    SystemRoleNames.Helpdesk));
+        });
+
+        services.AddHttpClient("captcha");
+        services.AddHttpClient("sms");
+
+        services.AddScoped<AppUserManager>();
+        services.AddScoped<UserManager<AppUser>>(sp => sp.GetRequiredService<AppUserManager>());
+        services.AddScoped<ITotpService, TotpService>();
+        services.AddScoped<ILabelRenderingService, LabelRenderingService>();
+        services.AddScoped<ILdapSyncService, LdapSyncService>();
+        services.AddScoped<ILdapConfigurationStore, LdapConfigurationStore>();
+        services.AddScoped<IExternalIdentityService, ExternalIdentityService>();
+        services.AddScoped<ICaptchaConfigurationStore, CaptchaConfigurationStore>();
+        services.AddScoped<ICaptchaValidator, CaptchaValidator>();
+        services.AddScoped<ISmsGateway, SmsGateway>();
+        services.AddScoped<ISmsConnectorStore, SmsConnectorStore>();
+        services.AddScoped<IConnectorCatalogService, ConnectorCatalogService>();
+        services.AddScoped<IEmailConnectorStore, EmailConnectorStore>();
+        services.AddScoped<IPasswordPolicyConfigurationStore, PasswordPolicyConfigurationStore>();
+        services.AddScoped<IPasswordHistoryService, PasswordHistoryService>();
+        services.AddScoped<ISsprService, SsprService>();
+        services.AddScoped<ISsprConfigurationStore, SsprConfigurationStore>();
+        services.AddScoped<ISessionTracker, SessionTracker>();
+        services.AddScoped<IObservabilityConfigurationStore, ObservabilityConfigurationStore>();
+        services.AddScoped<IObservabilityRuntime, ObservabilityRuntime>();
+        services.AddSingleton<IRequestMetricsCollector, RequestMetricsCollector>();
+        services.AddScoped<ISecretProtector, DataProtectionSecretProtector>();
+        services.AddSingleton<IConfigureOptions<IdentityOptions>, PasswordPolicyOptionsConfigurator>();
+        services.AddScoped<IBackupConfigurationStore, BackupConfigurationStore>();
+        services.AddScoped<IBackupService, BackupService>();
+        services.AddScoped<IExportService, ExportService>();
+        services.AddScoped<IImportService, ImportService>();
+        services.AddScoped<IUpdateService, UpdateService>();
+
+        services.AddQuartz(q =>
+        {
+            q.UseMicrosoftDependencyInjectionJobFactory();
+            var jobKey = new JobKey("LabelPrintJobProcessor");
+            q.AddJob<LabelPrintJobProcessor>(options => options.WithIdentity(jobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity("LabelPrintJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).RepeatForever()));
+
+            var backupJobKey = new JobKey("BackupJobProcessor");
+            q.AddJob<BackupJobProcessor>(options => options.WithIdentity(backupJobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(backupJobKey)
+                .WithIdentity("BackupJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(5).RepeatForever()));
+
+            var exportJobKey = new JobKey("ExportJobProcessor");
+            q.AddJob<ExportJobProcessor>(options => options.WithIdentity(exportJobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(exportJobKey)
+                .WithIdentity("ExportJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(2).RepeatForever()));
+
+            var importJobKey = new JobKey("ImportJobProcessor");
+            q.AddJob<ImportJobProcessor>(options => options.WithIdentity(importJobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(importJobKey)
+                .WithIdentity("ImportJobProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(2).RepeatForever()));
+
+            var updateJobKey = new JobKey("UpdatePackageProcessor");
+            q.AddJob<UpdatePackageProcessor>(options => options.WithIdentity(updateJobKey));
+            q.AddTrigger(trigger => trigger
+                .ForJob(updateJobKey)
+                .WithIdentity("UpdatePackageProcessor-trigger")
+                .WithSimpleSchedule(x => x.WithIntervalInMinutes(1).RepeatForever()));
+        });
+
+        services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
+
+        return services;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
+++ b/src/api/src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Otp.NET" Version="1.3.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.7.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
+++ b/src/api/src/HWInventory.Infrastructure/HostExtensions.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using HWInventory.Application.Abstractions;
+using HWInventory.Infrastructure.Observability;
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace HWInventory.Infrastructure;
+
+public static class HostExtensions
+{
+    public static async Task<IHost> InitializeDatabaseAsync(this IHost host, CancellationToken cancellationToken = default)
+    {
+        using var scope = host.Services.CreateScope();
+        var serviceProvider = scope.ServiceProvider;
+        var context = serviceProvider.GetRequiredService<AppDbContext>();
+
+        if (context.Database.IsRelational())
+        {
+            await context.Database.MigrateAsync(cancellationToken);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        await SeedData.InitializeAsync(serviceProvider, cancellationToken);
+
+        var observabilityStore = serviceProvider.GetRequiredService<IObservabilityConfigurationStore>();
+        var configuration = await observabilityStore.GetAsync(cancellationToken);
+        ObservabilityLogging.ApplyMinimumLevel(configuration.LogLevel);
+
+        var updatesPath = Path.Combine(AppContext.BaseDirectory, "updates");
+        Directory.CreateDirectory(updatesPath);
+
+        return host;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/ImportExport/ExportJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/ImportExport/ExportJobProcessor.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.ImportExport;
+
+[DisallowConcurrentExecution]
+public class ExportJobProcessor : IJob
+{
+    private readonly IExportService _exportService;
+    private readonly ILogger<ExportJobProcessor> _logger;
+
+    public ExportJobProcessor(IExportService exportService, ILogger<ExportJobProcessor> logger)
+    {
+        _exportService = exportService;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Spouštím úlohu exportu");
+        await _exportService.ProcessPendingJobsAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/ImportExport/ExportService.cs
+++ b/src/api/src/HWInventory.Infrastructure/ImportExport/ExportService.cs
@@ -1,0 +1,514 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.ImportExport;
+
+public class ExportService : IExportService
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IEmailConnectorStore _emailConnectorStore;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ExportService> _logger;
+
+    public ExportService(
+        IAppDbContext dbContext,
+        IEmailConnectorStore emailConnectorStore,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ExportService> logger)
+    {
+        _dbContext = dbContext;
+        _emailConnectorStore = emailConnectorStore;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<ExportJobModel> QueueExportAsync(ExportRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            throw new ArgumentException("Storage path is required.", nameof(request));
+        }
+
+        var storagePath = Path.GetFullPath(request.StoragePath);
+        Directory.CreateDirectory(storagePath);
+
+        var actor = ResolveActor();
+
+        var job = new ExportJob
+        {
+            Scope = request.Scope,
+            Format = request.Format,
+            StoragePath = storagePath,
+            FileName = BuildFileName(request.Scope, request.Format),
+            FilterJson = request.FilterJson,
+            SendEmail = request.SendEmail,
+            EmailRecipients = NormalizeRecipients(request.EmailRecipients),
+            CreatedBy = actor,
+            ModifiedBy = actor,
+            ExpiresAtUtc = DateTime.UtcNow.AddDays(7)
+        };
+
+        _dbContext.ExportJobs.Add(job);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return Map(job);
+    }
+
+    public async Task<IReadOnlyList<ExportJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default)
+    {
+        var jobs = await _dbContext.ExportJobs
+            .AsNoTracking()
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .Skip(Math.Max(page - 1, 0) * size)
+            .Take(size)
+            .ToListAsync(cancellationToken);
+
+        return jobs.Select(Map).ToList();
+    }
+
+    public async Task<ExportJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var job = await _dbContext.ExportJobs.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return job is null ? null : Map(job);
+    }
+
+    public async Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default)
+    {
+        var pendingJobs = await _dbContext.ExportJobs
+            .Where(x => x.JobStatus == ExportJobStatus.Pending)
+            .OrderBy(x => x.CreatedAtUtc)
+            .Take(5)
+            .ToListAsync(cancellationToken);
+
+        foreach (var job in pendingJobs)
+        {
+            job.JobStatus = ExportJobStatus.Running;
+            job.ModifiedBy = "system";
+        }
+
+        if (pendingJobs.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        foreach (var job in pendingJobs)
+        {
+            await ProcessJobAsync(job, cancellationToken);
+        }
+
+        var expirationThreshold = DateTime.UtcNow;
+        var expiredJobs = await _dbContext.ExportJobs
+            .Where(x => x.JobStatus == ExportJobStatus.Completed && x.ExpiresAtUtc < expirationThreshold)
+            .ToListAsync(cancellationToken);
+
+        if (expiredJobs.Count > 0)
+        {
+            foreach (var job in expiredJobs)
+            {
+                job.JobStatus = ExportJobStatus.Expired;
+                job.ModifiedBy = "system";
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task ProcessJobAsync(ExportJob job, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var artifactPath = await GenerateExportAsync(job, cancellationToken);
+            job.ArtifactPath = artifactPath;
+            job.CompletedAtUtc = DateTime.UtcNow;
+            job.FileSizeBytes = File.Exists(artifactPath) ? new FileInfo(artifactPath).Length : null;
+            job.JobStatus = ExportJobStatus.Completed;
+            job.FailureReason = null;
+
+            if (job.SendEmail)
+            {
+                await SendNotificationAsync(job, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Zpracování exportu selhalo");
+            job.JobStatus = ExportJobStatus.Failed;
+            job.CompletedAtUtc = DateTime.UtcNow;
+            job.FailureReason = ex.Message;
+        }
+        finally
+        {
+            job.ModifiedBy = "system";
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task<string> GenerateExportAsync(ExportJob job, CancellationToken cancellationToken)
+    {
+        var fullPath = Path.Combine(job.StoragePath, job.FileName);
+        Directory.CreateDirectory(job.StoragePath);
+
+        switch (job.Scope)
+        {
+            case ExportScope.Servers:
+                await ExportServersAsync(fullPath, cancellationToken);
+                break;
+            case ExportScope.NetworkDevices:
+                await ExportNetworkDevicesAsync(fullPath, cancellationToken);
+                break;
+            case ExportScope.Workstations:
+                await ExportWorkstationsAsync(fullPath, cancellationToken);
+                break;
+            case ExportScope.Dictionaries:
+                await ExportDictionariesAsync(fullPath, cancellationToken);
+                break;
+            case ExportScope.AuditLogs:
+                await ExportAuditLogsAsync(fullPath, cancellationToken);
+                break;
+            default:
+                throw new InvalidOperationException($"Export scope {job.Scope} není podporován.");
+        }
+
+        return fullPath;
+    }
+
+    private async Task ExportServersAsync(string path, CancellationToken cancellationToken)
+    {
+        var servers = await _dbContext.Servers
+            .AsNoTracking()
+            .Include(x => x.NetworkAssignments)
+            .ToListAsync(cancellationToken);
+
+        var dictionaryLookup = await LoadDictionaryLookupAsync(servers.SelectMany(s => new[]
+        {
+            s.EnvironmentId,
+            s.WsusPriorityId,
+            s.OperatingSystemId,
+            s.ServerRoleId,
+            s.LocationId
+        }), cancellationToken);
+
+        await using var writer = CreateWriter(path);
+        await writer.WriteLineAsync("Name,InventoryNumber,Manufacturer,Model,Environment,WsusPriority,OperatingSystem,ServerRole,Location,RackPosition,PurchasedAt,SupportUntil,Status,NetworkAssignments");
+
+        foreach (var server in servers)
+        {
+            var assignments = string.Join(" | ", server.NetworkAssignments.Select(a =>
+                $"{a.Label}:{ResolveDictionaryName(dictionaryLookup, a.VlanId)}:{a.IpAddress}"));
+
+            await WriteCsvLineAsync(writer,
+                server.Name,
+                server.InventoryNumber,
+                server.Manufacturer,
+                server.Model,
+                ResolveDictionaryName(dictionaryLookup, server.EnvironmentId),
+                ResolveDictionaryName(dictionaryLookup, server.WsusPriorityId),
+                ResolveDictionaryName(dictionaryLookup, server.OperatingSystemId),
+                ResolveDictionaryName(dictionaryLookup, server.ServerRoleId),
+                ResolveDictionaryName(dictionaryLookup, server.LocationId),
+                server.RackPosition,
+                FormatDate(server.PurchasedAt),
+                FormatDate(server.SupportUntil),
+                server.Status.ToString(),
+                assignments);
+        }
+    }
+
+    private async Task ExportNetworkDevicesAsync(string path, CancellationToken cancellationToken)
+    {
+        var devices = await _dbContext.NetworkDevices
+            .AsNoTracking()
+            .Include(x => x.NetworkAssignments)
+            .ToListAsync(cancellationToken);
+
+        var dictionaryLookup = await LoadDictionaryLookupAsync(devices.SelectMany(device => new[]
+        {
+            device.DeviceTypeId,
+            device.LocationId
+        }), cancellationToken);
+
+        await using var writer = CreateWriter(path);
+        await writer.WriteLineAsync("Name,InventoryNumber,DeviceType,Manufacturer,Model,Location,RackPosition,SupportUntil,Status,NetworkAssignments");
+
+        foreach (var device in devices)
+        {
+            var assignments = string.Join(" | ", device.NetworkAssignments.Select(a =>
+                $"{a.Label}:{ResolveDictionaryName(dictionaryLookup, a.VlanId)}:{a.IpAddress}"));
+
+            await WriteCsvLineAsync(writer,
+                device.Name,
+                device.InventoryNumber,
+                ResolveDictionaryName(dictionaryLookup, device.DeviceTypeId),
+                device.Manufacturer,
+                device.Model,
+                ResolveDictionaryName(dictionaryLookup, device.LocationId),
+                device.RackPosition,
+                FormatDate(device.SupportUntil),
+                device.Status.ToString(),
+                assignments);
+        }
+    }
+
+    private async Task ExportWorkstationsAsync(string path, CancellationToken cancellationToken)
+    {
+        var workstations = await _dbContext.Workstations
+            .AsNoTracking()
+            .Include(x => x.NetworkAssignments)
+            .ToListAsync(cancellationToken);
+
+        var dictionaryLookup = await LoadDictionaryLookupAsync(workstations.SelectMany(ws => new[]
+        {
+            ws.OperatingSystemId,
+            ws.WorkstationTypeId,
+            ws.LocationId
+        }), cancellationToken);
+
+        await using var writer = CreateWriter(path);
+        await writer.WriteLineAsync("Name,InventoryNumber,OperatingSystem,WorkstationType,Owner,OwnerDepartment,Location,Cpu,Ram,Storage,MacAddress,PurchasedAt,SupportUntil,Status,NetworkAssignments");
+
+        foreach (var workstation in workstations)
+        {
+            var assignments = string.Join(" | ", workstation.NetworkAssignments.Select(a =>
+                $"{a.Label}:{ResolveDictionaryName(dictionaryLookup, a.VlanId)}:{a.IpAddress}"));
+
+            await WriteCsvLineAsync(writer,
+                workstation.Name,
+                workstation.InventoryNumber,
+                ResolveDictionaryName(dictionaryLookup, workstation.OperatingSystemId),
+                ResolveDictionaryName(dictionaryLookup, workstation.WorkstationTypeId),
+                workstation.OwnerDisplayName,
+                workstation.OwnerDepartment,
+                ResolveDictionaryName(dictionaryLookup, workstation.LocationId),
+                workstation.Cpu,
+                workstation.Ram,
+                workstation.Storage,
+                workstation.MacAddress,
+                FormatDate(workstation.PurchasedAt),
+                FormatDate(workstation.SupportUntil),
+                workstation.Status.ToString(),
+                assignments);
+        }
+    }
+
+    private async Task ExportDictionariesAsync(string path, CancellationToken cancellationToken)
+    {
+        var dictionaries = await _dbContext.DictionaryEntries
+            .AsNoTracking()
+            .OrderBy(x => x.DictType)
+            .ThenBy(x => x.Key)
+            .ToListAsync(cancellationToken);
+
+        await using var writer = CreateWriter(path);
+        await writer.WriteLineAsync("DictType,Key,Value,Description,Status");
+
+        foreach (var entry in dictionaries)
+        {
+            await WriteCsvLineAsync(writer,
+                entry.DictType,
+                entry.Key,
+                entry.Value,
+                entry.Description,
+                entry.Status.ToString());
+        }
+    }
+
+    private async Task ExportAuditLogsAsync(string path, CancellationToken cancellationToken)
+    {
+        var logs = await _dbContext.AuditLogs
+            .AsNoTracking()
+            .OrderByDescending(x => x.PerformedAtUtc)
+            .Take(5000)
+            .ToListAsync(cancellationToken);
+
+        await using var writer = CreateWriter(path);
+        await writer.WriteLineAsync("PerformedAtUtc,EntityType,EntityId,Action,PerformedBy,Roles,Summary");
+
+        foreach (var log in logs)
+        {
+            await WriteCsvLineAsync(writer,
+                log.PerformedAtUtc.ToString("o", CultureInfo.InvariantCulture),
+                log.EntityType,
+                log.EntityId.ToString(),
+                log.Action,
+                log.PerformedBy,
+                log.Roles,
+                log.ChangeSummary);
+        }
+    }
+
+    private async Task<Dictionary<Guid, string>> LoadDictionaryLookupAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken)
+    {
+        var uniqueIds = ids.Where(id => id != Guid.Empty).Distinct().ToList();
+        if (uniqueIds.Count == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var entries = await _dbContext.DictionaryEntries
+            .AsNoTracking()
+            .Where(x => uniqueIds.Contains(x.Id))
+            .Select(x => new { x.Id, x.Value })
+            .ToListAsync(cancellationToken);
+
+        return entries.ToDictionary(x => x.Id, x => x.Value);
+    }
+
+    private static StreamWriter CreateWriter(string path)
+    {
+        return new StreamWriter(path, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+    }
+
+    private static Task WriteCsvLineAsync(StreamWriter writer, params string?[] values)
+    {
+        var escaped = values.Select(Escape).ToArray();
+        return writer.WriteLineAsync(string.Join(',', escaped));
+    }
+
+    private static string Escape(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var needsQuotes = value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r');
+        var normalized = value.Replace("\"", "\"\"");
+        return needsQuotes ? $"\"{normalized}\"" : normalized;
+    }
+
+    private static string? ResolveDictionaryName(Dictionary<Guid, string> lookup, Guid? id)
+    {
+        if (!id.HasValue)
+        {
+            return null;
+        }
+
+        return lookup.TryGetValue(id.Value, out var value) ? value : id.Value.ToString();
+    }
+
+    private static string? FormatDate(DateTime? date)
+    {
+        return date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private async Task SendNotificationAsync(ExportJob job, CancellationToken cancellationToken)
+    {
+        var connector = await _emailConnectorStore.GetAsync(cancellationToken);
+        if (connector is null || !connector.Enabled)
+        {
+            _logger.LogWarning("SMTP konektor není nastaven, notifikace nebude odeslána.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(connector.Host) || string.IsNullOrWhiteSpace(job.EmailRecipients))
+        {
+            return;
+        }
+
+        var recipients = job.EmailRecipients
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (recipients.Length == 0)
+        {
+            return;
+        }
+
+        var password = connector.HasPassword
+            ? await _dbContext.ConnectorProfiles
+                .Include(x => x.Secrets)
+                .Where(x => x.Type == "SMTP")
+                .SelectMany(x => x.Secrets)
+                .Select(x => x.SecretReference)
+                .FirstOrDefaultAsync(cancellationToken)
+            : null;
+
+        using var client = new SmtpClient(connector.Host, connector.Port ?? 25)
+        {
+            EnableSsl = connector.UseSsl
+        };
+
+        if (!string.IsNullOrWhiteSpace(connector.Username))
+        {
+            client.Credentials = new System.Net.NetworkCredential(connector.Username, password);
+        }
+
+        var message = new MailMessage
+        {
+            From = new MailAddress(connector.FromAddress ?? "noreply@example.com"),
+            Subject = $"HW Inventory export dokončen ({job.Scope})",
+            Body = $"Export {job.Scope} byl dokončen v {DateTime.UtcNow:yyyy-MM-dd HH:mm} UTC. Soubor: {job.FileName}",
+            IsBodyHtml = false
+        };
+
+        foreach (var recipient in recipients)
+        {
+            message.To.Add(recipient);
+        }
+
+        await client.SendMailAsync(message, cancellationToken);
+    }
+
+    private ExportJobModel Map(ExportJob job)
+    {
+        return new ExportJobModel(
+            job.Id,
+            job.Scope.ToString(),
+            job.Format.ToString(),
+            job.StoragePath,
+            job.FileName,
+            job.JobStatus.ToString(),
+            job.FileSizeBytes,
+            job.CreatedAtUtc,
+            job.CompletedAtUtc,
+            job.ExpiresAtUtc,
+            job.CreatedBy,
+            job.FailureReason,
+            job.SendEmail,
+            job.EmailRecipients,
+            job.ArtifactPath);
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+
+    private static string? NormalizeRecipients(string? recipients)
+    {
+        if (string.IsNullOrWhiteSpace(recipients))
+        {
+            return null;
+        }
+
+        var normalized = string.Join(";", recipients
+            .Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string BuildFileName(ExportScope scope, ExportFormat format)
+    {
+        var extension = format switch
+        {
+            ExportFormat.Csv => ".csv",
+            ExportFormat.Xlsx => ".xlsx",
+            _ => ".dat"
+        };
+
+        return $"HWInventory_{scope}_{DateTime.UtcNow:yyyyMMddHHmmss}{extension}";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/ImportExport/ImportJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/ImportExport/ImportJobProcessor.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.ImportExport;
+
+[DisallowConcurrentExecution]
+public class ImportJobProcessor : IJob
+{
+    private readonly IImportService _importService;
+    private readonly ILogger<ImportJobProcessor> _logger;
+
+    public ImportJobProcessor(IImportService importService, ILogger<ImportJobProcessor> logger)
+    {
+        _importService = importService;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Spouštím úlohu importů");
+        await _importService.ProcessPendingJobsAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/ImportExport/ImportService.cs
+++ b/src/api/src/HWInventory.Infrastructure/ImportExport/ImportService.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.ImportExport;
+
+public class ImportService : IImportService
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IEmailConnectorStore _emailConnectorStore;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ImportService> _logger;
+
+    public ImportService(
+        IAppDbContext dbContext,
+        IEmailConnectorStore emailConnectorStore,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ImportService> logger)
+    {
+        _dbContext = dbContext;
+        _emailConnectorStore = emailConnectorStore;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<ImportJobModel> QueueImportAsync(ImportRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            throw new ArgumentException("Storage path is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ContentBase64))
+        {
+            throw new ArgumentException("Soubor importu je povinný.", nameof(request));
+        }
+
+        var storagePath = Path.GetFullPath(request.StoragePath);
+        Directory.CreateDirectory(storagePath);
+
+        var actor = ResolveActor();
+        var job = new ImportJob
+        {
+            Scope = request.Scope,
+            Format = request.Format,
+            ConflictStrategy = request.ConflictStrategy,
+            DryRun = request.DryRun,
+            StoragePath = storagePath,
+            OriginalFileName = request.FileName,
+            MappingJson = request.MappingJson,
+            SendEmail = request.SendEmail,
+            EmailRecipients = NormalizeRecipients(request.EmailRecipients),
+            CreatedBy = actor,
+            ModifiedBy = actor
+        };
+
+        var extension = request.Format switch
+        {
+            ImportFormat.Csv => ".csv",
+            ImportFormat.Xlsx => ".xlsx",
+            _ => ".dat"
+        };
+
+        var storedFilePath = Path.Combine(storagePath, $"{job.Id}{extension}");
+        var bytes = Convert.FromBase64String(request.ContentBase64);
+        await File.WriteAllBytesAsync(storedFilePath, bytes, cancellationToken);
+        job.StoredFilePath = storedFilePath;
+
+        _dbContext.ImportJobs.Add(job);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return Map(job);
+    }
+
+    public async Task<IReadOnlyList<ImportJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default)
+    {
+        var jobs = await _dbContext.ImportJobs
+            .AsNoTracking()
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .Skip(Math.Max(page - 1, 0) * size)
+            .Take(size)
+            .ToListAsync(cancellationToken);
+
+        return jobs.Select(Map).ToList();
+    }
+
+    public async Task<ImportJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var job = await _dbContext.ImportJobs.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return job is null ? null : Map(job);
+    }
+
+    public async Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default)
+    {
+        var pending = await _dbContext.ImportJobs
+            .Where(x => x.JobStatus == ImportJobStatus.Pending)
+            .OrderBy(x => x.CreatedAtUtc)
+            .Take(3)
+            .ToListAsync(cancellationToken);
+
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var job in pending)
+        {
+            job.JobStatus = ImportJobStatus.Running;
+            job.ModifiedBy = "system";
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        foreach (var job in pending)
+        {
+            await ProcessJobAsync(job, cancellationToken);
+        }
+    }
+
+    private async Task ProcessJobAsync(ImportJob job, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var summary = await ExecuteImportAsync(job, cancellationToken);
+            job.CompletedAtUtc = DateTime.UtcNow;
+            job.JobStatus = ImportJobStatus.Completed;
+            job.FailureReason = null;
+            job.ResultLog = summary.Message;
+            job.ProcessedRows = summary.Processed;
+            job.CreatedRows = summary.Created;
+            job.UpdatedRows = summary.Updated;
+            job.SkippedRows = summary.Skipped;
+
+            if (job.SendEmail)
+            {
+                await SendNotificationAsync(job, summary, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Import job failed");
+            job.JobStatus = ImportJobStatus.Failed;
+            job.CompletedAtUtc = DateTime.UtcNow;
+            job.FailureReason = ex.Message;
+        }
+        finally
+        {
+            job.ModifiedBy = "system";
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task<ImportSummary> ExecuteImportAsync(ImportJob job, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(job.StoredFilePath))
+        {
+            throw new FileNotFoundException("Import file not found.", job.StoredFilePath);
+        }
+
+        if (job.Format == ImportFormat.Xlsx)
+        {
+            // XLSX podpora bude doplněna později.
+            return new ImportSummary(0, 0, 0, 0, "XLSX import zatím není implementován – soubor byl archivován bez zpracování.");
+        }
+
+        var lines = await File.ReadAllLinesAsync(job.StoredFilePath, Encoding.UTF8, cancellationToken);
+        if (lines.Length == 0)
+        {
+            return new ImportSummary(0, 0, 0, 0, "Soubor je prázdný.");
+        }
+
+        var processed = Math.Max(lines.Length - 1, 0);
+        if (job.DryRun)
+        {
+            return new ImportSummary(processed, 0, 0, processed, $"Dry-run dokončen. Zpracováno {processed} řádků (bez zápisu).");
+        }
+
+        // Skutečné zpracování dat bude doplněno v dalších iteracích.
+        return new ImportSummary(processed, processed, 0, 0, $"Import dokončen – vytvořeno {processed} záznamů (placeholder).");
+    }
+
+    private async Task SendNotificationAsync(ImportJob job, ImportSummary summary, CancellationToken cancellationToken)
+    {
+        var client = await _emailConnectorStore.GetClientAsync(cancellationToken);
+        if (client is null)
+        {
+            _logger.LogWarning("SMTP konektor není nakonfigurován – notifikace nebude odeslána.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(job.EmailRecipients))
+        {
+            return;
+        }
+
+        var message = new MailMessage
+        {
+            Subject = $"HW Inventory – import {job.Scope} dokončen",
+            Body = $"Proces importu skončil se statusem {job.JobStatus}.\n{summary.Message}",
+            IsBodyHtml = false
+        };
+
+        foreach (var recipient in job.EmailRecipients.Split(';'))
+        {
+            message.To.Add(recipient);
+        }
+
+        await client.SendMailAsync(message, cancellationToken);
+    }
+
+    private ImportJobModel Map(ImportJob job)
+    {
+        return new ImportJobModel(
+            job.Id,
+            job.Scope.ToString(),
+            job.Format.ToString(),
+            job.JobStatus.ToString(),
+            job.ConflictStrategy.ToString(),
+            job.DryRun,
+            job.StoragePath,
+            job.OriginalFileName,
+            job.CreatedAtUtc,
+            job.CompletedAtUtc,
+            job.CreatedBy,
+            job.FailureReason,
+            job.ProcessedRows,
+            job.CreatedRows,
+            job.UpdatedRows,
+            job.SkippedRows,
+            job.ResultLog,
+            job.SendEmail,
+            job.EmailRecipients);
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+
+    private static string? NormalizeRecipients(string? recipients)
+    {
+        if (string.IsNullOrWhiteSpace(recipients))
+        {
+            return null;
+        }
+
+        var normalized = string.Join(";", recipients
+            .Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private record ImportSummary(long Processed, long Created, long Updated, long Skipped, string Message);
+}

--- a/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/Jobs/LabelPrintJobProcessor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.Jobs;
+
+public class LabelPrintJobProcessor : IJob
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly ILogger<LabelPrintJobProcessor> _logger;
+
+    public LabelPrintJobProcessor(IAppDbContext dbContext, ILogger<LabelPrintJobProcessor> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var queuedJobs = await _dbContext.LabelPrintJobs
+            .Where(job => job.JobStatus == "Queued")
+            .Include(job => job.Items)
+            .OrderBy(job => job.CreatedAtUtc)
+            .Take(10)
+            .ToListAsync(context.CancellationToken);
+
+        if (!queuedJobs.Any())
+        {
+            return;
+        }
+
+        foreach (var job in queuedJobs)
+        {
+            job.JobStatus = "Processed";
+            job.ModifiedAtUtc = DateTime.UtcNow;
+            job.ModifiedBy = "system-job";
+            _logger.LogInformation("Processed label print job {JobId} targeting {Target}", job.Id, job.Target);
+        }
+
+        await _dbContext.SaveChangesAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Jobs/UpdatePackageProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/Jobs/UpdatePackageProcessor.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.Jobs;
+
+public class UpdatePackageProcessor : IJob
+{
+    private readonly IUpdateService _updateService;
+    private readonly ILogger<UpdatePackageProcessor> _logger;
+
+    public UpdatePackageProcessor(IUpdateService updateService, ILogger<UpdatePackageProcessor> logger)
+    {
+        _updateService = updateService;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Spouštím kontrolu fronty aktualizačních balíčků");
+        await _updateService.ProcessPendingPackagesAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Labels/LabelRenderingService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace HWInventory.Infrastructure.Labels;
+
+public class LabelRenderingService : ILabelRenderingService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public string RenderZpl(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var builder = new StringBuilder();
+        builder.AppendLine("^XA");
+        builder.AppendLine("^CI28");
+        builder.AppendLine($"^PW{ToDots(model.WidthMm, model.Dpi)}");
+        builder.AppendLine($"^LL{ToDots(model.HeightMm, model.Dpi)}");
+
+        foreach (var element in model.Elements)
+        {
+            var x = ToDots(element.X, model.Dpi);
+            var y = ToDots(element.Y, model.Dpi);
+            var value = ResolveValue(element, data);
+
+            switch (element.Type)
+            {
+                case LabelElementType.Text:
+                    builder.AppendLine($"^FO{x},{y}^A0N,{element.FontSize},{element.FontSize}^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Barcode128:
+                    builder.AppendLine($"^FO{x},{y}^BCN,{ToDots(element.HeightMm, model.Dpi)},Y,N,N^FD{Escape(value)}^FS");
+                    break;
+                case LabelElementType.Qr:
+                    builder.AppendLine($"^FO{x},{y}^BQN,2,10^FDLA,{Escape(value)}^FS");
+                    break;
+            }
+        }
+
+        builder.AppendLine("^XZ");
+        return builder.ToString();
+    }
+
+    public byte[] RenderPdf(LabelTemplate template, IDictionary<string, string> data)
+    {
+        var model = ParsePayload(template);
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(10);
+                page.Size(model.WidthMm * 2.83465f, model.HeightMm * 2.83465f);
+                page.Content().Canvas((canvas, size) =>
+                {
+                    foreach (var element in model.Elements)
+                    {
+                        var value = ResolveValue(element, data);
+                        var x = element.X * 2.83465f;
+                        var y = element.Y * 2.83465f;
+
+                        switch (element.Type)
+                        {
+                            case LabelElementType.Text:
+                                canvas.DrawText(value, TextStyle.Default.FontSize(element.FontSize), new Position(x, y));
+                                break;
+                            case LabelElementType.Barcode128:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[Code128] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                            case LabelElementType.Qr:
+                                canvas.DrawRectangle(new Position(x, y), new Size(element.WidthMm * 2.83465f, element.HeightMm * 2.83465f));
+                                canvas.DrawText($"[QR] {value}", TextStyle.Default.FontSize(8), new Position(x, y + 8));
+                                break;
+                        }
+                    }
+                });
+            });
+        });
+
+        using var stream = new MemoryStream();
+        document.GeneratePdf(stream);
+        return stream.ToArray();
+    }
+
+    private static LabelTemplateModel ParsePayload(LabelTemplate template)
+    {
+        if (string.IsNullOrWhiteSpace(template.Payload))
+        {
+            throw new InvalidOperationException("Label template payload cannot be empty");
+        }
+
+        var model = JsonSerializer.Deserialize<LabelTemplateModel>(template.Payload, SerializerOptions);
+        if (model is null)
+        {
+            throw new InvalidOperationException("Label template payload is invalid");
+        }
+
+        return model;
+    }
+
+    private static string ResolveValue(LabelElement element, IDictionary<string, string> data)
+    {
+        if (!string.IsNullOrWhiteSpace(element.StaticValue))
+        {
+            return element.StaticValue!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(element.DataKey) && data.TryGetValue(element.DataKey!, out var value))
+        {
+            return value;
+        }
+
+        return string.Empty;
+    }
+
+    private static string Escape(string value) => value
+        .Replace("^", " ")
+        .Replace("~", " ");
+
+    private static int ToDots(float millimeters, int dpi)
+        => (int)Math.Round(millimeters / 25.4f * dpi);
+
+    private class LabelTemplateModel
+    {
+        public int Dpi { get; set; } = 203;
+        public float WidthMm { get; set; } = 50;
+        public float HeightMm { get; set; } = 30;
+        public IList<LabelElement> Elements { get; set; } = new List<LabelElement>();
+    }
+
+    private class LabelElement
+    {
+        public LabelElementType Type { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float WidthMm { get; set; } = 30;
+        public float HeightMm { get; set; } = 10;
+        public int FontSize { get; set; } = 12;
+        public string? StaticValue { get; set; }
+        public string? DataKey { get; set; }
+    }
+
+    private enum LabelElementType
+    {
+        Text,
+        Barcode128,
+        Qr
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Maintenance/BackupConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Maintenance/BackupConfigurationStore.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Maintenance;
+
+public class BackupConfigurationStore : IBackupConfigurationStore
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly ISecretProtector _secretProtector;
+
+    public BackupConfigurationStore(IAppDbContext dbContext, ISecretProtector secretProtector)
+    {
+        _dbContext = dbContext;
+        _secretProtector = secretProtector;
+    }
+
+    public async Task<BackupScheduleModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var schedule = await _dbContext.BackupSchedules.FirstOrDefaultAsync(cancellationToken);
+        if (schedule is null)
+        {
+            schedule = new BackupSchedule
+            {
+                Enabled = false,
+                Frequency = "Daily",
+                ExecutionTimeUtc = TimeSpan.FromHours(1),
+                Scope = "Full",
+                StoragePath = Path.Combine(AppContext.BaseDirectory, "backups"),
+                IntegrityCheckEnabled = true,
+                SendEmail = false
+            };
+
+            _dbContext.BackupSchedules.Add(schedule);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return Map(schedule);
+    }
+
+    public async Task<BackupScheduleModel> SaveAsync(BackupScheduleUpdate update, CancellationToken cancellationToken = default)
+    {
+        var schedule = await _dbContext.BackupSchedules.FirstOrDefaultAsync(cancellationToken);
+        if (schedule is null)
+        {
+            schedule = new BackupSchedule();
+            _dbContext.BackupSchedules.Add(schedule);
+        }
+
+        schedule.Enabled = update.Enabled;
+        schedule.Frequency = update.Frequency;
+        schedule.DayOfWeek = update.DayOfWeek;
+        schedule.DayOfMonth = update.DayOfMonth;
+        schedule.ExecutionTimeUtc = update.ExecutionTimeUtc;
+        schedule.Scope = update.Scope;
+        schedule.StoragePath = update.StoragePath;
+        schedule.EncryptionEnabled = update.EncryptionEnabled;
+        schedule.SendEmail = update.SendEmail;
+        schedule.EmailRecipients = string.IsNullOrWhiteSpace(update.EmailRecipients) ? null : update.EmailRecipients;
+        schedule.IntegrityCheckEnabled = update.IntegrityCheckEnabled;
+
+        if (update.RotatePassword)
+        {
+            schedule.ProtectedEncryptionSecret = null;
+        }
+
+        if (update.EncryptionEnabled && !string.IsNullOrWhiteSpace(update.Password))
+        {
+            schedule.ProtectedEncryptionSecret = _secretProtector.Protect(update.Password);
+        }
+
+        schedule.NextRunAtUtc = CalculateNextRunUtc(schedule, DateTime.UtcNow);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return Map(schedule);
+    }
+
+    public async Task<BackupScheduleTriggerResult> TryMarkTriggeredAsync(DateTime utcNow, CancellationToken cancellationToken = default)
+    {
+        var schedule = await _dbContext.BackupSchedules.FirstOrDefaultAsync(cancellationToken);
+        if (schedule is null || !schedule.Enabled)
+        {
+            return new BackupScheduleTriggerResult(false, schedule is null ? null : Map(schedule), null);
+        }
+
+        if (!schedule.NextRunAtUtc.HasValue)
+        {
+            schedule.NextRunAtUtc = CalculateNextRunUtc(schedule, utcNow);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new BackupScheduleTriggerResult(false, Map(schedule), schedule.ProtectedEncryptionSecret);
+        }
+
+        if (schedule.NextRunAtUtc > utcNow)
+        {
+            return new BackupScheduleTriggerResult(false, Map(schedule), schedule.ProtectedEncryptionSecret);
+        }
+
+        schedule.LastRunAtUtc = utcNow;
+        schedule.NextRunAtUtc = CalculateNextRunUtc(schedule, utcNow.AddMinutes(1));
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return new BackupScheduleTriggerResult(true, Map(schedule), schedule.ProtectedEncryptionSecret);
+    }
+
+    private static BackupScheduleModel Map(BackupSchedule schedule)
+    {
+        return new BackupScheduleModel(
+            schedule.Enabled,
+            schedule.Frequency,
+            schedule.DayOfWeek,
+            schedule.DayOfMonth,
+            schedule.ExecutionTimeUtc,
+            schedule.Scope,
+            schedule.StoragePath,
+            schedule.EncryptionEnabled,
+            !string.IsNullOrEmpty(schedule.ProtectedEncryptionSecret),
+            schedule.SendEmail,
+            schedule.EmailRecipients,
+            schedule.IntegrityCheckEnabled,
+            schedule.LastRunAtUtc,
+            schedule.NextRunAtUtc);
+    }
+
+    private static DateTime? CalculateNextRunUtc(BackupSchedule schedule, DateTime referenceUtc)
+    {
+        if (!schedule.Enabled)
+        {
+            return null;
+        }
+
+        var executionDate = new DateTime(referenceUtc.Year, referenceUtc.Month, referenceUtc.Day, 0, 0, 0, DateTimeKind.Utc)
+            .Add(schedule.ExecutionTimeUtc);
+
+        if (schedule.Frequency.Equals("Daily", StringComparison.OrdinalIgnoreCase))
+        {
+            if (executionDate <= referenceUtc)
+            {
+                executionDate = executionDate.AddDays(1);
+            }
+
+            return executionDate;
+        }
+
+        if (schedule.Frequency.Equals("Weekly", StringComparison.OrdinalIgnoreCase))
+        {
+            var dayOfWeek = schedule.DayOfWeek ?? 0;
+            var currentDay = (int)executionDate.DayOfWeek;
+            var daysToAdd = ((dayOfWeek - currentDay) + 7) % 7;
+            if (daysToAdd == 0 && executionDate <= referenceUtc)
+            {
+                daysToAdd = 7;
+            }
+
+            return executionDate.AddDays(daysToAdd);
+        }
+
+        if (schedule.Frequency.Equals("Monthly", StringComparison.OrdinalIgnoreCase))
+        {
+            var day = schedule.DayOfMonth ?? 1;
+            var daysInMonth = DateTime.DaysInMonth(executionDate.Year, executionDate.Month);
+            day = Math.Min(Math.Max(day, 1), daysInMonth);
+            executionDate = new DateTime(executionDate.Year, executionDate.Month, day, executionDate.Hour, executionDate.Minute, executionDate.Second, DateTimeKind.Utc);
+            if (executionDate <= referenceUtc)
+            {
+                var nextMonth = executionDate.AddMonths(1);
+                daysInMonth = DateTime.DaysInMonth(nextMonth.Year, nextMonth.Month);
+                day = Math.Min(Math.Max(schedule.DayOfMonth ?? day, 1), daysInMonth);
+                executionDate = new DateTime(nextMonth.Year, nextMonth.Month, day, nextMonth.Hour, nextMonth.Minute, nextMonth.Second, DateTimeKind.Utc);
+            }
+
+            return executionDate;
+        }
+
+        return executionDate <= referenceUtc ? executionDate.AddDays(1) : executionDate;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Maintenance/BackupJobProcessor.cs
+++ b/src/api/src/HWInventory.Infrastructure/Maintenance/BackupJobProcessor.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace HWInventory.Infrastructure.Maintenance;
+
+[DisallowConcurrentExecution]
+public class BackupJobProcessor : IJob
+{
+    private readonly IBackupService _backupService;
+    private readonly ILogger<BackupJobProcessor> _logger;
+
+    public BackupJobProcessor(IBackupService backupService, ILogger<BackupJobProcessor> logger)
+    {
+        _backupService = backupService;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Spouštím úlohu zpracování záloh");
+        await _backupService.QueueScheduledBackupIfDueAsync(context.CancellationToken);
+        await _backupService.ProcessPendingJobsAsync(context.CancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Maintenance/BackupService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Maintenance/BackupService.cs
@@ -1,0 +1,680 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Mail;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Maintenance;
+
+public class BackupService : IBackupService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private readonly IAppDbContext _dbContext;
+    private readonly IBackupConfigurationStore _scheduleStore;
+    private readonly ISecretProtector _secretProtector;
+    private readonly IEmailConnectorStore _emailConnectorStore;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<BackupService> _logger;
+
+    public BackupService(
+        IAppDbContext dbContext,
+        IBackupConfigurationStore scheduleStore,
+        ISecretProtector secretProtector,
+        IEmailConnectorStore emailConnectorStore,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<BackupService> logger)
+    {
+        _dbContext = dbContext;
+        _scheduleStore = scheduleStore;
+        _secretProtector = secretProtector;
+        _emailConnectorStore = emailConnectorStore;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<BackupJobModel> QueueBackupAsync(BackupRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            throw new ArgumentException("Storage path is required.", nameof(request));
+        }
+
+        var storagePath = Path.GetFullPath(request.StoragePath);
+        Directory.CreateDirectory(storagePath);
+
+        var fileName = BuildFileName(request.Scope, request.EncryptionEnabled);
+        var actor = ResolveActor(request.IsAutomatic);
+
+        var job = new BackupJob
+        {
+            Scope = request.Scope,
+            StoragePath = storagePath,
+            FileName = fileName,
+            EncryptionEnabled = request.EncryptionEnabled,
+            SendEmail = request.SendEmail,
+            EmailRecipients = NormalizeRecipients(request.EmailRecipients),
+            IntegrityCheckEnabled = request.IntegrityCheckEnabled,
+            IsAutomatic = request.IsAutomatic,
+            CreatedBy = actor,
+            ModifiedBy = actor
+        };
+
+        if (request.EncryptionEnabled)
+        {
+            if (!string.IsNullOrWhiteSpace(request.Password))
+            {
+                job.ProtectedEncryptionSecret = _secretProtector.Protect(request.Password);
+            }
+            else if (!string.IsNullOrWhiteSpace(request.ProtectedSecret))
+            {
+                job.ProtectedEncryptionSecret = request.ProtectedSecret;
+            }
+            else
+            {
+                throw new InvalidOperationException("Nelze vytvořit zálohu: chybí heslo pro šifrování.");
+            }
+        }
+
+        _dbContext.BackupJobs.Add(job);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return Map(job);
+    }
+
+    public async Task<IReadOnlyList<BackupJobModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.BackupJobs
+            .OrderByDescending(x => x.CreatedAtUtc);
+
+        var jobs = await query
+            .Skip(Math.Max(page - 1, 0) * size)
+            .Take(size)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        return jobs.Select(Map).ToList();
+    }
+
+    public async Task<BackupJobModel?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var job = await _dbContext.BackupJobs.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return job is null ? null : Map(job);
+    }
+
+    public async Task<RestoreResult> RestoreAsync(Guid jobId, RestoreRequest request, CancellationToken cancellationToken = default)
+    {
+        var job = await _dbContext.BackupJobs.FirstOrDefaultAsync(x => x.Id == jobId, cancellationToken);
+        if (job is null)
+        {
+            return new RestoreResult(false, "Záloha nebyla nalezena.");
+        }
+
+        var filePath = Path.Combine(job.StoragePath, job.FileName);
+        if (!File.Exists(filePath))
+        {
+            return new RestoreResult(false, "Soubor zálohy neexistuje.");
+        }
+
+        string? password = null;
+        if (job.EncryptionEnabled)
+        {
+            password = request.Password;
+            if (string.IsNullOrWhiteSpace(password) && !string.IsNullOrWhiteSpace(job.ProtectedEncryptionSecret))
+            {
+                password = _secretProtector.Unprotect(job.ProtectedEncryptionSecret);
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                return new RestoreResult(false, "Pro obnovení šifrované zálohy je nutné zadat heslo.");
+            }
+        }
+
+        var archiveBytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+        if (job.EncryptionEnabled)
+        {
+            archiveBytes = Decrypt(archiveBytes, password!);
+        }
+
+        await RestoreFromArchiveAsync(archiveBytes, job.Scope, cancellationToken);
+
+        if (request.PerformIntegrityTest)
+        {
+            var integrity = await PerformIntegrityTestAsync(archiveBytes, job.Scope, cancellationToken);
+            if (!integrity)
+            {
+                return new RestoreResult(true, "Obnova dokončena, ale integrita archivu nebyla potvrzena.");
+            }
+        }
+
+        return new RestoreResult(true, "Obnova byla úspěšně dokončena.");
+    }
+
+    public async Task<IntegrityTestResult> TestIntegrityAsync(Guid jobId, string? password, CancellationToken cancellationToken = default)
+    {
+        var job = await _dbContext.BackupJobs.FirstOrDefaultAsync(x => x.Id == jobId, cancellationToken);
+        if (job is null)
+        {
+            return new IntegrityTestResult(false, "Záloha nebyla nalezena.", null);
+        }
+
+        var filePath = Path.Combine(job.StoragePath, job.FileName);
+        if (!File.Exists(filePath))
+        {
+            return new IntegrityTestResult(false, "Soubor zálohy neexistuje.", null);
+        }
+
+        if (job.EncryptionEnabled)
+        {
+            password ??= job.ProtectedEncryptionSecret is null ? null : _secretProtector.Unprotect(job.ProtectedEncryptionSecret);
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                return new IntegrityTestResult(false, "Pro ověření šifrované zálohy je nutné heslo.", null);
+            }
+        }
+
+        var archiveBytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+        if (job.EncryptionEnabled)
+        {
+            archiveBytes = Decrypt(archiveBytes, password!);
+        }
+
+        var passed = await PerformIntegrityTestAsync(archiveBytes, job.Scope, cancellationToken);
+        job.IntegrityPassed = passed;
+        job.IntegrityCheckedAtUtc = DateTime.UtcNow;
+        job.ModifiedBy = ResolveActor(true);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new IntegrityTestResult(true, passed ? "Archiv je v pořádku." : "Archiv se nepodařilo ověřit.", passed);
+    }
+
+    public async Task QueueScheduledBackupIfDueAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var trigger = await _scheduleStore.TryMarkTriggeredAsync(DateTime.UtcNow, cancellationToken);
+            if (!trigger.Triggered || trigger.Schedule is null)
+            {
+                return;
+            }
+
+            var password = trigger.Schedule.EncryptionEnabled && !string.IsNullOrWhiteSpace(trigger.ProtectedSecret)
+                ? _secretProtector.Unprotect(trigger.ProtectedSecret)
+                : null;
+
+            var request = new BackupRequest(
+                ParseScope(trigger.Schedule.Scope),
+                trigger.Schedule.StoragePath,
+                trigger.Schedule.EncryptionEnabled,
+                password,
+                trigger.ProtectedSecret,
+                trigger.Schedule.SendEmail,
+                trigger.Schedule.EmailRecipients,
+                trigger.Schedule.IntegrityCheckEnabled,
+                true);
+
+            await QueueBackupAsync(request, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Naplánovanou zálohu se nepodařilo zařadit do fronty.");
+        }
+    }
+
+    public async Task ProcessPendingJobsAsync(CancellationToken cancellationToken = default)
+    {
+        var pendingJobs = await _dbContext.BackupJobs
+            .Where(x => x.JobStatus == BackupJobStatus.Pending)
+            .OrderBy(x => x.CreatedAtUtc)
+            .Take(3)
+            .ToListAsync(cancellationToken);
+
+        if (pendingJobs.Count == 0)
+        {
+            return;
+        }
+
+        var actor = ResolveActor(true);
+        foreach (var job in pendingJobs)
+        {
+            job.JobStatus = BackupJobStatus.Running;
+            job.ModifiedBy = actor;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        foreach (var job in pendingJobs)
+        {
+            await ProcessJobAsync(job, cancellationToken);
+        }
+    }
+
+    private async Task ProcessJobAsync(BackupJob job, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var archiveBytes = await BuildArchiveAsync(job.Scope, cancellationToken);
+            var filePath = Path.Combine(job.StoragePath, job.FileName);
+
+            var payloadBytes = archiveBytes;
+            string? password = null;
+            if (job.EncryptionEnabled)
+            {
+                password = job.ProtectedEncryptionSecret is null
+                    ? throw new InvalidOperationException("Šifrovaná záloha nemá uložené heslo.")
+                    : _secretProtector.Unprotect(job.ProtectedEncryptionSecret);
+
+                payloadBytes = Encrypt(archiveBytes, password);
+            }
+
+            await File.WriteAllBytesAsync(filePath, payloadBytes, cancellationToken);
+            var info = new FileInfo(filePath);
+            job.FileSizeBytes = info.Length;
+            job.ArtifactPath = filePath;
+            job.CompletedAtUtc = DateTime.UtcNow;
+
+            if (job.IntegrityCheckEnabled)
+            {
+                var integrityBytes = job.EncryptionEnabled && password is not null
+                    ? archiveBytes
+                    : payloadBytes;
+
+                job.IntegrityPassed = await PerformIntegrityTestAsync(integrityBytes, job.Scope, cancellationToken);
+                job.IntegrityCheckedAtUtc = DateTime.UtcNow;
+            }
+
+            job.JobStatus = BackupJobStatus.Completed;
+            job.FailureReason = null;
+
+            if (job.SendEmail)
+            {
+                await SendNotificationAsync(job, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Zpracování zálohy selhalo");
+            job.JobStatus = BackupJobStatus.Failed;
+            job.FailureReason = ex.Message;
+            job.CompletedAtUtc = DateTime.UtcNow;
+        }
+        finally
+        {
+            job.ModifiedBy = ResolveActor(true);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task<byte[]> BuildArchiveAsync(BackupScope scope, CancellationToken cancellationToken)
+    {
+        await using var memory = new MemoryStream();
+        using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, true))
+        {
+            await WriteJsonEntryAsync(archive, "metadata.json", new
+            {
+                Scope = scope.ToString(),
+                GeneratedAtUtc = DateTime.UtcNow
+            }, cancellationToken);
+
+            if (scope == BackupScope.Full || scope == BackupScope.Dictionaries)
+            {
+                var dictionaries = await _dbContext.DictionaryEntries.AsNoTracking().ToListAsync(cancellationToken);
+                await WriteJsonEntryAsync(archive, "dictionaries.json", dictionaries, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Servers)
+            {
+                var servers = await _dbContext.Servers
+                    .AsNoTracking()
+                    .Include(x => x.NetworkAssignments)
+                    .ToListAsync(cancellationToken);
+                await WriteJsonEntryAsync(archive, "servers.json", servers, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.NetworkDevices)
+            {
+                var network = await _dbContext.NetworkDevices
+                    .AsNoTracking()
+                    .Include(x => x.NetworkAssignments)
+                    .ToListAsync(cancellationToken);
+                await WriteJsonEntryAsync(archive, "network-devices.json", network, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Workstations)
+            {
+                var workstations = await _dbContext.Workstations
+                    .AsNoTracking()
+                    .Include(x => x.NetworkAssignments)
+                    .ToListAsync(cancellationToken);
+                await WriteJsonEntryAsync(archive, "workstations.json", workstations, cancellationToken);
+            }
+        }
+
+        return memory.ToArray();
+    }
+
+    private static async Task WriteJsonEntryAsync(ZipArchive archive, string entryName, object data, CancellationToken cancellationToken)
+    {
+        var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+        await using var entryStream = entry.Open();
+        await JsonSerializer.SerializeAsync(entryStream, data, JsonOptions, cancellationToken);
+    }
+
+    private async Task RestoreFromArchiveAsync(byte[] archiveBytes, BackupScope scope, CancellationToken cancellationToken)
+    {
+        await using var stream = new MemoryStream(archiveBytes);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, true);
+
+        var dbContext = _dbContext as DbContext;
+        if (dbContext is null)
+        {
+            throw new InvalidOperationException("DbContext neumožňuje transakce.");
+        }
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            if (scope == BackupScope.Full || scope == BackupScope.Dictionaries)
+            {
+                await RestoreCollectionAsync<DictionaryEntry>(archive, "dictionaries.json", _dbContext.DictionaryEntries, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Servers)
+            {
+                await RestoreCollectionAsync<Server>(archive, "servers.json", _dbContext.Servers, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.NetworkDevices)
+            {
+                await RestoreCollectionAsync<NetworkDevice>(archive, "network-devices.json", _dbContext.NetworkDevices, cancellationToken);
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Workstations)
+            {
+                await RestoreCollectionAsync<Workstation>(archive, "workstations.json", _dbContext.Workstations, cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    private async Task RestoreCollectionAsync<TEntity>(ZipArchive archive, string entryName, DbSet<TEntity> set, CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        var entry = archive.GetEntry(entryName);
+        if (entry is null)
+        {
+            return;
+        }
+
+        await using var entryStream = entry.Open();
+        var items = await JsonSerializer.DeserializeAsync<List<TEntity>>(entryStream, JsonOptions, cancellationToken);
+        if (items is null)
+        {
+            return;
+        }
+
+        set.RemoveRange(set);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await set.AddRangeAsync(items, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<bool> PerformIntegrityTestAsync(byte[] archiveBytes, BackupScope scope, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = new MemoryStream(archiveBytes);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read, true);
+            var expectedEntries = new List<string> { "metadata.json" };
+            if (scope == BackupScope.Full || scope == BackupScope.Dictionaries)
+            {
+                expectedEntries.Add("dictionaries.json");
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Servers)
+            {
+                expectedEntries.Add("servers.json");
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.NetworkDevices)
+            {
+                expectedEntries.Add("network-devices.json");
+            }
+
+            if (scope == BackupScope.Full || scope == BackupScope.Workstations)
+            {
+                expectedEntries.Add("workstations.json");
+            }
+
+            foreach (var entry in expectedEntries)
+            {
+                if (archive.GetEntry(entry) is null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Integrity check failed");
+            return false;
+        }
+    }
+
+    private async Task SendNotificationAsync(BackupJob job, CancellationToken cancellationToken)
+    {
+        var connector = await _emailConnectorStore.GetAsync(cancellationToken);
+        if (connector is null || !connector.Enabled)
+        {
+            _logger.LogWarning("SMTP konektor není nastaven, notifikace nebude odeslána.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(connector.Host))
+        {
+            _logger.LogWarning("SMTP host není nastaven.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(job.EmailRecipients))
+        {
+            return;
+        }
+
+        var recipients = job.EmailRecipients.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (recipients.Length == 0)
+        {
+            return;
+        }
+
+        var password = connector.HasPassword
+            ? (await _dbContext.ConnectorProfiles
+                .Include(x => x.Secrets)
+                .Where(x => x.Type == "SMTP")
+                .SelectMany(x => x.Secrets)
+                .Select(x => x.SecretReference)
+                .FirstOrDefaultAsync(cancellationToken))
+            : null;
+
+        try
+        {
+#pragma warning disable SYSLIB0014
+            using var smtp = new SmtpClient(connector.Host, connector.Port)
+            {
+                EnableSsl = connector.UseTls
+            };
+
+            if (!string.IsNullOrWhiteSpace(connector.Username) && !string.IsNullOrWhiteSpace(password))
+            {
+                smtp.Credentials = new System.Net.NetworkCredential(connector.Username, password);
+            }
+
+            using var message = new MailMessage
+            {
+                From = new MailAddress(connector.FromAddress ?? "no-reply@example.com"),
+                Subject = "HW Inventory – záloha dokončena",
+                Body = $"Záloha {job.FileName} byla dokončena v {job.CompletedAtUtc:yyyy-MM-dd HH:mm:ss} UTC.",
+                IsBodyHtml = false
+            };
+
+            foreach (var recipient in recipients)
+            {
+                message.To.Add(new MailAddress(recipient));
+            }
+
+            if (!string.IsNullOrWhiteSpace(job.ArtifactPath) && File.Exists(job.ArtifactPath))
+            {
+                message.Attachments.Add(new Attachment(job.ArtifactPath));
+            }
+
+            await smtp.SendMailAsync(message);
+#pragma warning restore SYSLIB0014
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Odeslání notifikace o záloze selhalo");
+            job.FailureReason = string.IsNullOrWhiteSpace(job.FailureReason)
+                ? $"Notifikace nebyla doručena: {ex.Message}"
+                : job.FailureReason + $"; Notifikace: {ex.Message}";
+        }
+    }
+
+    private static BackupScope ParseScope(string scope)
+    {
+        return Enum.TryParse<BackupScope>(scope, true, out var parsed) ? parsed : BackupScope.Full;
+    }
+
+    private static string BuildFileName(BackupScope scope, bool encrypted)
+    {
+        var suffix = encrypted ? ".hwbk" : ".zip";
+        return $"HWInventory_{scope}_{DateTime.UtcNow:yyyyMMddHHmmss}{suffix}";
+    }
+
+    private string ResolveActor(bool automatic)
+    {
+        if (automatic)
+        {
+            return "system";
+        }
+
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+
+    private static string? NormalizeRecipients(string? recipients)
+    {
+        if (string.IsNullOrWhiteSpace(recipients))
+        {
+            return null;
+        }
+
+        var normalized = string.Join(";", recipients
+            .Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static byte[] Encrypt(byte[] data, string password)
+    {
+        using var aes = Aes.Create();
+        aes.KeySize = 256;
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var key = new Rfc2898DeriveBytes(password, salt, 100_000, HashAlgorithmName.SHA256);
+        aes.Key = key.GetBytes(32);
+        aes.GenerateIV();
+
+        using var ms = new MemoryStream();
+        ms.Write(new byte[] { (byte)'H', (byte)'W', (byte)'B', (byte)'K', 1 });
+        ms.Write(BitConverter.GetBytes(salt.Length));
+        ms.Write(salt);
+        ms.Write(BitConverter.GetBytes(aes.IV.Length));
+        ms.Write(aes.IV);
+        using (var crypto = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        {
+            crypto.Write(data, 0, data.Length);
+            crypto.FlushFinalBlock();
+        }
+
+        return ms.ToArray();
+    }
+
+    private static byte[] Decrypt(byte[] encrypted, string password)
+    {
+        using var ms = new MemoryStream(encrypted);
+        Span<byte> header = stackalloc byte[5];
+        if (ms.Read(header) != 5 || header[0] != 'H' || header[1] != 'W' || header[2] != 'B' || header[3] != 'K')
+        {
+            throw new InvalidOperationException("Neplatný formát zálohy.");
+        }
+
+        var saltLengthBuffer = new byte[sizeof(int)];
+        ms.Read(saltLengthBuffer, 0, saltLengthBuffer.Length);
+        var saltLength = BitConverter.ToInt32(saltLengthBuffer, 0);
+        var salt = new byte[saltLength];
+        ms.Read(salt, 0, salt.Length);
+
+        var ivLengthBuffer = new byte[sizeof(int)];
+        ms.Read(ivLengthBuffer, 0, ivLengthBuffer.Length);
+        var ivLength = BitConverter.ToInt32(ivLengthBuffer, 0);
+        var iv = new byte[ivLength];
+        ms.Read(iv, 0, iv.Length);
+
+        using var aes = Aes.Create();
+        var key = new Rfc2898DeriveBytes(password, salt, 100_000, HashAlgorithmName.SHA256);
+        aes.Key = key.GetBytes(32);
+        aes.IV = iv;
+
+        using var crypto = new CryptoStream(ms, aes.CreateDecryptor(), CryptoStreamMode.Read);
+        using var result = new MemoryStream();
+        crypto.CopyTo(result);
+        return result.ToArray();
+    }
+
+    private static string BuildStatus(BackupJob job)
+    {
+        return job.JobStatus.ToString();
+    }
+
+    private static BackupJobModel Map(BackupJob job)
+    {
+        return new BackupJobModel(
+            job.Id,
+            job.Scope.ToString(),
+            job.FileName,
+            job.StoragePath,
+            job.EncryptionEnabled,
+            job.SendEmail,
+            job.IntegrityCheckEnabled,
+            job.IsAutomatic,
+            BuildStatus(job),
+            job.FileSizeBytes,
+            job.CompletedAtUtc,
+            job.IntegrityPassed,
+            job.CreatedAtUtc,
+            job.CreatedBy ?? "system",
+            job.FailureReason);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Maintenance/UpdateService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Maintenance/UpdateService.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Maintenance;
+
+public class UpdateService : IUpdateService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private readonly IAppDbContext _dbContext;
+    private readonly IBackupService _backupService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<UpdateService> _logger;
+
+    public UpdateService(
+        IAppDbContext dbContext,
+        IBackupService backupService,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<UpdateService> logger)
+    {
+        _dbContext = dbContext;
+        _backupService = backupService;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<UpdatePackageModel> QueuePackageAsync(UpdatePackageRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.StoragePath))
+        {
+            throw new ArgumentException("Storage path is required", nameof(request.StoragePath));
+        }
+
+        Directory.CreateDirectory(request.StoragePath);
+
+        var package = new UpdatePackage
+        {
+            Version = string.IsNullOrWhiteSpace(request.Version) ? InferVersion(request.FileName) : request.Version!,
+            FileName = string.IsNullOrWhiteSpace(request.FileName)
+                ? $"update_{DateTime.UtcNow:yyyyMMddHHmmss}.zip"
+                : request.FileName,
+            PreserveDatabaseConfiguration = request.PreserveDatabaseConfiguration,
+            CreateBackupBeforeInstall = request.CreateBackupBeforeInstall,
+            BackupStoragePath = request.BackupStoragePath,
+            PerformIntegrityCheck = request.PerformIntegrityCheck,
+            ConfirmedBackupAvailable = request.ConfirmedBackupAvailable,
+            Notes = request.Notes,
+            UpdateStatus = UpdatePackageStatus.Pending,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = ResolveActor()
+        };
+
+        var storedFileName = $"{package.Id:N}_{package.FileName}";
+        var storedPath = Path.Combine(request.StoragePath, storedFileName);
+        var stagingPath = Path.Combine(request.StoragePath, $"{package.Id:N}_staging");
+
+        var bytes = Convert.FromBase64String(request.ContentBase64);
+        await File.WriteAllBytesAsync(storedPath, bytes, cancellationToken);
+
+        package.StoredPath = storedPath;
+        package.StagingPath = stagingPath;
+        package.Sha256 = Convert.ToHexString(SHA256.HashData(bytes));
+
+        _dbContext.UpdatePackages.Add(package);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Update balík {Version} zařazen do fronty (soubor {File})", package.Version, package.FileName);
+
+        return Map(package);
+    }
+
+    public async Task<IReadOnlyList<UpdatePackageModel>> ListHistoryAsync(int page, int size, CancellationToken cancellationToken = default)
+    {
+        var packages = await _dbContext.UpdatePackages
+            .AsNoTracking()
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .Skip(Math.Max(page - 1, 0) * size)
+            .Take(size)
+            .ToListAsync(cancellationToken);
+
+        return packages.Select(Map).ToList();
+    }
+
+    public async Task<UpdatePackageModel?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var package = await _dbContext.UpdatePackages.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return package is null ? null : Map(package);
+    }
+
+    public async Task<byte[]?> GetLogAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var package = await _dbContext.UpdatePackages.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (package?.LogPath is null || !File.Exists(package.LogPath))
+        {
+            return null;
+        }
+
+        return await File.ReadAllBytesAsync(package.LogPath, cancellationToken);
+    }
+
+    public async Task ProcessPendingPackagesAsync(CancellationToken cancellationToken = default)
+    {
+        var pendingPackages = await _dbContext.UpdatePackages
+            .Where(x => x.UpdateStatus == UpdatePackageStatus.Pending)
+            .OrderBy(x => x.CreatedAtUtc)
+            .Take(1)
+            .ToListAsync(cancellationToken);
+
+        if (!pendingPackages.Any())
+        {
+            return;
+        }
+
+        foreach (var package in pendingPackages)
+        {
+            package.UpdateStatus = UpdatePackageStatus.Validating;
+            package.ModifiedAtUtc = DateTime.UtcNow;
+            package.ModifiedBy = "system";
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        foreach (var package in pendingPackages)
+        {
+            await ProcessPackageAsync(package, cancellationToken);
+        }
+    }
+
+    private async Task ProcessPackageAsync(UpdatePackage package, CancellationToken cancellationToken)
+    {
+        var log = new List<string>();
+        var logPath = Path.Combine(Path.GetDirectoryName(package.StoredPath) ?? AppContext.BaseDirectory, $"{package.Id:N}_update.log");
+
+        try
+        {
+            log.Add(LogLine("Start verifikace aktualizačního balíčku."));
+            if (!File.Exists(package.StoredPath))
+            {
+                throw new FileNotFoundException("Balíček nebyl nalezen na disku.", package.StoredPath);
+            }
+
+            if (package.PerformIntegrityCheck)
+            {
+                var bytes = await File.ReadAllBytesAsync(package.StoredPath, cancellationToken);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                log.Add(LogLine($"Výpočet SHA256: {hash}"));
+                if (!hash.Equals(package.Sha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException("Kontrola integrity souboru selhala – hash nesouhlasí.");
+                }
+            }
+
+            package.UpdateStatus = UpdatePackageStatus.Running;
+            package.ModifiedAtUtc = DateTime.UtcNow;
+            package.ModifiedBy = "system";
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            if (package.CreateBackupBeforeInstall)
+            {
+                var backupPath = package.BackupStoragePath;
+                if (string.IsNullOrWhiteSpace(backupPath))
+                {
+                    backupPath = Path.Combine(Path.GetDirectoryName(package.StoredPath) ?? AppContext.BaseDirectory, "backups");
+                }
+
+                Directory.CreateDirectory(backupPath);
+
+                log.Add(LogLine($"Spouštím zálohu před aktualizací do {backupPath}."));
+                var backupJob = await _backupService.QueueBackupAsync(new BackupRequest(
+                    BackupScope.Full,
+                    backupPath,
+                    false,
+                    null,
+                    null,
+                    false,
+                    null,
+                    package.PerformIntegrityCheck,
+                    true),
+                    cancellationToken);
+
+                await _backupService.ProcessPendingJobsAsync(cancellationToken);
+                log.Add(LogLine($"Záloha {backupJob.Id} byla dokončena se stavem {backupJob.Status}."));
+            }
+
+            if (Directory.Exists(package.StagingPath))
+            {
+                Directory.Delete(package.StagingPath, true);
+            }
+
+            Directory.CreateDirectory(package.StagingPath);
+            log.Add(LogLine($"Extrahuji balíček do {package.StagingPath}."));
+            ZipFile.ExtractToDirectory(package.StoredPath, package.StagingPath, true);
+
+            var manifestPath = ResolveManifestPath(package.StagingPath);
+            if (manifestPath is not null)
+            {
+                var manifestJson = await File.ReadAllTextAsync(manifestPath, cancellationToken);
+                package.ManifestJson = manifestJson;
+                log.Add(LogLine($"Načten manifest {Path.GetFileName(manifestPath)}."));
+
+                var manifest = JsonSerializer.Deserialize<UpdateManifest>(manifestJson, JsonOptions);
+                if (!string.IsNullOrWhiteSpace(manifest?.Version))
+                {
+                    package.Version = manifest.Version!;
+                    log.Add(LogLine($"Verze dle manifestu: {manifest.Version}"));
+                }
+
+                if (manifest?.Migrations is { Length: > 0 })
+                {
+                    log.Add(LogLine($"Manifest deklaruje {manifest.Migrations.Length} migrací."));
+                }
+            }
+            else
+            {
+                log.Add(LogLine("Manifest nebyl nalezen – pokračuji bez něj."));
+            }
+
+            package.UpdateStatus = UpdatePackageStatus.Completed;
+            package.CompletedAtUtc = DateTime.UtcNow;
+            package.ModifiedAtUtc = DateTime.UtcNow;
+            package.ModifiedBy = "system";
+            package.FailureReason = null;
+            log.Add(LogLine("Aktualizace připravena ve staging adresáři. Nasazení je možné dokončit publikací obsahu dle dokumentace."));
+        }
+        catch (Exception ex)
+        {
+            package.UpdateStatus = UpdatePackageStatus.Failed;
+            package.CompletedAtUtc = DateTime.UtcNow;
+            package.ModifiedAtUtc = DateTime.UtcNow;
+            package.ModifiedBy = "system";
+            package.FailureReason = ex.Message;
+            log.Add(LogLine($"Chyba: {ex.Message}"));
+            _logger.LogError(ex, "Zpracování aktualizačního balíčku {PackageId} selhalo", package.Id);
+        }
+        finally
+        {
+            package.LogPath = logPath;
+            await File.WriteAllLinesAsync(logPath, log, cancellationToken);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static string InferVersion(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return "vNext";
+        }
+
+        var parts = Path.GetFileNameWithoutExtension(fileName).Split(new[] { '_', '-' }, StringSplitOptions.RemoveEmptyEntries);
+        var versionPart = parts.LastOrDefault(part => part.Any(char.IsDigit));
+        return string.IsNullOrWhiteSpace(versionPart) ? "vNext" : versionPart;
+    }
+
+    private static string? ResolveManifestPath(string stagingPath)
+    {
+        var manifestCandidates = new[]
+        {
+            Path.Combine(stagingPath, "update-manifest.json"),
+            Path.Combine(stagingPath, "manifest.json"),
+            Path.Combine(stagingPath, "docs", "update-manifest.json")
+        };
+
+        return manifestCandidates.FirstOrDefault(File.Exists);
+    }
+
+    private string ResolveActor()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        if (user?.Identity is not null && user.Identity.IsAuthenticated)
+        {
+            return user.Identity.Name ?? "unknown";
+        }
+
+        return "system";
+    }
+
+    private static string LogLine(string message) => $"[{DateTime.UtcNow:O}] {message}";
+
+    private static UpdatePackageModel Map(UpdatePackage package) => new(
+        package.Id,
+        package.Version,
+        package.FileName,
+        package.UpdateStatus.ToString(),
+        package.Sha256,
+        package.StoredPath,
+        package.StagingPath,
+        package.PreserveDatabaseConfiguration,
+        package.CreateBackupBeforeInstall,
+        package.PerformIntegrityCheck,
+        package.ConfirmedBackupAvailable,
+        package.Notes,
+        package.CreatedAtUtc,
+        package.CompletedAtUtc,
+        package.CreatedBy,
+        package.FailureReason,
+        package.ManifestJson,
+        package.LogPath);
+
+    private sealed record UpdateManifest(string? Version, string? Description, string? RequiredDbVersion, string[]? Migrations);
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,755 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: string.Empty),
+                    IsDomainAccount = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorRequired = table.Column<bool>(type: "bit", nullable: false),
+                    Department = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AuthenticatorKey = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false, defaultValue: "system"),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "bit", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AppSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Section = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    EntityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Action = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    PerformedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Roles = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    PerformedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ChangeSummary = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true),
+                    ChangedFieldsJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    UserAgent = table.Column<string>(type: "nvarchar(400)", maxLength: 400, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Alias = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    HealthStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Configuration = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DictionaryEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DictType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DictionaryEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FeatureModules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FeatureModules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Target = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    JobStatus = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ArtifactPath = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Format = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDevices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    DeviceTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDevices", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Servers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Manufacturer = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Model = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    EnvironmentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WsusPriorityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerRoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RackPosition = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Servers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Workstations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    InventoryNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    OperatingSystemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationTypeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OwnerId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    OwnerDisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    OwnerDepartment = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LocationNote = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Cpu = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Ram = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Storage = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    MacAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    PurchasedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SupportUntil = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    PrimaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SecondaryAdministratorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Workstations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConnectorSecrets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ConnectorProfileId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    SecretReference = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConnectorSecrets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConnectorSecrets_ConnectorProfiles_ConnectorProfileId",
+                        column: x => x.ConnectorProfileId,
+                        principalTable: "ConnectorProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataScopes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DepartmentKey = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    LocationId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    ScopeType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataScopes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DataScopes_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PasswordResetTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DeliveryMethod = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    DeliveryAddress = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: true),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ConsumedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CaptchaToken = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IdentityToken = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: false),
+                    SmsCodeHash = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    RequiresSmsVerification = table.Column<bool>(type: "bit", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PasswordResetTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PasswordResetTokens_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserSessions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AppUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SessionIdentifier = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    IssuedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    LastSeenAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IpAddress = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    UserAgent = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    RevokedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RevokedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    TerminationReason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserSessions_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LabelPrintJobItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LabelPrintJobId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Copies = table.Column<int>(type: "int", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LabelPrintJobItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LabelPrintJobItems_LabelPrintJobs_LabelPrintJobId",
+                        column: x => x.LabelPrintJobId,
+                        principalTable: "LabelPrintJobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NetworkDeviceAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    NetworkDeviceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NetworkDeviceAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NetworkDeviceAssignments_NetworkDevices_NetworkDeviceId",
+                        column: x => x.NetworkDeviceId,
+                        principalTable: "NetworkDevices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServerNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServerNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServerNetworkAssignments_Servers_ServerId",
+                        column: x => x.ServerId,
+                        principalTable: "Servers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkstationNetworkAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkstationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    VlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IpAddress = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkstationNetworkAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkstationNetworkAssignments_Workstations_WorkstationId",
+                        column: x => x.WorkstationId,
+                        principalTable: "Workstations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true,
+                filter: "[NormalizedName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true,
+                filter: "[NormalizedUserName] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConnectorSecrets_ConnectorProfileId",
+                table: "ConnectorSecrets",
+                column: "ConnectorProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataScopes_AppUserId",
+                table: "DataScopes",
+                column: "AppUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PasswordResetTokens_AppUserId_Status",
+                table: "PasswordResetTokens",
+                columns: new[] { "AppUserId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PasswordResetTokens_Token",
+                table: "PasswordResetTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_AppUserId_IsRevoked",
+                table: "UserSessions",
+                columns: new[] { "AppUserId", "IsRevoked" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_SessionIdentifier",
+                table: "UserSessions",
+                column: "SessionIdentifier",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LabelPrintJobItems_LabelPrintJobId",
+                table: "LabelPrintJobItems",
+                column: "LabelPrintJobId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NetworkDeviceAssignments_NetworkDeviceId",
+                table: "NetworkDeviceAssignments",
+                column: "NetworkDeviceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerNetworkAssignments_ServerId",
+                table: "ServerNetworkAssignments",
+                column: "ServerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkstationNetworkAssignments_WorkstationId",
+                table: "WorkstationNetworkAssignments",
+                column: "WorkstationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppSettings");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AuditLogs");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorSecrets");
+
+            migrationBuilder.DropTable(
+                name: "PasswordResetTokens");
+
+            migrationBuilder.DropTable(
+                name: "UserSessions");
+
+            migrationBuilder.DropTable(
+                name: "DataScopes");
+
+            migrationBuilder.DropTable(
+                name: "DictionaryEntries");
+
+            migrationBuilder.DropTable(
+                name: "FeatureModules");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobItems");
+
+            migrationBuilder.DropTable(
+                name: "LabelTemplates");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDeviceAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ServerNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "WorkstationNetworkAssignments");
+
+            migrationBuilder.DropTable(
+                name: "ConnectorProfiles");
+
+            migrationBuilder.DropTable(
+                name: "LabelPrintJobs");
+
+            migrationBuilder.DropTable(
+                name: "NetworkDevices");
+
+            migrationBuilder.DropTable(
+                name: "Servers");
+
+            migrationBuilder.DropTable(
+                name: "Workstations");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101000500_AddLdapRoleMappingsAndSecurityConnectors.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101000500_AddLdapRoleMappingsAndSecurityConnectors.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddLdapRoleMappingsAndSecurityConnectors : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LdapRoleMappings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    GroupName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    RoleName = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LdapRoleMappings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LdapRoleMappings_GroupName",
+                table: "LdapRoleMappings",
+                column: "GroupName");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LdapRoleMappings");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101001500_AddBackupModule.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101001500_AddBackupModule.cs
@@ -1,0 +1,82 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBackupModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BackupSchedules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    Frequency = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    DayOfWeek = table.Column<int>(type: "int", nullable: true),
+                    DayOfMonth = table.Column<int>(type: "int", nullable: true),
+                    ExecutionTimeUtc = table.Column<TimeSpan>(type: "time", nullable: false),
+                    Scope = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    StoragePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    EncryptionEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    ProtectedEncryptionSecret = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SendEmail = table.Column<bool>(type: "bit", nullable: false),
+                    EmailRecipients = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    IntegrityCheckEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    LastRunAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    NextRunAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupSchedules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Scope = table.Column<int>(type: "int", nullable: false),
+                    StoragePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    FileName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    EncryptionEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    ProtectedEncryptionSecret = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SendEmail = table.Column<bool>(type: "bit", nullable: false),
+                    EmailRecipients = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    IntegrityCheckEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    JobStatus = table.Column<int>(type: "int", nullable: false),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: true),
+                    CompletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IntegrityPassed = table.Column<bool>(type: "bit", nullable: true),
+                    IntegrityCheckedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ArtifactPath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    FailureReason = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    IsAutomatic = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupJobs", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BackupJobs");
+
+            migrationBuilder.DropTable(
+                name: "BackupSchedules");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101002500_AddExportJobs.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101002500_AddExportJobs.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddExportJobs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExportJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Scope = table.Column<int>(type: "int", nullable: false),
+                    Format = table.Column<int>(type: "int", nullable: false),
+                    JobStatus = table.Column<int>(type: "int", nullable: false),
+                    StoragePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    FileName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    FilterJson = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: true),
+                    CompletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    FailureReason = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    ArtifactPath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    SendEmail = table.Column<bool>(type: "bit", nullable: false),
+                    EmailRecipients = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExportJobs", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExportJobs");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101002600_AddImportJobs.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101002600_AddImportJobs.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddImportJobs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImportJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Scope = table.Column<int>(type: "int", nullable: false),
+                    Format = table.Column<int>(type: "int", nullable: false),
+                    JobStatus = table.Column<int>(type: "int", nullable: false),
+                    ConflictStrategy = table.Column<int>(type: "int", nullable: false),
+                    DryRun = table.Column<bool>(type: "bit", nullable: false),
+                    StoragePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    OriginalFileName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    StoredFilePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    MappingJson = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    ResultLog = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    CompletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    FailureReason = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    ProcessedRows = table.Column<long>(type: "bigint", nullable: true),
+                    CreatedRows = table.Column<long>(type: "bigint", nullable: true),
+                    UpdatedRows = table.Column<long>(type: "bigint", nullable: true),
+                    SkippedRows = table.Column<long>(type: "bigint", nullable: true),
+                    SendEmail = table.Column<bool>(type: "bit", nullable: false),
+                    EmailRecipients = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportJobs", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImportJobs");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101002700_AddPasswordHistory.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101002700_AddPasswordHistory.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddPasswordHistory : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PasswordHistoryEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PasswordHistoryEntries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PasswordHistoryEntries_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PasswordHistoryEntries_UserId_CreatedAtUtc",
+                table: "PasswordHistoryEntries",
+                columns: new[] { "UserId", "CreatedAtUtc" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PasswordHistoryEntries");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/20240101002800_AddUpdatePackages.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/20240101002800_AddUpdatePackages.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    public partial class AddUpdatePackages : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UpdatePackages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Version = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    FileName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    StoredPath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    StagingPath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    Sha256 = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    ManifestJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    UpdateStatus = table.Column<int>(type: "int", nullable: false),
+                    PreserveDatabaseConfiguration = table.Column<bool>(type: "bit", nullable: false),
+                    CreateBackupBeforeInstall = table.Column<bool>(type: "bit", nullable: false),
+                    BackupStoragePath = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    PerformIntegrityCheck = table.Column<bool>(type: "bit", nullable: false),
+                    ConfirmedBackupAvailable = table.Column<bool>(type: "bit", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    CompletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    FailureReason = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    LogPath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    ModifiedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UpdatePackages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdatePackages_CreatedAtUtc",
+                table: "UpdatePackages",
+                column: "CreatedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdatePackages_UpdateStatus",
+                table: "UpdatePackages",
+                column: "UpdateStatus");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UpdatePackages");
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/api/src/HWInventory.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -1,0 +1,1512 @@
+using System;
+using HWInventory.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace HWInventory.Infrastructure.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    partial class AppDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppRole", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Description")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("Name")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedName").IsUnique().HasFilter("[NormalizedName] IS NOT NULL");
+
+                b.ToTable("AspNetRoles", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppSetting", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Section")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Value")
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AppSettings");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.BackupJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ArtifactPath")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<DateTime?>("CompletedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("EmailRecipients")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<bool>("EncryptionEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<string>("FailureReason")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<string>("FileName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<long?>("FileSizeBytes")
+                    .HasColumnType("bigint");
+
+                b.Property<bool?>("IntegrityPassed")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("IntegrityCheckEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<DateTime?>("IntegrityCheckedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<bool>("IsAutomatic")
+                    .HasColumnType("bit");
+
+                b.Property<int>("JobStatus")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("ProtectedEncryptionSecret")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Scope")
+                    .HasColumnType("int");
+
+                b.Property<bool>("SendEmail")
+                    .HasColumnType("bit");
+
+                b.Property<string>("StoragePath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("BackupJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ExportJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ArtifactPath")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<DateTime?>("CompletedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("EmailRecipients")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<DateTime?>("ExpiresAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("FailureReason")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<string>("FileName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<long?>("FileSizeBytes")
+                    .HasColumnType("bigint");
+
+                b.Property<string>("FilterJson")
+                    .HasMaxLength(2048)
+                    .HasColumnType("nvarchar(2048)");
+
+                b.Property<int>("Format")
+                    .HasColumnType("int");
+
+                b.Property<int>("JobStatus")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Scope")
+                    .HasColumnType("int");
+
+                b.Property<bool>("SendEmail")
+                    .HasColumnType("bit");
+
+                b.Property<string>("StoragePath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("ExportJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ImportJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("CompletedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("ConflictStrategy")
+                    .HasColumnType("int");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<long?>("CreatedRows")
+                    .HasColumnType("bigint");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("DryRun")
+                    .HasColumnType("bit");
+
+                b.Property<string>("EmailRecipients")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<string>("FailureReason")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("Format")
+                    .HasColumnType("int");
+
+                b.Property<int>("JobStatus")
+                    .HasColumnType("int");
+
+                b.Property<string>("MappingJson")
+                    .HasMaxLength(2048)
+                    .HasColumnType("nvarchar(2048)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("OriginalFileName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<long?>("ProcessedRows")
+                    .HasColumnType("bigint");
+
+                b.Property<string>("ResultLog")
+                    .HasMaxLength(2048)
+                    .HasColumnType("nvarchar(2048)");
+
+                b.Property<long?>("SkippedRows")
+                    .HasColumnType("bigint");
+
+                b.Property<int>("Scope")
+                    .HasColumnType("int");
+
+                b.Property<bool>("SendEmail")
+                    .HasColumnType("bit");
+
+                b.Property<long?>("UpdatedRows")
+                    .HasColumnType("bigint");
+
+                b.Property<string>("StoragePath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<string>("StoredFilePath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("ImportJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.UpdatePackage", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("BackupStoragePath")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<bool>("ConfirmedBackupAvailable")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("CreateBackupBeforeInstall")
+                    .HasColumnType("bit");
+
+                b.Property<DateTime?>("CompletedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("FailureReason")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<string>("FileName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("LogPath")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<string>("ManifestJson")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("Notes")
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<bool>("PerformIntegrityCheck")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("PreserveDatabaseConfiguration")
+                    .HasColumnType("bit");
+
+                b.Property<string>("Sha256")
+                    .IsRequired()
+                    .HasMaxLength(128)
+                    .HasColumnType("nvarchar(128)");
+
+                b.Property<string>("StagingPath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("StoredPath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.Property<int>("UpdateStatus")
+                    .HasColumnType("int");
+
+                b.Property<string>("Version")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("CreatedAtUtc");
+
+                b.HasIndex("UpdateStatus");
+
+                b.ToTable("UpdatePackages");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.BackupSchedule", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int?>("DayOfMonth")
+                    .HasColumnType("int");
+
+                b.Property<int?>("DayOfWeek")
+                    .HasColumnType("int");
+
+                b.Property<string>("EmailRecipients")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<bool>("Enabled")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("EncryptionEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<TimeSpan>("ExecutionTimeUtc")
+                    .HasColumnType("time");
+
+                b.Property<string>("Frequency")
+                    .IsRequired()
+                    .HasMaxLength(32)
+                    .HasColumnType("nvarchar(32)");
+
+                b.Property<bool>("IntegrityCheckEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<DateTime?>("LastRunAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime?>("NextRunAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ProtectedEncryptionSecret")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Scope")
+                    .IsRequired()
+                    .HasMaxLength(32)
+                    .HasColumnType("nvarchar(32)");
+
+                b.Property<bool>("SendEmail")
+                    .HasColumnType("bit");
+
+                b.Property<string>("StoragePath")
+                    .IsRequired()
+                    .HasMaxLength(1024)
+                    .HasColumnType("nvarchar(1024)");
+
+                b.HasKey("Id");
+
+                b.ToTable("BackupSchedules");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("AccessFailedCount")
+                    .HasColumnType("int");
+
+                b.Property<string>("ConcurrencyStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue("system");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Department")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("AuthenticatorKey")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("DisplayName")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)")
+                    .HasDefaultValue(string.Empty);
+
+                b.Property<string>("Email")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<bool>("EmailConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("IsDomainAccount")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("LockoutEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<DateTimeOffset?>("LockoutEnd")
+                    .HasColumnType("datetimeoffset");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("NormalizedEmail")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("NormalizedUserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("PasswordHash")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("PhoneNumber")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("PhoneNumberConfirmed")
+                    .HasColumnType("bit");
+
+                b.Property<string>("SecurityStamp")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<bool>("TwoFactorEnabled")
+                    .HasColumnType("bit");
+
+                b.Property<bool>("TwoFactorRequired")
+                    .HasColumnType("bit");
+
+                b.Property<string>("UserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("NormalizedEmail");
+
+                b.HasIndex("NormalizedUserName").IsUnique().HasFilter("[NormalizedUserName] IS NOT NULL");
+
+                b.ToTable("AspNetUsers", (string)null);
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AuditLog", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Action")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ChangeSummary")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.Property<string>("ChangedFieldsJson")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid>("EntityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("EntityType")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("IpAddress")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<DateTime>("PerformedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("PerformedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Roles")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("UserAgent")
+                    .HasMaxLength(400)
+                    .HasColumnType("nvarchar(400)");
+
+                b.HasKey("Id");
+
+                b.ToTable("AuditLogs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Alias")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Configuration")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("HealthStatus")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("Type")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.ToTable("ConnectorProfiles");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ConnectorProfileId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("SecretReference")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ConnectorProfileId");
+
+                b.ToTable("ConnectorSecrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("DepartmentKey")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid?>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("ScopeType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId");
+
+                b.ToTable("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LdapRoleMapping", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("GroupName")
+                    .IsRequired()
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("RoleName")
+                    .IsRequired()
+                    .HasMaxLength(128)
+                    .HasColumnType("nvarchar(128)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("GroupName");
+
+                b.ToTable("LdapRoleMappings");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.PasswordResetToken", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CaptchaToken")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime?>("ConsumedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("DeliveryAddress")
+                    .HasMaxLength(300)
+                    .HasColumnType("nvarchar(300)");
+
+                b.Property<string>("DeliveryMethod")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<DateTime>("ExpiresAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("IdentityToken")
+                    .IsRequired()
+                    .HasMaxLength(2048)
+                    .HasColumnType("nvarchar(2048)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<bool>("RequiresSmsVerification")
+                    .HasColumnType("bit");
+
+                b.Property<string>("SmsCodeHash")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid>("Token")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId", "Status");
+
+                b.HasIndex("Token")
+                    .IsUnique();
+
+                b.ToTable("PasswordResetTokens");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.PasswordHistoryEntry", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("PasswordHash")
+                    .IsRequired()
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("UserId", "CreatedAtUtc");
+
+                b.ToTable("PasswordHistoryEntries");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.UserSession", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AppUserId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("IssuedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<bool>("IsRevoked")
+                    .HasColumnType("bit");
+
+                b.Property<DateTime>("LastSeenAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RevokedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("RevokedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("SessionIdentifier")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("TerminationReason")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("IpAddress")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("UserAgent")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("AppUserId", "IsRevoked");
+
+                b.HasIndex("SessionIdentifier")
+                    .IsUnique();
+
+                b.ToTable("UserSessions");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DictionaryEntry", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("DictType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Value")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("DictionaryEntries");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.FeatureModule", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<bool>("Enabled")
+                    .HasColumnType("bit");
+
+                b.Property<string>("Key")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("FeatureModules");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ArtifactPath")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("JobStatus")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Target")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelPrintJobs");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("AssetId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("AssetType")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<int>("Copies")
+                    .HasColumnType("int")
+                    .HasDefaultValue(1);
+
+                b.Property<Guid>("LabelPrintJobId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("LabelPrintJobId");
+
+                b.ToTable("LabelPrintJobItems");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelTemplate", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Code")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Format")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("ModifiedBy")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("ModifiedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Payload")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.ToTable("LabelTemplates");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("DeviceTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.HasKey("Id");
+
+                b.ToTable("NetworkDevices");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("EnvironmentId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("InventoryNumber")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Manufacturer")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Model")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RackPosition")
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("ServerRoleId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WsusPriorityId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Servers");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Cpu")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("CreatedBy")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime>("CreatedAtUtc")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("LocationId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("LocationNote")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("MacAddress")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid?>("OwnerId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("OwnerDepartment")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("OwnerDisplayName")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid?>("PrimaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("PurchasedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Ram")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid?>("SecondaryAdministratorId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Status")
+                    .HasColumnType("int");
+
+                b.Property<string>("Storage")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("SupportUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<Guid>("OperatingSystemId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("WorkstationTypeId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.ToTable("Workstations");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorSecret", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.ConnectorProfile", "ConnectorProfile")
+                    .WithMany("Secrets")
+                    .HasForeignKey("ConnectorProfileId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("ConnectorProfile");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.DataScope", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.AppUser", "AppUser")
+                    .WithMany("DataScopes")
+                    .HasForeignKey("AppUserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("AppUser");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJobItem", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.LabelPrintJob", null)
+                    .WithMany("Items")
+                    .HasForeignKey("LabelPrintJobId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.NetworkDevice", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("NetworkDeviceId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("NetworkDeviceId");
+
+                    b1.ToTable("NetworkDeviceAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Server", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("ServerId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("ServerId");
+
+                    b1.ToTable("ServerNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.Workstation", b =>
+            {
+                b.OwnsMany("NetworkAssignments", "HWInventory.Domain.ValueObjects.NetworkEndpoint", b1 =>
+                {
+                    b1.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<string>("IpAddress")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b1.Property<string>("Label")
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
+                    b1.Property<Guid?>("VlanId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.Property<Guid>("WorkstationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b1.HasKey("Id");
+
+                    b1.WithOwner().HasForeignKey("WorkstationId");
+
+                    b1.ToTable("WorkstationNetworkAssignments");
+                });
+
+                b.Navigation("NetworkAssignments");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.PasswordHistoryEntry", b =>
+            {
+                b.HasOne("HWInventory.Domain.Entities.AppUser", "User")
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("User");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.AppUser", b =>
+            {
+                b.Navigation("DataScopes");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.ConnectorProfile", b =>
+            {
+                b.Navigation("Secrets");
+            });
+
+            modelBuilder.Entity("HWInventory.Domain.Entities.LabelPrintJob", b =>
+            {
+                b.Navigation("Items");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityConfigurationStore.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Observability;
+
+public class ObservabilityConfigurationStore : IObservabilityConfigurationStore
+{
+    private const string SectionName = "Observability";
+
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ObservabilityConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<ObservabilityConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        var model = new ObservabilityConfigurationModel(
+            ReadString(settings, "LogLevel", "Information", allowNull: false) ?? "Information",
+            ReadBool(settings, "HealthEndpointEnabled", true),
+            ReadBool(settings, "MetricsEndpointEnabled", false),
+            ReadBool(settings, "CorrelationIdsEnabled", true),
+            ReadBool(settings, "IncludeTraceIdentifier", true),
+            ReadBool(settings, "OtelExporterEnabled", false),
+            ReadString(settings, "OtelEndpoint", null, allowNull: true),
+            ReadSecretPresent(settings, "OtelAuthToken"),
+            ReadString(settings, "ResourceAttributes", null, allowNull: true));
+
+        ObservabilityLogging.ApplyMinimumLevel(model.LogLevel);
+        return model;
+    }
+
+    public async Task<ObservabilityConfigurationModel> SaveAsync(ObservabilityConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("LogLevel", update.LogLevel, false);
+        Upsert("HealthEndpointEnabled", update.HealthEndpointEnabled.ToString(), false);
+        Upsert("MetricsEndpointEnabled", update.MetricsEndpointEnabled.ToString(), false);
+        Upsert("CorrelationIdsEnabled", update.CorrelationIdsEnabled.ToString(), false);
+        Upsert("IncludeTraceIdentifier", update.IncludeTraceIdentifier.ToString(), false);
+        Upsert("OtelExporterEnabled", update.OtelExporterEnabled.ToString(), false);
+        Upsert("OtelEndpoint", string.IsNullOrWhiteSpace(update.OtelEndpoint) ? null : update.OtelEndpoint, false);
+        Upsert("ResourceAttributes", string.IsNullOrWhiteSpace(update.ResourceAttributes) ? null : update.ResourceAttributes, false);
+
+        if (update.RotateOtelAuthToken)
+        {
+            Upsert("OtelAuthToken", string.IsNullOrWhiteSpace(update.OtelAuthToken) ? null : update.OtelAuthToken, true);
+        }
+        else if (!string.IsNullOrWhiteSpace(update.OtelAuthToken))
+        {
+            Upsert("OtelAuthToken", update.OtelAuthToken, true);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        ObservabilityLogging.ApplyMinimumLevel(update.LogLevel);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key, bool fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key, string? fallback, bool allowNull)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value!;
+        }
+
+        if (allowNull)
+        {
+            return fallback;
+        }
+
+        return fallback ?? string.Empty;
+    }
+
+    private static bool ReadSecretPresent(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value);
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityLogging.cs
+++ b/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityLogging.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Observability;
+
+public static class ObservabilityLogging
+{
+    private static LogLevel _minimumLevel = LogLevel.Information;
+
+    public static LogLevel MinimumLevel => Volatile.Read(ref _minimumLevel);
+
+    public static void ApplyMinimumLevel(string? level)
+    {
+        if (!Enum.TryParse<LogLevel>(level, true, out var parsed))
+        {
+            parsed = LogLevel.Information;
+        }
+
+        ApplyMinimumLevel(parsed);
+    }
+
+    public static void ApplyMinimumLevel(LogLevel level)
+    {
+        Volatile.Write(ref _minimumLevel, level);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityRuntime.cs
+++ b/src/api/src/HWInventory.Infrastructure/Observability/ObservabilityRuntime.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace HWInventory.Infrastructure.Observability;
+
+public class ObservabilityRuntime : IObservabilityRuntime
+{
+    private static readonly string CacheKey = "observability:configuration";
+
+    private readonly IObservabilityConfigurationStore _store;
+    private readonly IMemoryCache _cache;
+
+    public ObservabilityRuntime(IObservabilityConfigurationStore store, IMemoryCache cache)
+    {
+        _store = store;
+        _cache = cache;
+    }
+
+    public async Task<ObservabilityConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cache.TryGetValue(CacheKey, out ObservabilityConfigurationModel? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var configuration = await _store.GetAsync(cancellationToken);
+        _cache.Set(CacheKey, configuration, TimeSpan.FromMinutes(1));
+        return configuration;
+    }
+
+    public void Invalidate()
+    {
+        _cache.Remove(CacheKey);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Observability/RequestMetricsCollector.cs
+++ b/src/api/src/HWInventory.Infrastructure/Observability/RequestMetricsCollector.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using HWInventory.Application.Abstractions;
+
+namespace HWInventory.Infrastructure.Observability;
+
+public class RequestMetricsCollector : IRequestMetricsCollector
+{
+    private readonly ConcurrentDictionary<string, long> _methodTotals = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<int, long> _statusTotals = new();
+    private readonly ConcurrentDictionary<string, long> _durationBuckets = new();
+
+    private long _totalRequests;
+    private long _activeRequests;
+    private long _failedRequests;
+    private readonly DateTime _processStartUtc = DateTime.UtcNow;
+
+    public void IncrementActive()
+    {
+        Interlocked.Increment(ref _activeRequests);
+    }
+
+    public void Record(string method, int statusCode, TimeSpan duration)
+    {
+        Interlocked.Decrement(ref _activeRequests);
+        Interlocked.Increment(ref _totalRequests);
+
+        if (statusCode >= 500)
+        {
+            Interlocked.Increment(ref _failedRequests);
+        }
+
+        _methodTotals.AddOrUpdate(method.ToUpperInvariant(), 1, static (_, current) => current + 1);
+        _statusTotals.AddOrUpdate(statusCode, 1, static (_, current) => current + 1);
+        _durationBuckets.AddOrUpdate(GetDurationBucket(duration), 1, static (_, current) => current + 1);
+    }
+
+    public string ExportSnapshot()
+    {
+        var sb = new StringBuilder();
+        var culture = CultureInfo.InvariantCulture;
+
+        sb.AppendLine("# HELP hwinventory_http_requests_total Total HTTP requests processed by the API.");
+        sb.AppendLine("# TYPE hwinventory_http_requests_total counter");
+        sb.AppendLine($"hwinventory_http_requests_total {Interlocked.Read(ref _totalRequests).ToString(culture)}");
+
+        sb.AppendLine("# HELP hwinventory_http_requests_active Active HTTP requests being processed.");
+        sb.AppendLine("# TYPE hwinventory_http_requests_active gauge");
+        sb.AppendLine($"hwinventory_http_requests_active {Interlocked.Read(ref _activeRequests).ToString(culture)}");
+
+        sb.AppendLine("# HELP hwinventory_http_requests_failed_total Total failed HTTP requests (5xx).");
+        sb.AppendLine("# TYPE hwinventory_http_requests_failed_total counter");
+        sb.AppendLine($"hwinventory_http_requests_failed_total {Interlocked.Read(ref _failedRequests).ToString(culture)}");
+
+        sb.AppendLine("# HELP hwinventory_http_requests_by_method_total Total HTTP requests by verb.");
+        sb.AppendLine("# TYPE hwinventory_http_requests_by_method_total counter");
+        foreach (var method in _methodTotals.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            sb.AppendLine($"hwinventory_http_requests_by_method_total{{method=\"{method.Key.ToUpperInvariant()}\"}} {method.Value.ToString(culture)}");
+        }
+
+        sb.AppendLine("# HELP hwinventory_http_requests_by_status_total Total HTTP requests by status code.");
+        sb.AppendLine("# TYPE hwinventory_http_requests_by_status_total counter");
+        foreach (var status in _statusTotals.OrderBy(kvp => kvp.Key))
+        {
+            sb.AppendLine($"hwinventory_http_requests_by_status_total{{status=\"{status.Key}\"}} {status.Value.ToString(culture)}");
+        }
+
+        sb.AppendLine("# HELP hwinventory_http_request_duration_bucket Request duration histogram buckets.");
+        sb.AppendLine("# TYPE hwinventory_http_request_duration_bucket counter");
+        foreach (var bucket in GetOrderedBuckets())
+        {
+            if (_durationBuckets.TryGetValue(bucket, out var value))
+            {
+                sb.AppendLine($"hwinventory_http_request_duration_bucket{{bucket=\"{bucket}\"}} {value.ToString(culture)}");
+            }
+        }
+
+        var uptimeSeconds = (DateTime.UtcNow - _processStartUtc).TotalSeconds;
+        sb.AppendLine("# HELP hwinventory_process_uptime_seconds Application uptime in seconds.");
+        sb.AppendLine("# TYPE hwinventory_process_uptime_seconds gauge");
+        sb.AppendLine($"hwinventory_process_uptime_seconds {uptimeSeconds.ToString(culture)}");
+
+        return sb.ToString();
+    }
+
+    private static string GetDurationBucket(TimeSpan duration)
+    {
+        var milliseconds = duration.TotalMilliseconds;
+        if (milliseconds < 100)
+        {
+            return "lt_100ms";
+        }
+
+        if (milliseconds < 500)
+        {
+            return "lt_500ms";
+        }
+
+        if (milliseconds < 1000)
+        {
+            return "lt_1000ms";
+        }
+
+        if (milliseconds < 5000)
+        {
+            return "lt_5000ms";
+        }
+
+        return "gte_5000ms";
+    }
+
+    private static IEnumerable<string> GetOrderedBuckets()
+    {
+        yield return "lt_100ms";
+        yield return "lt_500ms";
+        yield return "lt_1000ms";
+        yield return "lt_5000ms";
+        yield return "gte_5000ms";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,129 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public class AppDbContext : IdentityDbContext<AppUser, AppRole, Guid, IdentityUserClaim<Guid>, IdentityUserRole<Guid>, IdentityUserLogin<Guid>, IdentityRoleClaim<Guid>, IdentityUserToken<Guid>>, IAppDbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Server> Servers => Set<Server>();
+    public DbSet<NetworkDevice> NetworkDevices => Set<NetworkDevice>();
+    public DbSet<Workstation> Workstations => Set<Workstation>();
+    public DbSet<DictionaryEntry> DictionaryEntries => Set<DictionaryEntry>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<LabelTemplate> LabelTemplates => Set<LabelTemplate>();
+    public DbSet<LabelPrintJob> LabelPrintJobs => Set<LabelPrintJob>();
+    public new DbSet<AppUser> Users => Set<AppUser>();
+    public new DbSet<AppRole> Roles => Set<AppRole>();
+    public DbSet<FeatureModule> FeatureModules => Set<FeatureModule>();
+    public DbSet<AppSetting> Settings => Set<AppSetting>();
+    public DbSet<ConnectorProfile> ConnectorProfiles => Set<ConnectorProfile>();
+    public DbSet<LdapRoleMapping> LdapRoleMappings => Set<LdapRoleMapping>();
+    public DbSet<DataScope> DataScopes => Set<DataScope>();
+    public DbSet<UserSession> UserSessions => Set<UserSession>();
+    public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
+    public DbSet<PasswordHistoryEntry> PasswordHistoryEntries => Set<PasswordHistoryEntry>();
+    public DbSet<BackupJob> BackupJobs => Set<BackupJob>();
+    public DbSet<BackupSchedule> BackupSchedules => Set<BackupSchedule>();
+    public DbSet<ExportJob> ExportJobs => Set<ExportJob>();
+    public DbSet<ImportJob> ImportJobs => Set<ImportJob>();
+    public DbSet<UpdatePackage> UpdatePackages => Set<UpdatePackage>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var auditLogs = BuildAuditEntries();
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        if (auditLogs.Count > 0)
+        {
+            AuditLogs.AddRange(auditLogs);
+            await base.SaveChangesAsync(cancellationToken);
+        }
+
+        return result;
+    }
+
+    private List<AuditLog> BuildAuditEntries()
+    {
+        var auditEntries = new List<AuditLog>();
+        var now = DateTime.UtcNow;
+
+        foreach (var entry in ChangeTracker.Entries<AuditableEntity>())
+        {
+            if (entry.State == EntityState.Detached || entry.State == EntityState.Unchanged)
+            {
+                continue;
+            }
+
+            var auditLog = new AuditLog
+            {
+                EntityType = entry.Entity.GetType().Name,
+                EntityId = entry.Entity.Id,
+                PerformedAtUtc = now,
+                PerformedBy = entry.Entity.ModifiedBy ?? entry.Entity.CreatedBy,
+                Roles = null
+            };
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    entry.Entity.CreatedAtUtc = now;
+                    auditLog.Action = "Create";
+                    auditLog.ChangeSummary = "Entity created";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.CurrentValues.ToObject());
+                    break;
+                case EntityState.Modified:
+                    entry.Entity.ModifiedAtUtc = now;
+                    auditLog.Action = "Update";
+                    auditLog.ChangeSummary = "Entity updated";
+                    auditLog.ChangedFieldsJson = SerializeChanges(entry);
+                    break;
+                case EntityState.Deleted:
+                    auditLog.Action = "Delete";
+                    auditLog.ChangeSummary = "Entity deleted";
+                    auditLog.ChangedFieldsJson = JsonSerializer.Serialize(entry.OriginalValues.ToObject());
+                    break;
+            }
+
+            auditEntries.Add(auditLog);
+        }
+
+        return auditEntries;
+    }
+
+    private static string SerializeChanges(EntityEntry entry)
+    {
+        var changes = new Dictionary<string, object?>();
+
+        foreach (var property in entry.Properties)
+        {
+            if (!property.IsModified)
+            {
+                continue;
+            }
+
+            changes[property.Metadata.Name] = new
+            {
+                Original = property.OriginalValue,
+                Current = property.CurrentValue
+            };
+        }
+
+        return JsonSerializer.Serialize(changes);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppRoleConfiguration.cs
@@ -1,0 +1,14 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppRoleConfiguration : IEntityTypeConfiguration<AppRole>
+{
+    public void Configure(EntityTypeBuilder<AppRole> builder)
+    {
+        builder.ToTable("AspNetRoles");
+        builder.Property(x => x.Description).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppSettingConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppSettingConfiguration : IEntityTypeConfiguration<AppSetting>
+{
+    public void Configure(EntityTypeBuilder<AppSetting> builder)
+    {
+        builder.ToTable("AppSettings");
+        builder.Property(x => x.Section).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
@@ -1,0 +1,27 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.ToTable("AspNetUsers");
+        builder.Property(x => x.DisplayName).HasMaxLength(200);
+        builder.Property(x => x.Department).HasMaxLength(200);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.AuthenticatorKey).HasMaxLength(256);
+        builder.HasMany(x => x.DataScopes)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+        builder.HasMany(x => x.Sessions)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+        builder.HasMany(x => x.PasswordResetTokens)
+            .WithOne(x => x.AppUser)
+            .HasForeignKey(x => x.AppUserId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+{
+    public void Configure(EntityTypeBuilder<AuditLog> builder)
+    {
+        builder.ToTable("AuditLogs");
+        builder.Property(x => x.EntityType).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Action).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.PerformedBy).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Roles).HasMaxLength(200);
+        builder.Property(x => x.ChangeSummary).HasMaxLength(400);
+        builder.Property(x => x.IpAddress).HasMaxLength(50);
+        builder.Property(x => x.UserAgent).HasMaxLength(400);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/BackupJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/BackupJobConfiguration.cs
@@ -1,0 +1,18 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class BackupJobConfiguration : IEntityTypeConfiguration<BackupJob>
+{
+    public void Configure(EntityTypeBuilder<BackupJob> builder)
+    {
+        builder.ToTable("BackupJobs");
+        builder.Property(x => x.StoragePath).HasMaxLength(1024).IsRequired();
+        builder.Property(x => x.FileName).HasMaxLength(256).IsRequired();
+        builder.Property(x => x.EmailRecipients).HasMaxLength(512);
+        builder.Property(x => x.FailureReason).HasMaxLength(1024);
+        builder.Property(x => x.ArtifactPath).HasMaxLength(1024);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/BackupScheduleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/BackupScheduleConfiguration.cs
@@ -1,0 +1,17 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class BackupScheduleConfiguration : IEntityTypeConfiguration<BackupSchedule>
+{
+    public void Configure(EntityTypeBuilder<BackupSchedule> builder)
+    {
+        builder.ToTable("BackupSchedules");
+        builder.Property(x => x.Frequency).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.Scope).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.StoragePath).HasMaxLength(1024).IsRequired();
+        builder.Property(x => x.EmailRecipients).HasMaxLength(512);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorProfileConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorProfileConfiguration : IEntityTypeConfiguration<ConnectorProfile>
+{
+    public void Configure(EntityTypeBuilder<ConnectorProfile> builder)
+    {
+        builder.ToTable("ConnectorProfiles");
+        builder.Property(x => x.Type).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Alias).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.HealthStatus).HasMaxLength(50);
+        builder.HasMany(x => x.Secrets)
+            .WithOne(x => x.ConnectorProfile)
+            .HasForeignKey(x => x.ConnectorProfileId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ConnectorSecretConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ConnectorSecretConfiguration : IEntityTypeConfiguration<ConnectorSecret>
+{
+    public void Configure(EntityTypeBuilder<ConnectorSecret> builder)
+    {
+        builder.ToTable("ConnectorSecrets");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.SecretReference).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DataScopeConfiguration.cs
@@ -1,0 +1,18 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DataScopeConfiguration : IEntityTypeConfiguration<DataScope>
+{
+    public void Configure(EntityTypeBuilder<DataScope> builder)
+    {
+        builder.ToTable("DataScopes");
+        builder.Property(x => x.ScopeType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.DepartmentKey).HasMaxLength(200);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status).HasMaxLength(50);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/DictionaryEntryConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class DictionaryEntryConfiguration : IEntityTypeConfiguration<DictionaryEntry>
+{
+    public void Configure(EntityTypeBuilder<DictionaryEntry> builder)
+    {
+        builder.ToTable("DictionaryEntries");
+        builder.Property(x => x.DictType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Value).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ExportJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ExportJobConfiguration.cs
@@ -1,0 +1,18 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ExportJobConfiguration : IEntityTypeConfiguration<ExportJob>
+{
+    public void Configure(EntityTypeBuilder<ExportJob> builder)
+    {
+        builder.Property(x => x.StoragePath).HasMaxLength(1024);
+        builder.Property(x => x.FileName).HasMaxLength(256);
+        builder.Property(x => x.FilterJson).HasMaxLength(2048);
+        builder.Property(x => x.EmailRecipients).HasMaxLength(512);
+        builder.Property(x => x.ArtifactPath).HasMaxLength(1024);
+        builder.Property(x => x.FailureReason).HasMaxLength(1024);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/FeatureModuleConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class FeatureModuleConfiguration : IEntityTypeConfiguration<FeatureModule>
+{
+    public void Configure(EntityTypeBuilder<FeatureModule> builder)
+    {
+        builder.ToTable("FeatureModules");
+        builder.Property(x => x.Key).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ImportJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ImportJobConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ImportJobConfiguration : IEntityTypeConfiguration<ImportJob>
+{
+    public void Configure(EntityTypeBuilder<ImportJob> builder)
+    {
+        builder.ToTable("ImportJobs");
+        builder.Property(x => x.StoragePath).HasMaxLength(1024).IsRequired();
+        builder.Property(x => x.OriginalFileName).HasMaxLength(256).IsRequired();
+        builder.Property(x => x.StoredFilePath).HasMaxLength(1024).IsRequired();
+        builder.Property(x => x.MappingJson).HasMaxLength(2048);
+        builder.Property(x => x.ResultLog).HasMaxLength(2048);
+        builder.Property(x => x.FailureReason).HasMaxLength(1024);
+        builder.Property(x => x.EmailRecipients).HasMaxLength(512);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobConfiguration.cs
@@ -1,0 +1,19 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobConfiguration : IEntityTypeConfiguration<LabelPrintJob>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJob> builder)
+    {
+        builder.ToTable("LabelPrintJobs");
+        builder.Property(x => x.Target).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.JobStatus).HasMaxLength(50).IsRequired();
+        builder.HasMany(x => x.Items)
+            .WithOne()
+            .HasForeignKey(x => x.LabelPrintJobId);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelPrintJobItemConfiguration.cs
@@ -1,0 +1,15 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelPrintJobItemConfiguration : IEntityTypeConfiguration<LabelPrintJobItem>
+{
+    public void Configure(EntityTypeBuilder<LabelPrintJobItem> builder)
+    {
+        builder.ToTable("LabelPrintJobItems");
+        builder.Property(x => x.AssetType).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Copies).HasDefaultValue(1);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LabelTemplateConfiguration.cs
@@ -1,0 +1,16 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LabelTemplateConfiguration : IEntityTypeConfiguration<LabelTemplate>
+{
+    public void Configure(EntityTypeBuilder<LabelTemplate> builder)
+    {
+        builder.ToTable("LabelTemplates");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Code).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Format).HasMaxLength(50).HasDefaultValue("ZPL");
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LdapRoleMappingConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/LdapRoleMappingConfiguration.cs
@@ -1,0 +1,30 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class LdapRoleMappingConfiguration : IEntityTypeConfiguration<LdapRoleMapping>
+{
+    public void Configure(EntityTypeBuilder<LdapRoleMapping> builder)
+    {
+        builder.ToTable("LdapRoleMappings");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.GroupName)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(x => x.RoleName)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status)
+            .HasMaxLength(50)
+            .HasConversion<string>();
+
+        builder.HasIndex(x => x.GroupName);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/NetworkDeviceConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class NetworkDeviceConfiguration : IEntityTypeConfiguration<NetworkDevice>
+{
+    public void Configure(EntityTypeBuilder<NetworkDevice> builder)
+    {
+        builder.ToTable("NetworkDevices");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("NetworkDeviceAssignments");
+            nb.WithOwner().HasForeignKey("NetworkDeviceId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordHistoryEntryConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordHistoryEntryConfiguration.cs
@@ -1,0 +1,27 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class PasswordHistoryEntryConfiguration : IEntityTypeConfiguration<PasswordHistoryEntry>
+{
+    public void Configure(EntityTypeBuilder<PasswordHistoryEntry> builder)
+    {
+        builder.ToTable("PasswordHistoryEntries");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.PasswordHash)
+            .IsRequired()
+            .HasMaxLength(512);
+
+        builder.Property(x => x.CreatedAtUtc)
+            .IsRequired();
+
+        builder.HasOne(x => x.User)
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordResetTokenConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/PasswordResetTokenConfiguration.cs
@@ -1,0 +1,21 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class PasswordResetTokenConfiguration : IEntityTypeConfiguration<PasswordResetToken>
+{
+    public void Configure(EntityTypeBuilder<PasswordResetToken> builder)
+    {
+        builder.ToTable("PasswordResetTokens");
+        builder.HasIndex(x => x.Token).IsUnique();
+        builder.Property(x => x.DeliveryMethod).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.DeliveryAddress).HasMaxLength(300);
+        builder.Property(x => x.Status).HasMaxLength(50).IsRequired();
+        builder.Property(x => x.SmsCodeHash).HasMaxLength(256);
+        builder.Property(x => x.IdentityToken).HasMaxLength(2048).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/ServerConfiguration.cs
@@ -1,0 +1,26 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class ServerConfiguration : IEntityTypeConfiguration<Server>
+{
+    public void Configure(EntityTypeBuilder<Server> builder)
+    {
+        builder.ToTable("Servers");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Manufacturer).HasMaxLength(200);
+        builder.Property(x => x.Model).HasMaxLength(200);
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("ServerNetworkAssignments");
+            nb.WithOwner().HasForeignKey("ServerId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UpdatePackageConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UpdatePackageConfiguration.cs
@@ -1,0 +1,62 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class UpdatePackageConfiguration : IEntityTypeConfiguration<UpdatePackage>
+{
+    public void Configure(EntityTypeBuilder<UpdatePackage> builder)
+    {
+        builder.ToTable("UpdatePackages");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Version)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(x => x.FileName)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(x => x.StoredPath)
+            .HasMaxLength(1024)
+            .IsRequired();
+
+        builder.Property(x => x.StagingPath)
+            .HasMaxLength(1024)
+            .IsRequired();
+
+        builder.Property(x => x.Sha256)
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(x => x.ManifestJson)
+            .HasColumnType("nvarchar(max)");
+
+        builder.Property(x => x.Notes)
+            .HasMaxLength(1024);
+
+        builder.Property(x => x.BackupStoragePath)
+            .HasMaxLength(512);
+
+        builder.Property(x => x.FailureReason)
+            .HasMaxLength(1024);
+
+        builder.Property(x => x.LogPath)
+            .HasMaxLength(1024);
+
+        builder.Property(x => x.CreatedBy)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(x => x.ModifiedBy)
+            .HasMaxLength(256);
+
+        builder.Property(x => x.UpdateStatus)
+            .HasConversion<int>();
+
+        builder.HasIndex(x => x.CreatedAtUtc);
+        builder.HasIndex(x => x.UpdateStatus);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
@@ -1,0 +1,20 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class UserSessionConfiguration : IEntityTypeConfiguration<UserSession>
+{
+    public void Configure(EntityTypeBuilder<UserSession> builder)
+    {
+        builder.ToTable("UserSessions");
+        builder.Property(x => x.SessionIdentifier).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.IpAddress).HasMaxLength(200);
+        builder.Property(x => x.UserAgent).HasMaxLength(512);
+        builder.Property(x => x.CreatedBy).HasMaxLength(200);
+        builder.Property(x => x.ModifiedBy).HasMaxLength(200);
+        builder.Property(x => x.Status).HasMaxLength(50);
+        builder.HasIndex(x => new { x.AppUserId, x.IsRevoked });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/Configurations/WorkstationConfiguration.cs
@@ -1,0 +1,28 @@
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HWInventory.Infrastructure.Persistence.Configurations;
+
+public class WorkstationConfiguration : IEntityTypeConfiguration<Workstation>
+{
+    public void Configure(EntityTypeBuilder<Workstation> builder)
+    {
+        builder.ToTable("Workstations");
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.InventoryNumber).HasMaxLength(100).IsRequired();
+        builder.Property(x => x.Cpu).HasMaxLength(200);
+        builder.Property(x => x.Ram).HasMaxLength(100);
+        builder.Property(x => x.Storage).HasMaxLength(200);
+        builder.Property(x => x.MacAddress).HasMaxLength(100).IsRequired();
+        builder.OwnsMany(x => x.NetworkAssignments, nb =>
+        {
+            nb.ToTable("WorkstationNetworkAssignments");
+            nb.WithOwner().HasForeignKey("WorkstationId");
+            nb.Property<Guid>("Id");
+            nb.HasKey("Id");
+            nb.Property(x => x.Label).HasMaxLength(50);
+            nb.Property(x => x.IpAddress).HasMaxLength(100);
+        });
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
+++ b/src/api/src/HWInventory.Infrastructure/Persistence/SeedData.cs
@@ -1,0 +1,81 @@
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HWInventory.Infrastructure.Persistence;
+
+public static class SeedData
+{
+    private static readonly (string Dict, string Key, string Value)[] DictionarySeeds =
+    {
+        ("Environment", "PROD", "Production"),
+        ("Environment", "TEST", "Testing"),
+        ("Environment", "DEV", "Development"),
+        ("WsusPriority", "HIGH", "Vysoká"),
+        ("WsusPriority", "NORMAL", "Standard"),
+        ("OperatingSystem", "WIN2022", "Windows Server 2022"),
+        ("OperatingSystem", "WIN11", "Windows 11"),
+        ("ServerRole", "APP", "Application Server"),
+        ("ServerRole", "DB", "Database Server"),
+        ("WorkstationType", "PC", "Desktop"),
+        ("WorkstationType", "LAPTOP", "Notebook"),
+        ("Location", "HQ-1F", "HQ 1st Floor"),
+        ("Location", "HQ-2F", "HQ 2nd Floor"),
+        ("VLAN", "VLAN10", "Production 10"),
+        ("VLAN", "VLAN20", "DMZ 20"),
+    };
+
+    public static async Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<AppRole>>();
+
+        if (!await roleManager.Roles.AnyAsync(cancellationToken))
+        {
+            var roles = new[]
+            {
+                new AppRole { Name = SystemRoleNames.SuperAdmin, NormalizedName = SystemRoleNames.SuperAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.ServerAdmin, NormalizedName = SystemRoleNames.ServerAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.NetworkAdmin, NormalizedName = SystemRoleNames.NetworkAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.AppAdmin, NormalizedName = SystemRoleNames.AppAdmin.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.Helpdesk, NormalizedName = SystemRoleNames.Helpdesk.ToUpperInvariant() },
+                new AppRole { Name = SystemRoleNames.HelpdeskRead, NormalizedName = SystemRoleNames.HelpdeskRead.ToUpperInvariant() }
+            };
+
+            foreach (var role in roles)
+            {
+                await roleManager.CreateAsync(role);
+            }
+        }
+
+        foreach (var seed in DictionarySeeds)
+        {
+            if (!await context.DictionaryEntries.AnyAsync(x => x.DictType == seed.Dict && x.Key == seed.Key, cancellationToken))
+            {
+                context.DictionaryEntries.Add(new DictionaryEntry
+                {
+                    DictType = seed.Dict,
+                    Key = seed.Key,
+                    Value = seed.Value,
+                    CreatedAtUtc = DateTime.UtcNow,
+                    CreatedBy = "seed"
+                });
+            }
+        }
+
+        if (!await context.FeatureModules.AnyAsync(cancellationToken))
+        {
+            context.FeatureModules.AddRange(new[]
+            {
+                new FeatureModule { Key = "labels", Name = "Labels & Printing", Enabled = true, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "reports", Name = "Reports & Schedules", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" },
+                new FeatureModule { Key = "zabbix", Name = "Zabbix Metrics", Enabled = false, CreatedAtUtc = DateTime.UtcNow, CreatedBy = "seed" }
+            });
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/AppUserManager.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/AppUserManager.cs
@@ -1,0 +1,39 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class AppUserManager : UserManager<AppUser>
+{
+    private readonly IPasswordHistoryService _passwordHistoryService;
+
+    public AppUserManager(
+        IUserStore<AppUser> store,
+        IOptions<IdentityOptions> optionsAccessor,
+        IPasswordHasher<AppUser> passwordHasher,
+        IEnumerable<IUserValidator<AppUser>> userValidators,
+        IEnumerable<IPasswordValidator<AppUser>> passwordValidators,
+        ILookupNormalizer keyNormalizer,
+        IdentityErrorDescriber errors,
+        IServiceProvider services,
+        ILogger<UserManager<AppUser>> logger,
+        IPasswordHistoryService passwordHistoryService)
+        : base(store, optionsAccessor, passwordHasher, userValidators, passwordValidators, keyNormalizer, errors, services, logger)
+    {
+        _passwordHistoryService = passwordHistoryService;
+    }
+
+    protected override async Task<IdentityResult> UpdatePasswordHash(AppUser user, string? newPassword, bool validatePassword)
+    {
+        var result = await base.UpdatePasswordHash(user, newPassword, validatePassword);
+        if (result.Succeeded && !string.IsNullOrEmpty(user.PasswordHash))
+        {
+            await _passwordHistoryService.RecordAsync(user);
+        }
+
+        return result;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/CaptchaConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/CaptchaConfigurationStore.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class CaptchaConfigurationStore : ICaptchaConfigurationStore
+{
+    private const string SectionName = "Security.Captcha";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CaptchaConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<CaptchaConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        var enabled = ReadBool(settings, "Enabled");
+        var siteKey = ReadString(settings, "SiteKey");
+        var endpoint = ReadString(settings, "VerificationEndpoint");
+        var bypass = ReadNullableString(settings, "BypassToken");
+        var hasSecret = settings.TryGetValue("Secret", out var secretSetting) && !string.IsNullOrWhiteSpace(secretSetting.Value);
+
+        return new CaptchaConfigurationModel(enabled, siteKey, hasSecret, endpoint, bypass);
+    }
+
+    public async Task<CaptchaConfigurationModel> SaveAsync(CaptchaConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("SiteKey", update.SiteKey, false);
+        Upsert("VerificationEndpoint", update.VerificationEndpoint, false);
+        Upsert("BypassToken", update.BypassToken, false);
+
+        if (update.RotateSecret)
+        {
+            Upsert("Secret", update.Secret, true);
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Secret))
+        {
+            Upsert("Secret", update.Secret, true);
+        }
+        else if (!existing.Any(x => x.Key == "Secret"))
+        {
+            Upsert("Secret", null, true);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static string ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value!;
+        }
+
+        return string.Empty;
+    }
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return null;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/CaptchaValidator.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/CaptchaValidator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using HWInventory.Application.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class CaptchaValidator : ICaptchaValidator
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<CaptchaValidator> _logger;
+
+    public CaptchaValidator(IAppDbContext dbContext, IHttpClientFactory httpClientFactory, ILogger<CaptchaValidator> logger)
+    {
+        _dbContext = dbContext;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<bool> ValidateAsync(string token, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == "Security.Captcha")
+            .ToDictionaryAsync(x => x.Key, x => x.Value, cancellationToken);
+
+        var isEnabled = settings.TryGetValue("Enabled", out var enabledValue) && bool.TryParse(enabledValue, out var enabled) && enabled;
+        if (!isEnabled)
+        {
+            return true;
+        }
+
+        if (settings.TryGetValue("BypassToken", out var bypassToken) && !string.IsNullOrWhiteSpace(bypassToken) &&
+            string.Equals(token, bypassToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!settings.TryGetValue("VerificationEndpoint", out var endpoint) || string.IsNullOrWhiteSpace(endpoint))
+        {
+            _logger.LogWarning("Captcha verification endpoint not configured. Rejecting tokens.");
+            return false;
+        }
+
+        settings.TryGetValue("Secret", out var secret);
+        settings.TryGetValue("SiteKey", out var siteKey);
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient("captcha");
+            var response = await client.PostAsJsonAsync(endpoint, new
+            {
+                token,
+                secret,
+                siteKey
+            }, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Captcha verification failed with status {StatusCode}", response.StatusCode);
+                return false;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<CaptchaResponse>(cancellationToken: cancellationToken);
+            return result?.Success ?? false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Captcha verification error");
+            return false;
+        }
+    }
+
+    private sealed record CaptchaResponse(bool Success, IEnumerable<string>? Errors);
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/DataProtectionSecretProtector.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/DataProtectionSecretProtector.cs
@@ -1,0 +1,35 @@
+using System;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class DataProtectionSecretProtector : ISecretProtector
+{
+    private readonly IDataProtector _protector;
+
+    public DataProtectionSecretProtector(IDataProtectionProvider provider)
+    {
+        _protector = provider.CreateProtector("HWInventory.SecretStorage");
+    }
+
+    public string Protect(string secret)
+    {
+        if (string.IsNullOrEmpty(secret))
+        {
+            throw new ArgumentException("Secret must be provided.", nameof(secret));
+        }
+
+        return _protector.Protect(secret);
+    }
+
+    public string Unprotect(string protectedSecret)
+    {
+        if (string.IsNullOrEmpty(protectedSecret))
+        {
+            throw new ArgumentException("Protected secret must be provided.", nameof(protectedSecret));
+        }
+
+        return _protector.Unprotect(protectedSecret);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/EmailConnectorStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/EmailConnectorStore.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class EmailConnectorStore : IEmailConnectorStore
+{
+    private const string ConnectorType = "SMTP";
+
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<EmailConnectorStore> _logger;
+
+    public EmailConnectorStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor, ILogger<EmailConnectorStore> logger)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<EmailConnectorModel?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == ConnectorType, cancellationToken);
+
+        if (connector is null)
+        {
+            return null;
+        }
+
+        var configuration = ParseConfiguration(connector.ConfigurationJson);
+
+        return new EmailConnectorModel(
+            connector.Id,
+            connector.Alias,
+            connector.Enabled,
+            configuration.TryGetValue("host", out var host) ? host ?? string.Empty : string.Empty,
+            configuration.TryGetValue("port", out var portValue) && int.TryParse(portValue, out var port) ? port : 25,
+            configuration.TryGetValue("useTls", out var tlsValue) && bool.TryParse(tlsValue, out var useTls) && useTls,
+            configuration.TryGetValue("username", out var username) ? username : null,
+            connector.Secrets.Any(),
+            configuration.TryGetValue("fromAddress", out var from) ? from : null,
+            configuration.TryGetValue("replyToAddress", out var replyTo) ? replyTo : null,
+            connector.HealthStatus,
+            connector.LastTestedAtUtc);
+    }
+
+    public async Task<EmailConnectorModel> SaveAsync(EmailConnectorUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == ConnectorType, cancellationToken);
+
+        var configuration = new Dictionary<string, string?>
+        {
+            ["host"] = update.Host,
+            ["port"] = update.Port.ToString(),
+            ["useTls"] = update.UseTls.ToString(),
+            ["username"] = update.Username,
+            ["fromAddress"] = update.FromAddress,
+            ["replyToAddress"] = update.ReplyToAddress
+        };
+
+        if (connector is null)
+        {
+            connector = new ConnectorProfile
+            {
+                Type = ConnectorType,
+                Alias = string.IsNullOrWhiteSpace(update.Alias) ? "Primary SMTP" : update.Alias,
+                Enabled = update.Enabled,
+                ConfigurationJson = JsonSerializer.Serialize(configuration),
+                CreatedBy = actor,
+                ModifiedBy = actor
+            };
+
+            _dbContext.ConnectorProfiles.Add(connector);
+        }
+        else
+        {
+            connector.Alias = string.IsNullOrWhiteSpace(update.Alias) ? connector.Alias : update.Alias;
+            connector.Enabled = update.Enabled;
+            connector.ConfigurationJson = JsonSerializer.Serialize(configuration);
+            connector.ModifiedBy = actor;
+        }
+
+        if (update.RotateSecret && string.IsNullOrWhiteSpace(update.Password))
+        {
+            connector.Secrets.Clear();
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Password))
+        {
+            connector.Secrets.Clear();
+            connector.Secrets.Add(new ConnectorSecret
+            {
+                Key = "password",
+                SecretReference = update.Password!,
+                RotatedAtUtc = DateTime.UtcNow
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return (await GetAsync(cancellationToken))!;
+    }
+
+    public async Task<EmailTestResult> SendTestAsync(EmailTestRequest request, CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == ConnectorType && x.Enabled, cancellationToken);
+
+        if (connector is null)
+        {
+            return new EmailTestResult(false, "SMTP connector is not configured or disabled.");
+        }
+
+        var configuration = ParseConfiguration(connector.ConfigurationJson);
+        if (!configuration.TryGetValue("host", out var host) || string.IsNullOrWhiteSpace(host))
+        {
+            return new EmailTestResult(false, "SMTP host is missing.");
+        }
+
+        var fromAddress = configuration.TryGetValue("fromAddress", out var from) && !string.IsNullOrWhiteSpace(from)
+            ? from!
+            : "no-reply@example.com";
+
+        var port = configuration.TryGetValue("port", out var portValue) && int.TryParse(portValue, out var parsedPort)
+            ? parsedPort
+            : 25;
+        var useTls = configuration.TryGetValue("useTls", out var tlsValue) && bool.TryParse(tlsValue, out var tls) && tls;
+        var username = configuration.TryGetValue("username", out var user) ? user : null;
+        var password = connector.Secrets.FirstOrDefault()?.SecretReference;
+
+        try
+        {
+#pragma warning disable SYSLIB0014
+            using var smtp = new SmtpClient(host!, port)
+            {
+                EnableSsl = useTls
+            };
+
+            if (!string.IsNullOrWhiteSpace(username))
+            {
+                smtp.Credentials = new System.Net.NetworkCredential(username, password);
+            }
+
+            using var message = new MailMessage
+            {
+                From = new MailAddress(fromAddress),
+                Subject = request.Subject,
+                Body = request.Body,
+                IsBodyHtml = false
+            };
+
+            message.To.Add(new MailAddress(request.Recipient));
+
+            if (configuration.TryGetValue("replyToAddress", out var replyTo) && !string.IsNullOrWhiteSpace(replyTo))
+            {
+                message.ReplyToList.Add(new MailAddress(replyTo));
+            }
+
+            await smtp.SendMailAsync(message);
+#pragma warning restore SYSLIB0014
+
+            connector.HealthStatus = "Healthy";
+            connector.LastTestedAtUtc = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return new EmailTestResult(true, "Test e-mail was sent successfully.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SMTP test send failed");
+            connector.HealthStatus = "Degraded";
+            connector.LastTestedAtUtc = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new EmailTestResult(false, $"SMTP send failed: {ex.Message}");
+        }
+    }
+
+    private static Dictionary<string, string?> ParseConfiguration(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string?>>(json) ?? new Dictionary<string, string?>();
+        }
+        catch
+        {
+            return new Dictionary<string, string?>();
+        }
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/ExternalIdentityService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/ExternalIdentityService.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class ExternalIdentityService : IExternalIdentityService
+{
+    private const string SectionName = "Security.Oidc";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ExternalIdentityService> _logger;
+
+    public ExternalIdentityService(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor, ILogger<ExternalIdentityService> logger)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task ConfigureOidcAsync(OidcConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        var actor = ResolveActor();
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret
+                };
+
+                row.CreatedBy = actor;
+                row.ModifiedBy = actor;
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.ModifiedBy = actor;
+                row.Value = value;
+                row.IsSecret = isSecret;
+            }
+        }
+
+        Upsert("Enabled", configuration.Enabled.ToString(), false);
+        Upsert("Authority", configuration.Authority, false);
+        Upsert("ClientId", configuration.ClientId, true);
+        Upsert("ClientSecret", configuration.ClientSecret, true);
+        Upsert("ResponseType", configuration.ResponseType ?? "code", false);
+        Upsert("UsePkce", configuration.UsePkce.ToString(), false);
+        Upsert("Scopes", string.Join(' ', configuration.Scopes), false);
+
+        var claimMappings = string.Join(';', configuration.ClaimMappings.Select(pair => $"{pair.Key}:{pair.Value}"));
+        Upsert("ClaimMappings", claimMappings, false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("OIDC configuration updated by {Actor}", actor);
+    }
+
+    public async Task<OidcConfiguration?> GetConfigurationAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        if (settings.Count == 0)
+        {
+            return null;
+        }
+
+        bool enabled = settings.TryGetValue("Enabled", out var enabledSetting) && bool.TryParse(enabledSetting.Value, out var enabledValue) && enabledValue;
+        settings.TryGetValue("Authority", out var authoritySetting);
+        settings.TryGetValue("ClientId", out var clientIdSetting);
+        settings.TryGetValue("ClientSecret", out var secretSetting);
+        settings.TryGetValue("ResponseType", out var responseTypeSetting);
+        settings.TryGetValue("UsePkce", out var pkceSetting);
+        settings.TryGetValue("Scopes", out var scopesSetting);
+        settings.TryGetValue("ClaimMappings", out var claimsSetting);
+
+        var scopes = (scopesSetting?.Value ?? "openid profile email").Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var claimMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(claimsSetting?.Value))
+        {
+            foreach (var pair in claimsSetting.Value.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kvp = pair.Split(':', 2);
+                if (kvp.Length == 2)
+                {
+                    claimMap[kvp[0]] = kvp[1];
+                }
+            }
+        }
+
+        var configuration = new OidcConfiguration(
+            enabled,
+            authoritySetting?.Value ?? string.Empty,
+            clientIdSetting?.Value ?? string.Empty,
+            secretSetting?.Value,
+            responseTypeSetting?.Value,
+            scopes,
+            claimMap,
+            pkceSetting != null && bool.TryParse(pkceSetting.Value, out var pkce) && pkce);
+
+        _logger.LogDebug("OIDC configuration requested. Enabled={Enabled}", configuration.Enabled);
+        return configuration;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/LdapConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/LdapConfigurationStore.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class LdapConfigurationStore : ILdapConfigurationStore
+{
+    private const string SectionName = "Security.Ldap";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LdapConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<LdapConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new LdapConfigurationModel(
+            ReadBool(settings, "Enabled"),
+            ReadString(settings, "Host"),
+            ReadInt(settings, "Port", 389),
+            ReadBool(settings, "UseSsl"),
+            ReadString(settings, "BindDn"),
+            settings.TryGetValue("Password", out var passwordSetting) && !string.IsNullOrWhiteSpace(passwordSetting.Value),
+            ReadBool(settings, "IgnoreCertificateErrors"),
+            ReadString(settings, "UsersBaseDn"),
+            ReadNullableString(settings, "UsersFilter"),
+            ReadList(settings, "AttributeMap"));
+    }
+
+    public async Task<LdapConfigurationModel> SaveAsync(LdapConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("Host", update.Host, false);
+        Upsert("Port", update.Port.ToString(), false);
+        Upsert("UseSsl", update.UseSsl.ToString(), false);
+        Upsert("BindDn", update.BindDn, false);
+        Upsert("IgnoreCertificateErrors", update.IgnoreCertificateErrors.ToString(), false);
+        Upsert("UsersBaseDn", update.UsersBaseDn, false);
+        Upsert("UsersFilter", update.UsersFilter, false);
+        Upsert("AttributeMap", string.Join('\n', update.AttributeMap ?? Array.Empty<string>()), false);
+
+        if (update.ResetPassword)
+        {
+            Upsert("Password", null, true);
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Password))
+        {
+            Upsert("Password", update.Password, true);
+        }
+        else if (!existing.Any(x => x.Key == "Password"))
+        {
+            Upsert("Password", null, true);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static string ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value!;
+        }
+
+        return string.Empty;
+    }
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyCollection<string> ReadList(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToArray();
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/LdapSyncService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/LdapSyncService.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.DirectoryServices.Protocols;
+using HWInventory.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class LdapSyncService : ILdapSyncService
+{
+    private readonly ILogger<LdapSyncService> _logger;
+
+    public LdapSyncService(ILogger<LdapSyncService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<LdapConnectionTestResult> TestConnectionAsync(LdapConnectionOptions options, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteTest(options), cancellationToken);
+    }
+
+    public Task<LdapDryRunResult> DryRunAsync(LdapDryRunRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteDryRun(request), cancellationToken);
+    }
+
+    private LdapConnectionTestResult ExecuteTest(LdapConnectionOptions options)
+    {
+        try
+        {
+            using var connection = CreateConnection(options);
+            connection.Bind();
+            var diagnostics = new Dictionary<string, string>
+            {
+                ["Server"] = options.Host,
+                ["Port"] = options.Port.ToString(),
+                ["Secure"] = options.UseSsl.ToString()
+            };
+
+            return new LdapConnectionTestResult(true, "Bind succeeded", diagnostics);
+        }
+        catch (LdapException ex)
+        {
+            _logger.LogWarning(ex, "LDAP bind failed");
+            return new LdapConnectionTestResult(false, ex.Message, BuildDiagnosticsFromException(ex));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected LDAP error");
+            return new LdapConnectionTestResult(false, ex.Message, BuildDiagnosticsFromException(ex));
+        }
+    }
+
+    private LdapDryRunResult ExecuteDryRun(LdapDryRunRequest request)
+    {
+        try
+        {
+            using var connection = CreateConnection(request.Connection);
+            connection.Bind();
+
+            var searchRequest = new SearchRequest(
+                request.UsersBaseDn,
+                string.IsNullOrWhiteSpace(request.UsersFilter) ? "(objectClass=user)" : request.UsersFilter,
+                SearchScope.Subtree,
+                request.AttributeMap.ToArray());
+
+            var response = (SearchResponse)connection.SendRequest(searchRequest);
+
+            var users = new List<LdapDryRunUser>();
+            foreach (SearchResultEntry entry in response.Entries)
+            {
+                var attributes = new Dictionary<string, string?>();
+                foreach (var attributeKey in request.AttributeMap)
+                {
+                    if (entry.Attributes.Contains(attributeKey))
+                    {
+                        var attribute = entry.Attributes[attributeKey];
+                        attributes[attributeKey] = attribute?.GetValues(typeof(string)).Cast<string?>().FirstOrDefault();
+                    }
+                    else
+                    {
+                        attributes[attributeKey] = null;
+                    }
+                }
+
+                users.Add(new LdapDryRunUser(entry.DistinguishedName, attributes));
+                if (users.Count >= request.ResultLimit)
+                {
+                    break;
+                }
+            }
+
+            var truncated = users.Count >= request.ResultLimit && response.Entries.Count > request.ResultLimit;
+            var notesBuilder = new StringBuilder();
+            if (truncated)
+            {
+                notesBuilder.Append("Result set truncated to limit");
+            }
+
+            return new LdapDryRunResult(users, response.Entries.Count, truncated, notesBuilder.Length == 0 ? null : notesBuilder.ToString());
+        }
+        catch (LdapException ex)
+        {
+            _logger.LogWarning(ex, "LDAP dry run failed");
+            throw;
+        }
+    }
+
+    private static LdapConnection CreateConnection(LdapConnectionOptions options)
+    {
+        var identifier = new LdapDirectoryIdentifier(options.Host, options.Port);
+        var connection = new LdapConnection(identifier)
+        {
+            Credential = new NetworkCredential(options.BindDn, options.Password ?? string.Empty),
+            AuthType = AuthType.Basic
+        };
+
+        if (options.UseSsl)
+        {
+            connection.SessionOptions.SecureSocketLayer = true;
+        }
+
+        if (options.IgnoreCertificateErrors)
+        {
+            connection.SessionOptions.VerifyServerCertificate += (_, _) => true;
+        }
+
+        connection.SessionOptions.ProtocolVersion = 3;
+        connection.Timeout = TimeSpan.FromSeconds(15);
+        return connection;
+    }
+
+    private static Dictionary<string, string> BuildDiagnosticsFromException(Exception ex)
+    {
+        var diagnostics = new Dictionary<string, string>
+        {
+            ["ExceptionType"] = ex.GetType().FullName ?? ex.GetType().Name,
+            ["Message"] = ex.Message
+        };
+
+        if (ex is LdapException ldapEx)
+        {
+            diagnostics["ErrorCode"] = ldapEx.ErrorCode.ToString();
+            diagnostics["ServerErrorMessage"] = ldapEx.ServerErrorMessage ?? string.Empty;
+        }
+
+        return diagnostics;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/PasswordHistoryService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/PasswordHistoryService.cs
@@ -1,0 +1,84 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class PasswordHistoryService : IPasswordHistoryService
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IPasswordHasher<AppUser> _passwordHasher;
+    private readonly IPasswordPolicyConfigurationStore _policyStore;
+
+    public PasswordHistoryService(
+        IAppDbContext dbContext,
+        IPasswordHasher<AppUser> passwordHasher,
+        IPasswordPolicyConfigurationStore policyStore)
+    {
+        _dbContext = dbContext;
+        _passwordHasher = passwordHasher;
+        _policyStore = policyStore;
+    }
+
+    public async Task RecordAsync(AppUser user, CancellationToken cancellationToken = default)
+    {
+        var policy = await _policyStore.GetAsync(cancellationToken);
+        if (!policy.Enabled)
+        {
+            return;
+        }
+
+        var entry = new PasswordHistoryEntry
+        {
+            UserId = user.Id,
+            PasswordHash = user.PasswordHash ?? string.Empty,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        _dbContext.PasswordHistoryEntries.Add(entry);
+
+        var keepCount = Math.Max(policy.HistoryCount, 0);
+        if (keepCount > 0)
+        {
+            var obsolete = await _dbContext.PasswordHistoryEntries
+                .Where(x => x.UserId == user.Id)
+                .OrderByDescending(x => x.CreatedAtUtc)
+                .Skip(keepCount)
+                .ToListAsync(cancellationToken);
+
+            if (obsolete.Count > 0)
+            {
+                _dbContext.PasswordHistoryEntries.RemoveRange(obsolete);
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> IsReusedAsync(AppUser user, string password, CancellationToken cancellationToken = default)
+    {
+        var policy = await _policyStore.GetAsync(cancellationToken);
+        if (!policy.Enabled || policy.HistoryCount <= 0)
+        {
+            return false;
+        }
+
+        var previous = await _dbContext.PasswordHistoryEntries
+            .Where(x => x.UserId == user.Id)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .Take(policy.HistoryCount)
+            .ToListAsync(cancellationToken);
+
+        foreach (var entry in previous)
+        {
+            var verification = _passwordHasher.VerifyHashedPassword(user, entry.PasswordHash, password);
+            if (verification == PasswordVerificationResult.Success || verification == PasswordVerificationResult.SuccessRehashRequired)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/PasswordHistoryValidator.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/PasswordHistoryValidator.cs
@@ -1,0 +1,38 @@
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class PasswordHistoryValidator : IPasswordValidator<AppUser>
+{
+    private readonly IPasswordHistoryService _passwordHistoryService;
+
+    public PasswordHistoryValidator(IPasswordHistoryService passwordHistoryService)
+    {
+        _passwordHistoryService = passwordHistoryService;
+    }
+
+    public async Task<IdentityResult> ValidateAsync(UserManager<AppUser> manager, AppUser user, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return IdentityResult.Failed(new IdentityError
+            {
+                Code = "PasswordRequired",
+                Description = "Password cannot be empty."
+            });
+        }
+
+        if (await _passwordHistoryService.IsReusedAsync(user, password))
+        {
+            return IdentityResult.Failed(new IdentityError
+            {
+                Code = "PasswordReused",
+                Description = "Password was used recently and cannot be reused."
+            });
+        }
+
+        return IdentityResult.Success;
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyConfigurationStore.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class PasswordPolicyConfigurationStore : IPasswordPolicyConfigurationStore
+{
+    private const string SectionName = "Security.PasswordPolicy";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public PasswordPolicyConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<PasswordPolicyModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new PasswordPolicyModel(
+            ReadBool(settings, "Enabled"),
+            ReadInt(settings, "MinimumLength", 12),
+            ReadBool(settings, "RequireUppercase", true),
+            ReadBool(settings, "RequireLowercase", true),
+            ReadBool(settings, "RequireDigit", true),
+            ReadBool(settings, "RequireNonAlphanumeric", false),
+            ReadInt(settings, "ExpirationDays", 90),
+            ReadInt(settings, "HistoryCount", 5),
+            ReadInt(settings, "LockoutAttempts", 5),
+            ReadInt(settings, "LockoutDurationMinutes", 15));
+    }
+
+    public async Task<PasswordPolicyModel> SaveAsync(PasswordPolicyUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = false,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString());
+        Upsert("MinimumLength", update.MinimumLength.ToString());
+        Upsert("RequireUppercase", update.RequireUppercase.ToString());
+        Upsert("RequireLowercase", update.RequireLowercase.ToString());
+        Upsert("RequireDigit", update.RequireDigit.ToString());
+        Upsert("RequireNonAlphanumeric", update.RequireNonAlphanumeric.ToString());
+        Upsert("ExpirationDays", update.ExpirationDays.ToString());
+        Upsert("HistoryCount", update.HistoryCount.ToString());
+        Upsert("LockoutAttempts", update.LockoutAttempts.ToString());
+        Upsert("LockoutDurationMinutes", update.LockoutDurationMinutes.ToString());
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key, bool fallback = false)
+    {
+        if (settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyOptionsConfigurator.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/PasswordPolicyOptionsConfigurator.cs
@@ -1,0 +1,44 @@
+using System;
+using HWInventory.Application.Abstractions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class PasswordPolicyOptionsConfigurator : IConfigureOptions<IdentityOptions>
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public PasswordPolicyOptionsConfigurator(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public void Configure(IdentityOptions options)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var policyStore = scope.ServiceProvider.GetRequiredService<IPasswordPolicyConfigurationStore>();
+        var policy = policyStore.GetAsync().GetAwaiter().GetResult();
+
+        if (!policy.Enabled)
+        {
+            return;
+        }
+
+        options.Password.RequiredLength = Math.Max(8, policy.MinimumLength);
+        options.Password.RequireUppercase = policy.RequireUppercase;
+        options.Password.RequireLowercase = policy.RequireLowercase;
+        options.Password.RequireDigit = policy.RequireDigit;
+        options.Password.RequireNonAlphanumeric = policy.RequireNonAlphanumeric;
+
+        options.Lockout.AllowedForNewUsers = true;
+        options.Lockout.MaxFailedAccessAttempts = Math.Max(1, policy.LockoutAttempts);
+        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(Math.Max(1, policy.LockoutDurationMinutes));
+
+        if (policy.ExpirationDays > 0)
+        {
+            options.SecurityStampValidationInterval = TimeSpan.FromDays(policy.ExpirationDays);
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SessionTracker.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SessionTracker.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SessionTracker : ISessionTracker
+{
+    private readonly IAppDbContext _dbContext;
+
+    public SessionTracker(IAppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<UserSessionDto> RegisterAsync(RegisterSessionRequest request, CancellationToken cancellationToken = default)
+    {
+        var actor = string.IsNullOrWhiteSpace(request.PerformedBy) ? "system" : request.PerformedBy;
+        var session = new UserSession
+        {
+            AppUserId = request.UserId,
+            SessionIdentifier = request.SessionIdentifier,
+            IssuedAtUtc = DateTime.UtcNow,
+            LastSeenAtUtc = DateTime.UtcNow,
+            IpAddress = request.IpAddress,
+            UserAgent = request.UserAgent,
+            CreatedBy = actor,
+            ModifiedBy = actor
+        };
+
+        _dbContext.UserSessions.Add(session);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new UserSessionDto(session.Id, session.SessionIdentifier, session.IssuedAtUtc, session.LastSeenAtUtc, session.IpAddress, session.UserAgent, session.IsRevoked);
+    }
+
+    public async Task<bool> TouchAsync(string sessionIdentifier, CancellationToken cancellationToken = default)
+    {
+        var session = await _dbContext.UserSessions.FirstOrDefaultAsync(x => x.SessionIdentifier == sessionIdentifier, cancellationToken);
+        if (session is null)
+        {
+            return false;
+        }
+
+        if (session.IsRevoked)
+        {
+            return false;
+        }
+
+        session.LastSeenAtUtc = DateTime.UtcNow;
+        session.ModifiedBy = session.ModifiedBy ?? "system";
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return !session.IsRevoked;
+    }
+
+    public async Task<IReadOnlyCollection<UserSessionDto>> GetActiveSessionsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var sessions = await _dbContext.UserSessions
+            .Where(x => x.AppUserId == userId && !x.IsRevoked)
+            .OrderByDescending(x => x.LastSeenAtUtc)
+            .Select(x => new UserSessionDto(x.Id, x.SessionIdentifier, x.IssuedAtUtc, x.LastSeenAtUtc, x.IpAddress, x.UserAgent, x.IsRevoked))
+            .ToListAsync(cancellationToken);
+
+        return sessions;
+    }
+
+    public async Task RevokeAsync(Guid sessionId, string performedBy, string? reason, CancellationToken cancellationToken = default)
+    {
+        var session = await _dbContext.UserSessions.FirstOrDefaultAsync(x => x.Id == sessionId, cancellationToken);
+        if (session is null)
+        {
+            return;
+        }
+
+        session.IsRevoked = true;
+        session.RevokedAtUtc = DateTime.UtcNow;
+        session.RevokedBy = performedBy;
+        session.TerminationReason = reason;
+        session.ModifiedBy = performedBy;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task RevokeAllAsync(Guid userId, string performedBy, CancellationToken cancellationToken = default)
+    {
+        var sessions = await _dbContext.UserSessions.Where(x => x.AppUserId == userId && !x.IsRevoked).ToListAsync(cancellationToken);
+        var now = DateTime.UtcNow;
+        foreach (var session in sessions)
+        {
+            session.IsRevoked = true;
+            session.RevokedAtUtc = now;
+            session.RevokedBy = performedBy;
+            session.ModifiedBy = performedBy;
+            session.TerminationReason = "Revoked by administrator";
+        }
+
+        if (sessions.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SmsConnectorStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SmsConnectorStore.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SmsConnectorStore : ISmsConnectorStore
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public SmsConnectorStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<SmsConnectorModel?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS", cancellationToken);
+
+        if (connector is null)
+        {
+            return null;
+        }
+
+        var config = ParseConfiguration(connector.ConfigurationJson);
+        var hasSecret = connector.Secrets.Any();
+
+        return new SmsConnectorModel(
+            connector.Id,
+            connector.Alias,
+            connector.Enabled,
+            config.TryGetValue("endpoint", out var endpoint) ? endpoint ?? string.Empty : string.Empty,
+            config.TryGetValue("sender", out var sender) ? sender : null,
+            config.TryGetValue("region", out var region) ? region : null,
+            hasSecret,
+            connector.HealthStatus,
+            connector.LastTestedAtUtc);
+    }
+
+    public async Task<SmsConnectorModel> SaveAsync(SmsConnectorUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS", cancellationToken);
+
+        var config = new Dictionary<string, string?>
+        {
+            ["endpoint"] = update.Endpoint,
+            ["sender"] = update.Sender,
+            ["region"] = update.Region
+        };
+
+        if (connector is null)
+        {
+            connector = new ConnectorProfile
+            {
+                Type = "SMS",
+                Alias = string.IsNullOrWhiteSpace(update.Alias) ? "Primary SMS" : update.Alias,
+                Enabled = update.Enabled,
+                ConfigurationJson = JsonSerializer.Serialize(config),
+                CreatedBy = actor,
+                ModifiedBy = actor
+            };
+
+            _dbContext.ConnectorProfiles.Add(connector);
+        }
+        else
+        {
+            connector.Alias = string.IsNullOrWhiteSpace(update.Alias) ? connector.Alias : update.Alias;
+            connector.Enabled = update.Enabled;
+            connector.ConfigurationJson = JsonSerializer.Serialize(config);
+            connector.ModifiedBy = actor;
+        }
+
+        if (update.RotateSecret && string.IsNullOrWhiteSpace(update.Secret))
+        {
+            connector.Secrets.Clear();
+        }
+        else if (!string.IsNullOrWhiteSpace(update.Secret))
+        {
+            connector.Secrets.Clear();
+            connector.Secrets.Add(new ConnectorSecret
+            {
+                Key = "token",
+                SecretReference = update.Secret!,
+                RotatedAtUtc = DateTime.UtcNow
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return (await GetAsync(cancellationToken))!;
+    }
+
+    private static Dictionary<string, string?> ParseConfiguration(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string?>>(json) ?? new Dictionary<string, string?>();
+        }
+        catch
+        {
+            return new Dictionary<string, string?>();
+        }
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SmsGateway.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SmsGateway.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HWInventory.Application.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SmsGateway : ISmsGateway
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<SmsGateway> _logger;
+
+    public SmsGateway(IAppDbContext dbContext, IHttpClientFactory httpClientFactory, ILogger<SmsGateway> logger)
+    {
+        _dbContext = dbContext;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(string destination, string message, CancellationToken cancellationToken = default)
+    {
+        var connector = await _dbContext.ConnectorProfiles
+            .Include(x => x.Secrets)
+            .FirstOrDefaultAsync(x => x.Type == "SMS" && x.Enabled, cancellationToken);
+
+        if (connector is null)
+        {
+            _logger.LogWarning("SMS connector not configured. Message to {Destination} dropped.", destination);
+            return;
+        }
+
+        try
+        {
+            var config = connector.ConfigurationJson is null
+                ? new Dictionary<string, string>()
+                : JsonSerializer.Deserialize<Dictionary<string, string>>(connector.ConfigurationJson) ?? new Dictionary<string, string>();
+
+            config.TryGetValue("endpoint", out var endpoint);
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                _logger.LogWarning("SMS connector endpoint missing. Message to {Destination} dropped.", destination);
+                return;
+            }
+
+            var client = _httpClientFactory.CreateClient("sms");
+            var payload = new
+            {
+                to = destination,
+                message,
+                sender = config.TryGetValue("sender", out var sender) ? sender : null,
+                token = connector.Secrets.FirstOrDefault()?.SecretReference
+            };
+
+            var response = await client.PostAsJsonAsync(endpoint, payload, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("SMS send failed for {Destination} with status {Status}", destination, response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SMS send error for {Destination}", destination);
+        }
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SsprConfigurationStore.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SsprConfigurationStore.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SsprConfigurationStore : ISsprConfigurationStore
+{
+    private const string SectionName = "Security.Sspr";
+    private readonly IAppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public SsprConfigurationStore(IAppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<SsprConfigurationModel> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToDictionaryAsync(x => x.Key, x => x, cancellationToken);
+
+        return new SsprConfigurationModel(
+            ReadBool(settings, "Enabled"),
+            ReadBool(settings, "RequireTwoFactor"),
+            ReadBool(settings, "RequireCaptcha"),
+            ReadBool(settings, "RequireSmsOtp"),
+            ReadInt(settings, "TokenExpiryMinutes", 30),
+            ReadInt(settings, "ThrottleWindowMinutes", 15),
+            ReadInt(settings, "MaxRequestsPerWindow", 3),
+            ReadString(settings, "SmsConnectorKey", allowNull: true));
+    }
+
+    public async Task<SsprConfigurationModel> SaveAsync(SsprConfigurationUpdate update, CancellationToken cancellationToken = default)
+    {
+        var actor = ResolveActor();
+        var existing = await _dbContext.Settings
+            .Where(x => x.Section == SectionName)
+            .ToListAsync(cancellationToken);
+
+        void Upsert(string key, string? value, bool isSecret)
+        {
+            var row = existing.FirstOrDefault(x => x.Key == key);
+            if (row is null)
+            {
+                row = new AppSetting
+                {
+                    Section = SectionName,
+                    Key = key,
+                    Value = value,
+                    IsSecret = isSecret,
+                    CreatedBy = actor,
+                    ModifiedBy = actor
+                };
+                _dbContext.Settings.Add(row);
+            }
+            else
+            {
+                row.Value = value;
+                row.IsSecret = isSecret;
+                row.ModifiedBy = actor;
+            }
+        }
+
+        Upsert("Enabled", update.Enabled.ToString(), false);
+        Upsert("RequireTwoFactor", update.RequireTwoFactor.ToString(), false);
+        Upsert("RequireCaptcha", update.RequireCaptcha.ToString(), false);
+        Upsert("RequireSmsOtp", update.RequireSmsOtp.ToString(), false);
+        Upsert("TokenExpiryMinutes", update.TokenExpiryMinutes.ToString(), false);
+        Upsert("ThrottleWindowMinutes", update.ThrottleWindowMinutes.ToString(), false);
+        Upsert("MaxRequestsPerWindow", update.MaxRequestsPerWindow.ToString(), false);
+        Upsert("SmsConnectorKey", string.IsNullOrWhiteSpace(update.SmsConnectorKey) ? null : update.SmsConnectorKey, false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return await GetAsync(cancellationToken);
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, AppSetting> settings, string key)
+    {
+        return settings.TryGetValue(key, out var setting) && bool.TryParse(setting.Value, out var value) && value;
+    }
+
+    private static int ReadInt(IReadOnlyDictionary<string, AppSetting> settings, string key, int fallback)
+    {
+        if (settings.TryGetValue(key, out var setting) && int.TryParse(setting.Value, out var value))
+        {
+            return value;
+        }
+
+        return fallback;
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, AppSetting> settings, string key, bool allowNull = false)
+    {
+        if (settings.TryGetValue(key, out var setting) && !string.IsNullOrWhiteSpace(setting.Value))
+        {
+            return setting.Value;
+        }
+
+        return allowNull ? null : string.Empty;
+    }
+
+    private string ResolveActor()
+    {
+        return _httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "system";
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/SsprService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/SsprService.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Domain.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class SsprService : ISsprService
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICaptchaValidator _captchaValidator;
+    private readonly ISmsGateway _smsGateway;
+    private readonly ILogger<SsprService> _logger;
+    private readonly ISessionTracker _sessionTracker;
+
+    public SsprService(UserManager<AppUser> userManager, IAppDbContext dbContext, ICaptchaValidator captchaValidator, ISmsGateway smsGateway, ISessionTracker sessionTracker, ILogger<SsprService> logger)
+    {
+        _userManager = userManager;
+        _dbContext = dbContext;
+        _captchaValidator = captchaValidator;
+        _smsGateway = smsGateway;
+        _sessionTracker = sessionTracker;
+        _logger = logger;
+    }
+
+    public async Task<PasswordResetRequestResult> RequestResetAsync(PasswordResetRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!await _captchaValidator.ValidateAsync(request.CaptchaToken, cancellationToken))
+        {
+            return new PasswordResetRequestResult(false, "CAPTCHA validation failed.", null, false);
+        }
+
+        var user = await _userManager.Users.FirstOrDefaultAsync(x => x.Email == request.UsernameOrEmail || x.UserName == request.UsernameOrEmail, cancellationToken);
+        if (user is null)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken); // mitigate enumeration
+            return new PasswordResetRequestResult(false, "User not found.", null, false);
+        }
+
+        var identityToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var resetToken = new PasswordResetToken
+        {
+            AppUserId = user.Id,
+            Token = Guid.NewGuid(),
+            DeliveryMethod = request.DeliveryMethod,
+            DeliveryAddress = request.DeliveryDestination,
+            ExpiresAtUtc = DateTime.UtcNow.AddMinutes(30),
+            RequiresSmsVerification = request.RequireSmsOtp,
+            Status = PasswordResetStatus.Pending,
+            CreatedBy = user.UserName ?? user.Email ?? "system",
+            ModifiedBy = user.UserName ?? user.Email ?? "system",
+            CaptchaToken = request.CaptchaToken,
+            IdentityToken = identityToken
+        };
+
+        string? smsCode = null;
+        if (request.RequireSmsOtp && !string.IsNullOrWhiteSpace(request.DeliveryDestination))
+        {
+            smsCode = GenerateSmsCode();
+            resetToken.SmsCodeHash = HashValue(smsCode);
+            await _smsGateway.SendAsync(request.DeliveryDestination, $"HWInventory reset kód: {smsCode}", cancellationToken);
+        }
+
+        _dbContext.PasswordResetTokens.Add(resetToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new PasswordResetRequestResult(true, "Reset token issued.", resetToken.Token, smsCode is not null);
+    }
+
+    public async Task<PasswordResetCompletionResult> CompleteResetAsync(PasswordResetCompletionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!await _captchaValidator.ValidateAsync(request.CaptchaToken, cancellationToken))
+        {
+            return new PasswordResetCompletionResult(false, "CAPTCHA validation failed.");
+        }
+
+        var token = await _dbContext.PasswordResetTokens
+            .Include(x => x.AppUser)
+            .FirstOrDefaultAsync(x => x.Token == request.Token, cancellationToken);
+
+        if (token is null)
+        {
+            return new PasswordResetCompletionResult(false, "Reset token not found.");
+        }
+
+        if (token.Status != PasswordResetStatus.Pending)
+        {
+            return new PasswordResetCompletionResult(false, "Reset token is not active.");
+        }
+
+        if (token.ExpiresAtUtc < DateTime.UtcNow)
+        {
+            token.Status = PasswordResetStatus.Expired;
+            token.ModifiedBy = token.ModifiedBy ?? "system";
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new PasswordResetCompletionResult(false, "Reset token expired.");
+        }
+
+        if (token.RequiresSmsVerification)
+        {
+            if (string.IsNullOrWhiteSpace(request.SmsCode) || token.SmsCodeHash != HashValue(request.SmsCode))
+            {
+                return new PasswordResetCompletionResult(false, "SMS code invalid.");
+            }
+        }
+
+        var user = token.AppUser;
+        var result = await _userManager.ResetPasswordAsync(user, token.IdentityToken, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            var message = string.Join(",", result.Errors.Select(e => e.Description));
+            _logger.LogWarning("Failed to reset password for user {UserId}: {Message}", user.Id, message);
+            return new PasswordResetCompletionResult(false, message);
+        }
+
+        token.Status = PasswordResetStatus.Completed;
+        token.ConsumedAtUtc = DateTime.UtcNow;
+        token.ModifiedBy = user.UserName ?? user.Email ?? "system";
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _sessionTracker.RevokeAllAsync(user.Id, user.UserName ?? user.Email ?? "system", cancellationToken);
+
+        return new PasswordResetCompletionResult(true, "Password reset successfully.");
+    }
+
+    private static string GenerateSmsCode()
+    {
+        var randomBytes = RandomNumberGenerator.GetBytes(4);
+        var value = BitConverter.ToUInt32(randomBytes, 0) % 1000000;
+        return value.ToString("D6");
+    }
+
+    private static string HashValue(string value)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
+++ b/src/api/src/HWInventory.Infrastructure/Security/TotpService.cs
@@ -1,0 +1,34 @@
+using System.Security.Cryptography;
+using HWInventory.Application.Abstractions;
+using OtpNet;
+
+namespace HWInventory.Infrastructure.Security;
+
+public class TotpService : ITotpService
+{
+    private const int SecretSize = 20;
+
+    public string GenerateSecretKey()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(SecretSize);
+        return Base32Encoding.ToString(bytes);
+    }
+
+    public string GenerateCode(string secretKey)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.ComputeTotp(DateTime.UtcNow);
+    }
+
+    public bool ValidateCode(string secretKey, string code)
+    {
+        var totp = CreateTotp(secretKey);
+        return totp.VerifyTotp(code, out _, VerificationWindow.RfcSpecifiedNetworkDelay);
+    }
+
+    private static Totp CreateTotp(string secretKey)
+    {
+        var key = Base32Encoding.ToBytes(secretKey);
+        return new Totp(key, mode: OtpHashMode.Sha1, step: 30, totpSize: 6);
+    }
+}

--- a/src/api/tests/HWInventory.Infrastructure.Tests/HWInventory.Infrastructure.Tests.csproj
+++ b/src/api/tests/HWInventory.Infrastructure.Tests/HWInventory.Infrastructure.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/HWInventory.Infrastructure/HWInventory.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/HWInventory.Application/HWInventory.Application.csproj" />
+    <ProjectReference Include="../../src/HWInventory.Domain/HWInventory.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/tests/HWInventory.Infrastructure.Tests/PasswordSecurityTests.cs
+++ b/src/api/tests/HWInventory.Infrastructure.Tests/PasswordSecurityTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HWInventory.Application.Abstractions;
+using HWInventory.Domain.Entities;
+using HWInventory.Infrastructure.Persistence;
+using HWInventory.Infrastructure.Security;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace HWInventory.Infrastructure.Tests;
+
+public class PasswordSecurityTests
+{
+    [Fact]
+    public async Task PasswordHistoryService_RecordsAndTrimsEntries()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var dbContext = new AppDbContext(options);
+        var user = new AppUser
+        {
+            Id = Guid.NewGuid(),
+            UserName = "alice",
+            NormalizedUserName = "ALICE",
+            Email = "alice@example.com",
+            NormalizedEmail = "ALICE@EXAMPLE.COM",
+            DisplayName = "Alice",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "tests"
+        };
+
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var policyStore = new FakePasswordPolicyStore(new PasswordPolicyModel(true, 12, true, true, true, false, 90, 2, 5, 15));
+        var hasher = new PasswordHasher<AppUser>();
+        var service = new PasswordHistoryService(dbContext, hasher, policyStore);
+
+        // Act
+        user.PasswordHash = hasher.HashPassword(user, "Password#1");
+        await service.RecordAsync(user);
+
+        user.PasswordHash = hasher.HashPassword(user, "Password#2");
+        await service.RecordAsync(user);
+
+        user.PasswordHash = hasher.HashPassword(user, "Password#3");
+        await service.RecordAsync(user);
+
+        // Assert
+        var entries = await dbContext.PasswordHistoryEntries
+            .Where(x => x.UserId == user.Id)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .ToListAsync();
+
+        Assert.Equal(2, entries.Count);
+        Assert.All(entries, entry => Assert.Equal(user.Id, entry.UserId));
+    }
+
+    [Fact]
+    public async Task PasswordHistoryValidator_RejectsReusedPasswords()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var dbContext = new AppDbContext(options);
+        var user = new AppUser
+        {
+            Id = Guid.NewGuid(),
+            UserName = "bob",
+            NormalizedUserName = "BOB",
+            Email = "bob@example.com",
+            NormalizedEmail = "BOB@EXAMPLE.COM",
+            DisplayName = "Bob",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "tests"
+        };
+
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var policy = new PasswordPolicyModel(true, 12, true, true, true, false, 90, 5, 5, 15);
+        var policyStore = new FakePasswordPolicyStore(policy);
+        var hasher = new PasswordHasher<AppUser>();
+        var historyService = new PasswordHistoryService(dbContext, hasher, policyStore);
+        var validator = new PasswordHistoryValidator(historyService);
+
+        var password = "Secure#Password1";
+        user.PasswordHash = hasher.HashPassword(user, password);
+        await historyService.RecordAsync(user);
+
+        // Act
+        var result = await validator.ValidateAsync(CreateUserManager(), user, password);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Errors, error => error.Code == "PasswordReused");
+    }
+
+    [Fact]
+    public void PasswordPolicyOptionsConfigurator_AppliesPolicyToIdentityOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var policy = new PasswordPolicyModel(true, 14, true, true, true, true, 120, 4, 7, 20);
+        services.AddScoped<IPasswordPolicyConfigurationStore>(_ => new FakePasswordPolicyStore(policy));
+        var provider = services.BuildServiceProvider();
+
+        var configurator = new PasswordPolicyOptionsConfigurator(provider);
+        var options = new IdentityOptions();
+
+        // Act
+        configurator.Configure(options);
+
+        // Assert
+        Assert.Equal(14, options.Password.RequiredLength);
+        Assert.True(options.Password.RequireDigit);
+        Assert.True(options.Password.RequireUppercase);
+        Assert.True(options.Password.RequireLowercase);
+        Assert.True(options.Password.RequireNonAlphanumeric);
+        Assert.Equal(7, options.Lockout.MaxFailedAccessAttempts);
+        Assert.Equal(TimeSpan.FromMinutes(20), options.Lockout.DefaultLockoutTimeSpan);
+    }
+
+    private static UserManager<AppUser> CreateUserManager()
+    {
+        var store = new MockUserStore();
+        var options = Options.Create(new IdentityOptions());
+        return new UserManager<AppUser>(store, options, new PasswordHasher<AppUser>(), Enumerable.Empty<IUserValidator<AppUser>>(), Enumerable.Empty<IPasswordValidator<AppUser>>(), new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), null!, new MockLogger<UserManager<AppUser>>());
+    }
+
+    private sealed class FakePasswordPolicyStore : IPasswordPolicyConfigurationStore
+    {
+        private readonly PasswordPolicyModel _model;
+
+        public FakePasswordPolicyStore(PasswordPolicyModel model)
+        {
+            _model = model;
+        }
+
+        public Task<PasswordPolicyModel> GetAsync(CancellationToken cancellationToken = default) => Task.FromResult(_model);
+
+        public Task<PasswordPolicyModel> SaveAsync(PasswordPolicyUpdate update, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class MockUserStore : IUserPasswordStore<AppUser>
+    {
+        public Task<IdentityResult> CreateAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(IdentityResult.Success);
+        public Task<IdentityResult> DeleteAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(IdentityResult.Success);
+        public void Dispose()
+        {
+        }
+
+        public Task<AppUser?> FindByIdAsync(string userId, CancellationToken cancellationToken) => Task.FromResult<AppUser?>(null);
+        public Task<AppUser?> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken) => Task.FromResult<AppUser?>(null);
+        public Task<string?> GetNormalizedUserNameAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult<string?>(user.NormalizedUserName);
+        public Task<string?> GetPasswordHashAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(user.PasswordHash);
+        public Task<string?> GetUserIdAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult<string?>(user.Id.ToString());
+        public Task<string?> GetUserNameAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(user.UserName);
+        public Task<bool> HasPasswordAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(!string.IsNullOrEmpty(user.PasswordHash));
+        public Task SetNormalizedUserNameAsync(AppUser user, string? normalizedName, CancellationToken cancellationToken)
+        {
+            user.NormalizedUserName = normalizedName;
+            return Task.CompletedTask;
+        }
+
+        public Task SetPasswordHashAsync(AppUser user, string? passwordHash, CancellationToken cancellationToken)
+        {
+            user.PasswordHash = passwordHash;
+            return Task.CompletedTask;
+        }
+
+        public Task SetUserNameAsync(AppUser user, string? userName, CancellationToken cancellationToken)
+        {
+            user.UserName = userName ?? string.Empty;
+            return Task.CompletedTask;
+        }
+
+        public Task<IdentityResult> UpdateAsync(AppUser user, CancellationToken cancellationToken) => Task.FromResult(IdentityResult.Success);
+    }
+
+    private sealed class MockLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => false;
+
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+
+        private sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,0 +1,10 @@
+# HW Inventory Admin UI (Placeholder)
+
+The React + Vite + Tailwind admin application will live in this directory. Upcoming milestones:
+
+1. Scaffold Vite project structure with routing, layout shell, and Tailwind theme tokens.
+2. Implement authentication shell (login, MFA prompt) integrated with the API once auth is available.
+3. Build pages for dashboard, servers, network, workstations, dictionaries, audit, labels, modules, and settings (including the onboarding wizard).
+4. Connect to API endpoints, implement pagination/filtering, and render label previews.
+
+Until the UI is generated the directory contains documentation placeholders only.

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HW Inventory Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "hw-inventory-admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.17.0",
+    "axios": "^1.6.0",
+    "clsx": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/web/postcss.config.cjs
+++ b/src/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,0 +1,127 @@
+import { Link, Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import { useTheme } from './hooks/useTheme';
+import { DashboardPage } from './pages/DashboardPage';
+import { FirstRunWizardPage } from './pages/FirstRunWizardPage';
+import { PlaceholderPage } from './pages/PlaceholderPage';
+import { EmailSettingsPage } from './pages/EmailSettingsPage';
+import { ConnectorsPage } from './pages/ConnectorsPage';
+import { ObservabilitySettingsPage } from './pages/ObservabilitySettingsPage';
+import { BackupRestorePage } from './pages/BackupRestorePage';
+import { SecuritySettingsPage } from './pages/SecuritySettingsPage';
+import { ExportJobsPage } from './pages/ExportJobsPage';
+import { UpdatesPage } from './pages/UpdatesPage';
+import { ServersPage } from './pages/ServersPage';
+import { NetworkDevicesPage } from './pages/NetworkDevicesPage';
+import { WorkstationsPage } from './pages/WorkstationsPage';
+import { AuditPage } from './pages/AuditPage';
+import { LabelsPage } from './pages/LabelsPage';
+import { DictionariesPage } from './pages/DictionariesPage';
+import { ModulesPage } from './pages/ModulesPage';
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/servers', label: 'Servers' },
+  { to: '/network', label: 'Network' },
+  { to: '/workstations', label: 'Workstations' },
+  { to: '/audit', label: 'Audit' },
+  { to: '/labels', label: 'Labels' },
+  { to: '/settings/security', label: 'Settings' },
+  { to: '/modules', label: 'Modules' }
+];
+
+const settingsItems = [
+  { to: 'security', label: 'Security & Auth' },
+  { to: 'email', label: 'Email (SMTP)' },
+  { to: 'connectors', label: 'Konektory' },
+  { to: 'observability', label: 'Observabilita' },
+  { to: 'backup', label: 'Backup & Restore' },
+  { to: 'export', label: 'Import/Export' },
+  { to: 'dictionaries', label: 'Číselníky' },
+  { to: 'updates', label: 'Aktualizace' }
+];
+
+const Layout = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="min-h-screen bg-slate-100 dark:bg-slate-950">
+      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-white">HW Inventory</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Operations control center</p>
+          </div>
+          <button
+            onClick={toggleTheme}
+            className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium shadow-sm transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            type="button"
+          >
+            {theme === 'light' ? '🌙 Dark mode' : '☀️ Light mode'}
+          </button>
+        </div>
+        <nav className="bg-slate-50 dark:bg-slate-950">
+          <div className="mx-auto flex max-w-6xl flex-wrap gap-3 px-6 py-2 text-sm font-medium">
+            {navItems.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className="rounded px-3 py-1 text-slate-700 transition hover:bg-slate-200 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+const SettingsLayout = () => (
+  <div className="space-y-6">
+    <nav className="flex flex-wrap gap-3">
+      {settingsItems.map((item) => (
+        <Link
+          key={item.to}
+          to={item.to}
+          className="rounded border border-slate-200 px-3 py-1 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+    <Outlet />
+  </div>
+);
+
+const App = () => (
+  <Routes>
+    <Route path="/" element={<Layout />}>
+      <Route index element={<DashboardPage />} />
+      <Route path="first-run" element={<FirstRunWizardPage />} />
+      <Route path="servers" element={<ServersPage />} />
+      <Route path="network" element={<NetworkDevicesPage />} />
+      <Route path="workstations" element={<WorkstationsPage />} />
+      <Route path="audit" element={<AuditPage />} />
+      <Route path="labels" element={<LabelsPage />} />
+      <Route path="settings" element={<SettingsLayout />}>
+        <Route index element={<Navigate to="security" replace />} />
+        <Route path="security" element={<SecuritySettingsPage />} />
+        <Route path="email" element={<EmailSettingsPage />} />
+        <Route path="connectors" element={<ConnectorsPage />} />
+        <Route path="observability" element={<ObservabilitySettingsPage />} />
+        <Route path="backup" element={<BackupRestorePage />} />
+        <Route path="export" element={<ExportJobsPage />} />
+        <Route path="updates" element={<UpdatesPage />} />
+        <Route path="dictionaries" element={<DictionariesPage />} />
+        <Route path="*" element={<PlaceholderPage title="Settings" description="Administrative configuration center." />} />
+      </Route>
+      <Route path="modules" element={<ModulesPage />} />
+    </Route>
+  </Routes>
+);
+
+export default App;

--- a/src/web/src/api/audit.ts
+++ b/src/web/src/api/audit.ts
@@ -1,0 +1,19 @@
+import { apiClient } from './client';
+
+export interface AuditLogEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  action: string;
+  performedBy: string;
+  roles?: string | null;
+  performedAtUtc: string;
+  changeSummary?: string | null;
+  changedFieldsJson?: string | null;
+}
+
+export const getAuditLogs = async (entityType?: string) => {
+  const params = entityType ? { entityType } : undefined;
+  const { data } = await apiClient.get<AuditLogEntry[]>('/audit', { params });
+  return data;
+};

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: '/api',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const message = error?.response?.data?.detail || error?.message || 'Neznámá chyba';
+    return Promise.reject(new Error(message));
+  }
+);

--- a/src/web/src/api/connectors.ts
+++ b/src/web/src/api/connectors.ts
@@ -1,0 +1,47 @@
+import { apiClient } from './client';
+
+export interface ConnectorSummary {
+  id?: string;
+  key: string;
+  type: string;
+  name: string;
+  enabled: boolean;
+  healthStatus?: string | null;
+  lastTestedAtUtc?: string | null;
+  hasSecret: boolean;
+  supportsToggle: boolean;
+  supportsTest: boolean;
+  supportsRotateSecret: boolean;
+  requiresConfiguration: boolean;
+  description?: string | null;
+}
+
+export interface ConnectorTestResponse {
+  success: boolean;
+  message: string;
+  connector?: ConnectorSummary;
+}
+
+export interface ConnectorTestRequest {
+  target?: string;
+}
+
+export const fetchConnectors = async () => {
+  const { data } = await apiClient.get<ConnectorSummary[]>('/connectors');
+  return data;
+};
+
+export const toggleConnector = async (id: string, enabled: boolean) => {
+  const { data } = await apiClient.post<ConnectorSummary>(`/connectors/${id}/toggle?enabled=${enabled}`);
+  return data;
+};
+
+export const rotateConnectorSecret = async (id: string) => {
+  const { data } = await apiClient.post<ConnectorSummary>(`/connectors/${id}/rotate-secret`);
+  return data;
+};
+
+export const testConnector = async (id: string, payload: ConnectorTestRequest) => {
+  const { data } = await apiClient.post<ConnectorTestResponse>(`/connectors/${id}/test`, payload);
+  return data;
+};

--- a/src/web/src/api/dictionaries.ts
+++ b/src/web/src/api/dictionaries.ts
@@ -1,0 +1,38 @@
+import { apiClient } from './client';
+
+export interface DictionaryEntry {
+  id: string;
+  dictType: string;
+  key: string;
+  value: string;
+  description?: string | null;
+  order: number;
+}
+
+export interface DictionaryEntryRequest {
+  dictType: string;
+  key: string;
+  value: string;
+  description?: string | null;
+  order: number;
+}
+
+export const getDictionaryEntries = async (type?: string) => {
+  const params = type ? { type } : undefined;
+  const { data } = await apiClient.get<DictionaryEntry[]>('/dictionaries', { params });
+  return data;
+};
+
+export const createDictionaryEntry = async (payload: DictionaryEntryRequest) => {
+  const { data } = await apiClient.post<DictionaryEntry>('/dictionaries', payload);
+  return data;
+};
+
+export const updateDictionaryEntry = async (id: string, payload: DictionaryEntryRequest) => {
+  const { data } = await apiClient.put<DictionaryEntry>(`/dictionaries/${id}`, payload);
+  return data;
+};
+
+export const deleteDictionaryEntry = async (id: string) => {
+  await apiClient.delete(`/dictionaries/${id}`);
+};

--- a/src/web/src/api/email.ts
+++ b/src/web/src/api/email.ts
@@ -1,0 +1,55 @@
+import { apiClient } from './client';
+
+export interface EmailSettings {
+  id: string;
+  alias: string;
+  enabled: boolean;
+  host: string;
+  port: number;
+  useTls: boolean;
+  username?: string | null;
+  hasPassword: boolean;
+  fromAddress?: string | null;
+  replyToAddress?: string | null;
+  healthStatus?: string | null;
+  lastTestedAtUtc?: string | null;
+}
+
+export interface EmailSettingsUpdate {
+  alias: string;
+  enabled: boolean;
+  host: string;
+  port: number;
+  useTls: boolean;
+  username?: string | null;
+  fromAddress?: string | null;
+  replyToAddress?: string | null;
+  rotateSecret: boolean;
+  password?: string | null;
+}
+
+export interface EmailTestRequest {
+  recipient: string;
+  subject: string;
+  body: string;
+}
+
+export interface EmailTestResult {
+  success: boolean;
+  message: string;
+}
+
+export async function fetchEmailSettings(): Promise<EmailSettings | null> {
+  const response = await apiClient.get<EmailSettings | null>('/api/settings/email');
+  return response.data ?? null;
+}
+
+export async function saveEmailSettings(payload: EmailSettingsUpdate): Promise<EmailSettings> {
+  const response = await apiClient.put<EmailSettings>('/api/settings/email', payload);
+  return response.data;
+}
+
+export async function sendEmailTest(payload: EmailTestRequest): Promise<EmailTestResult> {
+  const response = await apiClient.post<EmailTestResult>('/api/settings/email/test', payload);
+  return response.data;
+}

--- a/src/web/src/api/exportJobs.ts
+++ b/src/web/src/api/exportJobs.ts
@@ -1,0 +1,47 @@
+import { apiClient } from './client';
+
+export interface ExportJob {
+  id: string;
+  scope: string;
+  format: string;
+  storagePath: string;
+  fileName: string;
+  status: string;
+  fileSizeBytes?: number | null;
+  createdAtUtc: string;
+  completedAtUtc?: string | null;
+  expiresAtUtc?: string | null;
+  createdBy: string;
+  failureReason?: string | null;
+  sendEmail: boolean;
+  emailRecipients?: string | null;
+  artifactPath?: string | null;
+}
+
+export interface QueueExportPayload {
+  scope: string;
+  format: string;
+  storagePath: string;
+  filterJson?: string | null;
+  sendEmail: boolean;
+  emailRecipients?: string | null;
+}
+
+export const listExportJobs = async (page = 1, size = 20) => {
+  const { data } = await apiClient.get<ExportJob[]>(`/exports/history`, {
+    params: { page, size }
+  });
+  return data;
+};
+
+export const queueExportJob = async (payload: QueueExportPayload) => {
+  const { data } = await apiClient.post<ExportJob>('/exports', payload);
+  return data;
+};
+
+export const getExportJob = async (id: string) => {
+  const { data } = await apiClient.get<ExportJob>(`/exports/${id}`);
+  return data;
+};
+
+export const buildExportDownloadUrl = (id: string) => `/api/exports/${id}/artifact`;

--- a/src/web/src/api/importJobs.ts
+++ b/src/web/src/api/importJobs.ts
@@ -1,0 +1,54 @@
+import { apiClient } from './client';
+
+export type ImportScope = 'Servers' | 'NetworkDevices' | 'Workstations' | 'Dictionaries';
+export type ImportFormat = 'Csv' | 'Xlsx';
+export type ImportConflictStrategy = 'Skip' | 'Update' | 'CreateNew';
+
+export interface ImportJob {
+  id: string;
+  scope: string;
+  format: string;
+  status: string;
+  conflictStrategy: string;
+  dryRun: boolean;
+  storagePath: string;
+  originalFileName: string;
+  createdAtUtc: string;
+  completedAtUtc?: string;
+  createdBy: string;
+  failureReason?: string;
+  processedRows?: number;
+  createdRows?: number;
+  updatedRows?: number;
+  skippedRows?: number;
+  resultLog?: string;
+  sendEmail: boolean;
+  emailRecipients?: string;
+}
+
+export interface QueueImportPayload {
+  scope: ImportScope;
+  format: ImportFormat;
+  conflictStrategy: ImportConflictStrategy;
+  dryRun: boolean;
+  storagePath: string;
+  fileName: string;
+  contentBase64: string;
+  sendEmail: boolean;
+  emailRecipients?: string;
+  mappingJson?: string;
+}
+
+export async function queueImportJob(payload: QueueImportPayload): Promise<ImportJob> {
+  const response = await apiClient.post('/imports', payload);
+  return response.data;
+}
+
+export async function listImportJobs(page = 1, size = 50): Promise<ImportJob[]> {
+  const response = await apiClient.get('/imports', { params: { page, size } });
+  return response.data;
+}
+
+export function buildImportLogUrl(id: string): string {
+  return `/api/imports/${id}/log`;
+}

--- a/src/web/src/api/labels.ts
+++ b/src/web/src/api/labels.ts
@@ -1,0 +1,53 @@
+import { apiClient } from './client';
+
+export interface LabelTemplate {
+  id: string;
+  name: string;
+  code: string;
+  format: string;
+  payload: string;
+  description?: string | null;
+}
+
+export interface LabelPrintJob {
+  id: string;
+  target: string;
+  format: string;
+  jobStatus: string;
+  createdAtUtc: string;
+  createdBy: string;
+}
+
+export const getLabelTemplates = async () => {
+  const { data } = await apiClient.get<LabelTemplate[]>('/labels/templates');
+  return data;
+};
+
+export const createLabelTemplate = async (payload: LabelTemplate) => {
+  const { data } = await apiClient.post<LabelTemplate>('/labels/templates', payload);
+  return data;
+};
+
+export const updateLabelTemplate = async (id: string, payload: LabelTemplate) => {
+  const { data } = await apiClient.put<LabelTemplate>(`/labels/templates/${id}`, payload);
+  return data;
+};
+
+export const deleteLabelTemplate = async (id: string) => {
+  await apiClient.delete(`/labels/templates/${id}`);
+};
+
+export const renderLabelPdf = async (id: string, data: Record<string, string>) => {
+  const response = await apiClient.post(`/labels/templates/${id}/render/pdf`, { data }, { responseType: 'blob' });
+  return response.data as Blob;
+};
+
+export const renderLabelZpl = async (id: string, data: Record<string, string>) => {
+  const { data: response } = await apiClient.post<{ zpl: string }>(`/labels/templates/${id}/render/zpl`, { data });
+  return response.zpl;
+};
+
+export const getLabelPrintJobs = async () => {
+  const { data } = await apiClient.get<LabelPrintJob[]>('/labels/print-jobs');
+  return data;
+};

--- a/src/web/src/api/maintenance.ts
+++ b/src/web/src/api/maintenance.ts
@@ -1,0 +1,113 @@
+import { apiClient } from './client';
+
+export interface BackupJob {
+  id: string;
+  scope: string;
+  fileName: string;
+  storagePath: string;
+  encryptionEnabled: boolean;
+  sendEmail: boolean;
+  integrityCheckEnabled: boolean;
+  isAutomatic: boolean;
+  status: string;
+  fileSizeBytes?: number | null;
+  completedAtUtc?: string | null;
+  integrityPassed?: boolean | null;
+  createdAtUtc: string;
+  createdBy: string;
+  failureReason?: string | null;
+}
+
+export interface QueueBackupPayload {
+  scope: string;
+  storagePath: string;
+  encryptionEnabled: boolean;
+  password?: string | null;
+  passwordConfirmation?: string | null;
+  sendEmail: boolean;
+  emailRecipients?: string | null;
+  integrityCheckEnabled: boolean;
+}
+
+export interface RestoreBackupPayload {
+  password?: string | null;
+  performIntegrityTest: boolean;
+}
+
+export interface IntegrityTestPayload {
+  password?: string | null;
+}
+
+export interface BackupSchedule {
+  enabled: boolean;
+  frequency: string;
+  dayOfWeek?: number | null;
+  dayOfMonth?: number | null;
+  executionTimeUtc: string;
+  scope: string;
+  storagePath: string;
+  encryptionEnabled: boolean;
+  hasStoredPassword: boolean;
+  sendEmail: boolean;
+  emailRecipients?: string | null;
+  integrityCheckEnabled: boolean;
+  lastRunAtUtc?: string | null;
+  nextRunAtUtc?: string | null;
+}
+
+export interface BackupScheduleUpdatePayload {
+  enabled: boolean;
+  frequency: string;
+  dayOfWeek?: number | null;
+  dayOfMonth?: number | null;
+  executionTimeUtc: string;
+  scope: string;
+  storagePath: string;
+  encryptionEnabled: boolean;
+  password?: string | null;
+  passwordConfirmation?: string | null;
+  rotatePassword: boolean;
+  sendEmail: boolean;
+  emailRecipients?: string | null;
+  integrityCheckEnabled: boolean;
+}
+
+export const listBackups = async (page = 1, size = 20) => {
+  const { data } = await apiClient.get<BackupJob[]>(`/maintenance/backups/history`, {
+    params: { page, size }
+  });
+  return data;
+};
+
+export const queueBackup = async (payload: QueueBackupPayload) => {
+  const { data } = await apiClient.post<BackupJob>('/maintenance/backups', payload);
+  return data;
+};
+
+export const getBackup = async (id: string) => {
+  const { data } = await apiClient.get<BackupJob>(`/maintenance/backups/${id}`);
+  return data;
+};
+
+export const restoreBackup = async (id: string, payload: RestoreBackupPayload) => {
+  const { data } = await apiClient.post<{ message: string }>(`/maintenance/backups/${id}/restore`, payload);
+  return data;
+};
+
+export const testBackupIntegrity = async (id: string, payload: IntegrityTestPayload) => {
+  const { data } = await apiClient.post<{ message: string; passed: boolean | null }>(
+    `/maintenance/backups/${id}/test`,
+    payload
+  );
+  return data;
+};
+
+export const fetchBackupSchedule = async () => {
+  const { data } = await apiClient.get<BackupSchedule>('/maintenance/schedule');
+  return data;
+};
+
+export const updateBackupSchedule = async (payload: BackupScheduleUpdatePayload) => {
+  const { data } = await apiClient.put<BackupSchedule>('/maintenance/schedule', payload);
+  return data;
+};

--- a/src/web/src/api/modules.ts
+++ b/src/web/src/api/modules.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './client';
+
+export interface FeatureModule {
+  id: string;
+  key: string;
+  name: string;
+  description?: string | null;
+  enabled: boolean;
+  modifiedAtUtc?: string | null;
+}
+
+export const getFeatureModules = async () => {
+  const { data } = await apiClient.get<FeatureModule[]>('/modules');
+  return data;
+};
+
+export const toggleFeatureModule = async (key: string, enabled: boolean) => {
+  const { data } = await apiClient.post<FeatureModule>(`/modules/${key}/toggle`, undefined, { params: { enabled } });
+  return data;
+};

--- a/src/web/src/api/networkDevices.ts
+++ b/src/web/src/api/networkDevices.ts
@@ -1,0 +1,61 @@
+import { apiClient } from './client';
+import { PagedResult, NetworkAssignmentRequest } from './servers';
+
+export interface NetworkDevice {
+  id: string;
+  name: string;
+  inventoryNumber: string;
+  deviceTypeId: string;
+  manufacturer: string;
+  model: string;
+  locationId: string;
+  rackPosition?: string | null;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  supportUntil?: string | null;
+  notes?: string | null;
+  status: string;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export interface NetworkDeviceRequest {
+  name: string;
+  inventoryNumber: string;
+  deviceTypeId: string;
+  manufacturer: string;
+  model: string;
+  locationId: string;
+  rackPosition?: string | null;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  supportUntil?: string | null;
+  notes?: string | null;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export const getNetworkDevices = async (page = 1, size = 25) => {
+  const { data } = await apiClient.get<PagedResult<NetworkDevice>>('/network-devices', { params: { page, size } });
+  return data;
+};
+
+export const createNetworkDevice = async (payload: NetworkDeviceRequest) => {
+  const { data } = await apiClient.post<NetworkDevice>('/network-devices', payload);
+  return data;
+};
+
+export const updateNetworkDevice = async (id: string, payload: NetworkDeviceRequest) => {
+  const { data } = await apiClient.put<NetworkDevice>(`/network-devices/${id}`, payload);
+  return data;
+};
+
+export const retireNetworkDevice = async (id: string) => {
+  await apiClient.post(`/network-devices/${id}/retire`, {});
+};
+
+export const restoreNetworkDevice = async (id: string) => {
+  await apiClient.post(`/network-devices/${id}/restore`, {});
+};
+
+export const deleteNetworkDevice = async (id: string) => {
+  await apiClient.delete(`/network-devices/${id}`);
+};

--- a/src/web/src/api/observability.ts
+++ b/src/web/src/api/observability.ts
@@ -1,0 +1,43 @@
+import { apiClient } from './client';
+
+export interface ObservabilityConfiguration {
+  logLevel: string;
+  healthEndpointEnabled: boolean;
+  metricsEndpointEnabled: boolean;
+  correlationIdsEnabled: boolean;
+  includeTraceIdentifier: boolean;
+  otelExporterEnabled: boolean;
+  otelEndpoint?: string | null;
+  hasOtelAuthToken: boolean;
+  resourceAttributes?: string | null;
+}
+
+export interface ObservabilityConfigurationUpdate {
+  logLevel: string;
+  healthEndpointEnabled: boolean;
+  metricsEndpointEnabled: boolean;
+  correlationIdsEnabled: boolean;
+  includeTraceIdentifier: boolean;
+  otelExporterEnabled: boolean;
+  otelEndpoint?: string | null;
+  otelAuthToken?: string | null;
+  rotateOtelAuthToken: boolean;
+  resourceAttributes?: string | null;
+}
+
+export const fetchObservabilityConfiguration = async () => {
+  const { data } = await apiClient.get<ObservabilityConfiguration>('/observability/config');
+  return data;
+};
+
+export const saveObservabilityConfiguration = async (payload: ObservabilityConfigurationUpdate) => {
+  const { data } = await apiClient.put<ObservabilityConfiguration>('/observability/config', payload);
+  return data;
+};
+
+export const fetchMetricsPreview = async () => {
+  const response = await apiClient.get<string>('/observability/metrics/preview', {
+    responseType: 'text'
+  });
+  return response.data;
+};

--- a/src/web/src/api/security.ts
+++ b/src/web/src/api/security.ts
@@ -1,0 +1,285 @@
+import { apiClient } from './client';
+
+export interface OidcConfiguration {
+  enabled: boolean;
+  authority: string;
+  clientId: string;
+  clientSecret?: string | null;
+  responseType?: string | null;
+  scopes: string[];
+  claimMappings: Record<string, string>;
+  usePkce: boolean;
+}
+
+export interface LdapConfiguration {
+  enabled: boolean;
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  hasPassword: boolean;
+  ignoreCertificateErrors: boolean;
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+}
+
+export interface LdapConfigurationRequest {
+  enabled: boolean;
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  password?: string | null;
+  resetPassword: boolean;
+  ignoreCertificateErrors: boolean;
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+}
+
+export interface LdapConnectionOptions {
+  host: string;
+  port: number;
+  useSsl: boolean;
+  bindDn: string;
+  password?: string | null;
+  ignoreCertificateErrors: boolean;
+}
+
+export interface LdapDryRunRequest {
+  connection: LdapConnectionOptions & { password?: string | null };
+  usersBaseDn: string;
+  usersFilter?: string | null;
+  attributeMap: string[];
+  resultLimit: number;
+}
+
+export interface LdapConnectionTestResult {
+  success: boolean;
+  message: string;
+  diagnostics?: Record<string, string> | null;
+}
+
+export interface LdapDryRunResult {
+  users: Array<{ distinguishedName: string; attributes: Record<string, string | null> }>;
+  resultCount: number;
+  truncated: boolean;
+  notes?: string | null;
+}
+
+export interface SsprConfiguration {
+  enabled: boolean;
+  requireTwoFactor: boolean;
+  requireCaptcha: boolean;
+  requireSmsOtp: boolean;
+  tokenExpiryMinutes: number;
+  throttleWindowMinutes: number;
+  maxRequestsPerWindow: number;
+  smsConnectorKey?: string | null;
+}
+
+export interface CaptchaConfiguration {
+  enabled: boolean;
+  siteKey: string;
+  hasSecret: boolean;
+  verificationEndpoint: string;
+  bypassToken?: string | null;
+}
+
+export interface CaptchaConfigurationRequest {
+  enabled: boolean;
+  siteKey: string;
+  verificationEndpoint: string;
+  secret?: string | null;
+  rotateSecret: boolean;
+  bypassToken?: string | null;
+}
+
+export interface SmsConnectorConfiguration {
+  id?: string | null;
+  alias: string;
+  enabled: boolean;
+  endpoint: string;
+  sender?: string | null;
+  region?: string | null;
+  hasSecret: boolean;
+  healthStatus?: string | null;
+  lastTestedAtUtc?: string | null;
+}
+
+export interface SmsConnectorRequest {
+  alias: string;
+  enabled: boolean;
+  endpoint: string;
+  sender?: string | null;
+  region?: string | null;
+  secret?: string | null;
+  rotateSecret: boolean;
+}
+
+export interface SecurityChangeMetadata {
+  timestampUtc: string | null;
+  actor: string | null;
+}
+
+export interface SecuritySummary {
+  oidcEnabled: boolean;
+  ldapEnabled: boolean;
+  ssprEnabled: boolean;
+  captchaEnabled: boolean;
+  smsEnabled: boolean;
+  passwordPolicyEnabled: boolean;
+  totalUsers: number;
+  twoFactorUsers: number;
+  lockedOutUsers: number;
+  oidcLastChange: SecurityChangeMetadata;
+  ldapLastChange: SecurityChangeMetadata;
+  passwordPolicyLastChange: SecurityChangeMetadata;
+  ssprLastChange: SecurityChangeMetadata;
+  criticalReady: boolean;
+}
+
+export interface LdapRoleMapping {
+  id: string;
+  groupName: string;
+  roleName: string;
+}
+
+export interface PasswordPolicyConfiguration {
+  enabled: boolean;
+  minimumLength: number;
+  requireUppercase: boolean;
+  requireLowercase: boolean;
+  requireDigit: boolean;
+  requireNonAlphanumeric: boolean;
+  expirationDays: number;
+  historyCount: number;
+  lockoutAttempts: number;
+  lockoutDurationMinutes: number;
+}
+
+export interface UserSummary {
+  id: string;
+  displayName: string;
+  email: string;
+  userName: string;
+}
+
+export interface UserSession {
+  id: string;
+  sessionIdentifier: string;
+  issuedAtUtc: string;
+  lastSeenAtUtc: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  isRevoked: boolean;
+}
+
+export const getOidcConfiguration = async () => {
+  const { data } = await apiClient.get<OidcConfiguration>('/security/oidc');
+  return data;
+};
+
+export const updateOidcConfiguration = async (payload: OidcConfiguration) => {
+  await apiClient.post('/security/oidc', payload);
+};
+
+export const getLdapConfiguration = async () => {
+  const { data } = await apiClient.get<LdapConfiguration>('/security/ldap/config');
+  return data;
+};
+
+export const updateLdapConfiguration = async (payload: LdapConfigurationRequest) => {
+  await apiClient.post('/security/ldap/config', payload);
+};
+
+export const testLdapConnection = async (options: LdapConnectionOptions & { password?: string | null }) => {
+  const { data } = await apiClient.post<LdapConnectionTestResult>('/security/ldap/test', options);
+  return data;
+};
+
+export const dryRunLdap = async (request: LdapDryRunRequest) => {
+  const { data } = await apiClient.post<LdapDryRunResult>('/security/ldap/dry-run', request);
+  return data;
+};
+
+export const getSsprConfiguration = async () => {
+  const { data } = await apiClient.get<SsprConfiguration>('/security/sspr/config');
+  return data;
+};
+
+export const getSecuritySummary = async () => {
+  const { data } = await apiClient.get<SecuritySummary>('/security/summary');
+  return data;
+};
+
+export const updateSsprConfiguration = async (payload: SsprConfiguration) => {
+  await apiClient.post('/security/sspr/config', payload);
+};
+
+export const getCaptchaConfiguration = async () => {
+  const { data } = await apiClient.get<CaptchaConfiguration>('/security/captcha/config');
+  return data;
+};
+
+export const updateCaptchaConfiguration = async (payload: CaptchaConfigurationRequest) => {
+  await apiClient.post('/security/captcha/config', payload);
+};
+
+export const getSmsConfiguration = async () => {
+  const { data } = await apiClient.get<SmsConnectorConfiguration | null>('/security/sms/config');
+  return data;
+};
+
+export const updateSmsConfiguration = async (payload: SmsConnectorRequest) => {
+  const { data } = await apiClient.post<SmsConnectorConfiguration>('/security/sms/config', payload);
+  return data;
+};
+
+export const getPasswordPolicyConfiguration = async () => {
+  const { data } = await apiClient.get<PasswordPolicyConfiguration>('/security/password-policy');
+  return data;
+};
+
+export const updatePasswordPolicyConfiguration = async (payload: PasswordPolicyConfiguration) => {
+  await apiClient.post('/security/password-policy', payload);
+};
+
+export const getLdapRoleMappings = async () => {
+  const { data } = await apiClient.get<LdapRoleMapping[]>('/security/ldap/role-mappings');
+  return data;
+};
+
+export const createLdapRoleMapping = async (payload: { groupName: string; roleName: string }) => {
+  const { data } = await apiClient.post<LdapRoleMapping>('/security/ldap/role-mappings', payload);
+  return data;
+};
+
+export const updateLdapRoleMapping = async (id: string, payload: { groupName: string; roleName: string }) => {
+  const { data } = await apiClient.put<LdapRoleMapping>(`/security/ldap/role-mappings/${id}`, payload);
+  return data;
+};
+
+export const deleteLdapRoleMapping = async (id: string) => {
+  await apiClient.delete(`/security/ldap/role-mappings/${id}`);
+};
+
+export const searchSecurityUsers = async (query: string) => {
+  const params = query.trim().length > 0 ? { params: { query } } : {};
+  const { data } = await apiClient.get<UserSummary[]>('/security/users', params);
+  return data;
+};
+
+export const getUserSessions = async (userId: string) => {
+  const { data } = await apiClient.get<UserSession[]>(`/security/users/${userId}/sessions`);
+  return data;
+};
+
+export const revokeSession = async (sessionId: string, reason?: string) => {
+  await apiClient.post(`/security/sessions/${sessionId}/revoke`, reason ? { reason } : {});
+};
+
+export const revokeAllSessions = async (userId: string) => {
+  await apiClient.post(`/security/users/${userId}/sessions/revoke-all`);
+};

--- a/src/web/src/api/servers.ts
+++ b/src/web/src/api/servers.ts
@@ -1,0 +1,81 @@
+import { apiClient } from './client';
+
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface NetworkAssignmentRequest {
+  label: string;
+  vlanId?: string | null;
+  ipAddress?: string | null;
+}
+
+export interface Server {
+  id: string;
+  name: string;
+  inventoryNumber: string;
+  manufacturer: string;
+  model: string;
+  environmentId: string;
+  wsusPriorityId: string;
+  operatingSystemId: string;
+  serverRoleId: string;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  locationId: string;
+  rackPosition?: string | null;
+  purchasedAt?: string | null;
+  supportUntil?: string | null;
+  notes?: string | null;
+  status: string;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export interface ServerRequest {
+  name: string;
+  inventoryNumber: string;
+  manufacturer: string;
+  model: string;
+  environmentId: string;
+  wsusPriorityId: string;
+  operatingSystemId: string;
+  serverRoleId: string;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  locationId: string;
+  rackPosition?: string | null;
+  purchasedAt?: string | null;
+  supportUntil?: string | null;
+  notes?: string | null;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export const getServers = async (page = 1, size = 25) => {
+  const { data } = await apiClient.get<PagedResult<Server>>('/servers', { params: { page, size } });
+  return data;
+};
+
+export const createServer = async (payload: ServerRequest) => {
+  const { data } = await apiClient.post<Server>('/servers', payload);
+  return data;
+};
+
+export const updateServer = async (id: string, payload: ServerRequest) => {
+  const { data } = await apiClient.put<Server>(`/servers/${id}`, payload);
+  return data;
+};
+
+export const retireServer = async (id: string) => {
+  await apiClient.post(`/servers/${id}/retire`, {});
+};
+
+export const restoreServer = async (id: string) => {
+  await apiClient.post(`/servers/${id}/restore`, {});
+};
+
+export const deleteServer = async (id: string) => {
+  await apiClient.delete(`/servers/${id}`);
+};

--- a/src/web/src/api/updates.ts
+++ b/src/web/src/api/updates.ts
@@ -1,0 +1,64 @@
+import { apiClient } from './client';
+
+export interface UpdatePackageResponse {
+  id: string;
+  version: string;
+  fileName: string;
+  status: string;
+  sha256: string;
+  preserveDatabaseConfiguration: boolean;
+  createBackupBeforeInstall: boolean;
+  performIntegrityCheck: boolean;
+  confirmedBackupAvailable: boolean;
+  notes?: string;
+  createdAtUtc: string;
+  completedAtUtc?: string;
+  createdBy: string;
+  failureReason?: string;
+  manifestJson?: string;
+  logPath?: string;
+}
+
+export interface UploadUpdatePayload {
+  file: File;
+  version?: string;
+  preserveDatabaseConfiguration: boolean;
+  createBackupBeforeInstall: boolean;
+  backupStoragePath?: string;
+  performIntegrityCheck: boolean;
+  confirmedBackupAvailable: boolean;
+  notes?: string;
+}
+
+export async function listUpdateHistory(page = 1, size = 20) {
+  const response = await apiClient.get<UpdatePackageResponse[]>(`/api/updates/history?page=${page}&size=${size}`);
+  return response.data;
+}
+
+export async function uploadUpdatePackage(payload: UploadUpdatePayload) {
+  const form = new FormData();
+  form.append('Package', payload.file);
+  if (payload.version) {
+    form.append('Version', payload.version);
+  }
+  form.append('PreserveDatabaseConfiguration', String(payload.preserveDatabaseConfiguration));
+  form.append('CreateBackupBeforeInstall', String(payload.createBackupBeforeInstall));
+  form.append('PerformIntegrityCheck', String(payload.performIntegrityCheck));
+  form.append('ConfirmedBackupAvailable', String(payload.confirmedBackupAvailable));
+  if (payload.backupStoragePath) {
+    form.append('BackupStoragePath', payload.backupStoragePath);
+  }
+  if (payload.notes) {
+    form.append('Notes', payload.notes);
+  }
+
+  const response = await apiClient.post<UpdatePackageResponse>('/api/updates', form, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return response.data;
+}
+
+export async function downloadUpdateLog(id: string) {
+  const response = await apiClient.get(`/api/updates/${id}/log`, { responseType: 'blob' });
+  return response.data;
+}

--- a/src/web/src/api/workstations.ts
+++ b/src/web/src/api/workstations.ts
@@ -1,0 +1,91 @@
+import { apiClient } from './client';
+import { NetworkAssignmentRequest, PagedResult } from './servers';
+
+export interface Workstation {
+  id: string;
+  name: string;
+  inventoryNumber: string;
+  operatingSystemId: string;
+  workstationTypeId: string;
+  ownerId?: string | null;
+  ownerDisplayName?: string | null;
+  ownerDepartment?: string | null;
+  locationId: string;
+  locationNote?: string | null;
+  cpu: string;
+  ram: string;
+  storage: string;
+  macAddress: string;
+  purchasedAt?: string | null;
+  supportUntil?: string | null;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  notes?: string | null;
+  status: string;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export interface WorkstationRequest {
+  name: string;
+  inventoryNumber: string;
+  operatingSystemId: string;
+  workstationTypeId: string;
+  ownerId?: string | null;
+  ownerDisplayName?: string | null;
+  ownerDepartment?: string | null;
+  locationId: string;
+  locationNote?: string | null;
+  cpu: string;
+  ram: string;
+  storage: string;
+  macAddress: string;
+  purchasedAt?: string | null;
+  supportUntil?: string | null;
+  primaryAdministratorId?: string | null;
+  secondaryAdministratorId?: string | null;
+  notes?: string | null;
+  networkAssignments: NetworkAssignmentRequest[];
+}
+
+export const getWorkstations = async (page = 1, size = 25) => {
+  const { data } = await apiClient.get<PagedResult<Workstation>>('/workstations', { params: { page, size } });
+  return data;
+};
+
+export const createWorkstation = async (payload: WorkstationRequest) => {
+  const { data } = await apiClient.post<Workstation>('/workstations', payload);
+  return data;
+};
+
+export const updateWorkstation = async (id: string, payload: WorkstationRequest) => {
+  const { data } = await apiClient.put<Workstation>(`/workstations/${id}`, payload);
+  return data;
+};
+
+export const retireWorkstation = async (id: string) => {
+  await apiClient.post(`/workstations/${id}/retire`, {});
+};
+
+export const restoreWorkstation = async (id: string) => {
+  await apiClient.post(`/workstations/${id}/restore`, {});
+};
+
+export const deleteWorkstation = async (id: string) => {
+  await apiClient.delete(`/workstations/${id}`);
+};
+
+export const handoverWorkstation = async (
+  id: string,
+  payload: {
+    newOwnerId?: string | null;
+    newOwnerEmail: string;
+    oldLocation: string;
+    newLocation: string;
+    to?: string[];
+    cc?: string[];
+    bcc?: string[];
+    notes?: string | null;
+  }
+) => {
+  await apiClient.post(`/workstations/${id}/handover`, payload);
+};

--- a/src/web/src/hooks/useTheme.ts
+++ b/src/web/src/hooks/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../theme/ThemeProvider';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+};

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </ThemeProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/web/src/pages/AuditPage.tsx
+++ b/src/web/src/pages/AuditPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { AuditLogEntry, getAuditLogs } from '../api/audit';
+
+export const AuditPage = () => {
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [entityFilter, setEntityFilter] = useState('');
+
+  const loadLogs = async () => {
+    try {
+      setLoading(true);
+      const items = await getAuditLogs(entityFilter || undefined);
+      setLogs(items);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadLogs();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Auditní log</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Nejnovější změny v systému včetně diffů a identity uživatele.
+          </p>
+        </div>
+        <div className="flex items-end gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Filtr podle entity</span>
+            <input
+              value={entityFilter}
+              onChange={(event) => setEntityFilter(event.target.value)}
+              placeholder="Servers / Workstations / Settings…"
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <button
+            onClick={() => void loadLogs()}
+            className="rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+          >
+            Načíst
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="overflow-x-auto rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Čas</th>
+              <th className="px-4 py-3">Uživatel</th>
+              <th className="px-4 py-3">Role</th>
+              <th className="px-4 py-3">Entita</th>
+              <th className="px-4 py-3">Akce</th>
+              <th className="px-4 py-3">Detaily</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {logs.map((log) => (
+              <tr key={log.id} className="align-top hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">
+                  {new Date(log.performedAtUtc).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{log.performedBy}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{log.roles ?? '—'}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{log.entityType}</td>
+                <td className="px-4 py-3">
+                  <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                    {log.action}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">
+                  <pre className="whitespace-pre-wrap break-words text-xs leading-relaxed">
+                    {log.changedFieldsJson ?? log.changeSummary ?? '—'}
+                  </pre>
+                </td>
+              </tr>
+            ))}
+            {!loading && logs.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Zatím nejsou dostupné žádné auditní záznamy.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/web/src/pages/BackupRestorePage.tsx
+++ b/src/web/src/pages/BackupRestorePage.tsx
@@ -1,0 +1,557 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  BackupJob,
+  BackupSchedule,
+  BackupScheduleUpdatePayload,
+  IntegrityTestPayload,
+  QueueBackupPayload,
+  RestoreBackupPayload,
+  fetchBackupSchedule,
+  listBackups,
+  queueBackup,
+  restoreBackup,
+  testBackupIntegrity,
+  updateBackupSchedule
+} from '../api/maintenance';
+
+const scopes = [
+  { value: 'Full', label: 'Celá databáze' },
+  { value: 'Servers', label: 'Servery' },
+  { value: 'NetworkDevices', label: 'Síťová zařízení' },
+  { value: 'Workstations', label: 'Pracovní stanice' },
+  { value: 'Dictionaries', label: 'Číselníky' }
+];
+
+const frequencies = [
+  { value: 'Daily', label: 'Denně' },
+  { value: 'Weekly', label: 'Týdně' },
+  { value: 'Monthly', label: 'Měsíčně' }
+];
+
+const weekDays = [
+  { value: 1, label: 'Pondělí' },
+  { value: 2, label: 'Úterý' },
+  { value: 3, label: 'Středa' },
+  { value: 4, label: 'Čtvrtek' },
+  { value: 5, label: 'Pátek' },
+  { value: 6, label: 'Sobota' },
+  { value: 0, label: 'Neděle' }
+];
+
+const defaultQueuePayload: QueueBackupPayload = {
+  scope: 'Full',
+  storagePath: '',
+  encryptionEnabled: false,
+  password: '',
+  passwordConfirmation: '',
+  sendEmail: false,
+  emailRecipients: '',
+  integrityCheckEnabled: true
+};
+
+const buildSchedulePayload = (schedule: BackupSchedule | null): BackupScheduleUpdatePayload => ({
+  enabled: schedule?.enabled ?? false,
+  frequency: schedule?.frequency ?? 'Daily',
+  dayOfWeek: schedule?.dayOfWeek ?? null,
+  dayOfMonth: schedule?.dayOfMonth ?? null,
+  executionTimeUtc: schedule?.executionTimeUtc ?? '01:00',
+  scope: schedule?.scope ?? 'Full',
+  storagePath: schedule?.storagePath ?? '',
+  encryptionEnabled: schedule?.encryptionEnabled ?? false,
+  password: '',
+  passwordConfirmation: '',
+  rotatePassword: false,
+  sendEmail: schedule?.sendEmail ?? false,
+  emailRecipients: schedule?.emailRecipients ?? '',
+  integrityCheckEnabled: schedule?.integrityCheckEnabled ?? true
+});
+
+export const BackupRestorePage = () => {
+  const [history, setHistory] = useState<BackupJob[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [queueForm, setQueueForm] = useState<QueueBackupPayload>(defaultQueuePayload);
+  const [schedule, setSchedule] = useState<BackupSchedule | null>(null);
+  const [scheduleForm, setScheduleForm] = useState<BackupScheduleUpdatePayload>(buildSchedulePayload(null));
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const dayOptions = useMemo(() => Array.from({ length: 31 }, (_, i) => i + 1), []);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        const [historyData, scheduleData] = await Promise.all([listBackups(1, 50), fetchBackupSchedule()]);
+        setHistory(historyData);
+        setSchedule(scheduleData);
+        setScheduleForm(buildSchedulePayload(scheduleData));
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const refreshHistory = async () => {
+    const data = await listBackups(1, 50);
+    setHistory(data);
+  };
+
+  const handleQueueBackup = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setFeedback(null);
+
+    try {
+      const payload: QueueBackupPayload = {
+        ...queueForm,
+        password: queueForm.encryptionEnabled ? queueForm.password : undefined,
+        passwordConfirmation: queueForm.encryptionEnabled ? queueForm.passwordConfirmation : undefined,
+        emailRecipients: queueForm.sendEmail ? queueForm.emailRecipients : undefined
+      };
+
+      await queueBackup(payload);
+      setFeedback('Záloha byla zařazena do fronty.');
+      await refreshHistory();
+      setQueueForm({ ...defaultQueuePayload, storagePath: queueForm.storagePath });
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRestore = async (job: BackupJob) => {
+    const password = job.encryptionEnabled ? window.prompt('Zadejte heslo pro obnovení (pokud je potřeba):', '') ?? undefined : undefined;
+    const confirmIntegrity = window.confirm('Chcete po obnovení provést kontrolu integrity?');
+
+    const payload: RestoreBackupPayload = {
+      password: password || undefined,
+      performIntegrityTest: confirmIntegrity
+    };
+
+    try {
+      const response = await restoreBackup(job.id, payload);
+      setFeedback(response.message);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleTestIntegrity = async (job: BackupJob) => {
+    const password = job.encryptionEnabled ? window.prompt('Zadejte heslo pro ověření:', '') ?? undefined : undefined;
+    const payload: IntegrityTestPayload = { password: password || undefined };
+
+    try {
+      const response = await testBackupIntegrity(job.id, payload);
+      setFeedback(response.message + (response.passed === false ? ' (Test neprošel)' : ''));
+      await refreshHistory();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleScheduleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setFeedback(null);
+
+    try {
+      const payload: BackupScheduleUpdatePayload = {
+        ...scheduleForm,
+        password: scheduleForm.encryptionEnabled ? scheduleForm.password : undefined,
+        passwordConfirmation: scheduleForm.encryptionEnabled ? scheduleForm.passwordConfirmation : undefined,
+        emailRecipients: scheduleForm.sendEmail ? scheduleForm.emailRecipients : undefined
+      };
+
+      const updated = await updateBackupSchedule(payload);
+      setSchedule(updated);
+      setScheduleForm(buildSchedulePayload(updated));
+      setFeedback('Plán záloh byl uložen.');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Zálohování a obnova</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Spouštění ručních záloh, správa historie a konfigurace automatického plánu záloh.
+        </p>
+      </header>
+
+      {error && <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</div>}
+      {feedback && <div className="rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">{feedback}</div>}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Ruční záloha</h3>
+        <form className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={handleQueueBackup}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Rozsah
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={queueForm.scope}
+              onChange={(event) => setQueueForm((prev) => ({ ...prev, scope: event.target.value }))}
+            >
+              {scopes.map((scope) => (
+                <option key={scope.value} value={scope.value}>
+                  {scope.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Cesta k úložišti
+            <input
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={queueForm.storagePath}
+              onChange={(event) => setQueueForm((prev) => ({ ...prev, storagePath: event.target.value }))}
+              placeholder="např. C:\\Backups"
+              required
+            />
+          </label>
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="queue-encryption"
+              type="checkbox"
+              checked={queueForm.encryptionEnabled}
+              onChange={(event) => setQueueForm((prev) => ({ ...prev, encryptionEnabled: event.target.checked }))}
+            />
+            <label htmlFor="queue-encryption">Zapnout šifrování (AES-256)</label>
+          </div>
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="queue-email"
+              type="checkbox"
+              checked={queueForm.sendEmail}
+              onChange={(event) => setQueueForm((prev) => ({ ...prev, sendEmail: event.target.checked }))}
+            />
+            <label htmlFor="queue-email">Odeslat e-mail s výsledkem</label>
+          </div>
+
+          {queueForm.encryptionEnabled && (
+            <>
+              <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+                Heslo
+                <input
+                  type="password"
+                  className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                  value={queueForm.password ?? ''}
+                  onChange={(event) => setQueueForm((prev) => ({ ...prev, password: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+                Potvrzení hesla
+                <input
+                  type="password"
+                  className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                  value={queueForm.passwordConfirmation ?? ''}
+                  onChange={(event) => setQueueForm((prev) => ({ ...prev, passwordConfirmation: event.target.value }))}
+                  required
+                />
+              </label>
+            </>
+          )}
+
+          {queueForm.sendEmail && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+              Příjemci e-mailu (oddělit středníkem)
+              <input
+                className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={queueForm.emailRecipients ?? ''}
+                onChange={(event) => setQueueForm((prev) => ({ ...prev, emailRecipients: event.target.value }))}
+              />
+            </label>
+          )}
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="queue-integrity"
+              type="checkbox"
+              checked={queueForm.integrityCheckEnabled}
+              onChange={(event) => setQueueForm((prev) => ({ ...prev, integrityCheckEnabled: event.target.checked }))}
+            />
+            <label htmlFor="queue-integrity">Otestovat integritu po dokončení</label>
+          </div>
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+              disabled={loading}
+            >
+              Spustit zálohu
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Historie záloh</h3>
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+            <thead className="bg-slate-100 dark:bg-slate-800">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Název</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Rozsah</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Stav</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Dokončeno</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Velikost</th>
+                <th className="px-3 py-2 text-left font-medium text-slate-600 dark:text-slate-300">Akce</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              {history.map((job) => (
+                <tr key={job.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/60">
+                  <td className="px-3 py-2 font-medium text-slate-800 dark:text-slate-100">{job.fileName}</td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{job.scope}</td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-300">
+                    {job.status}
+                    {job.failureReason && <span className="block text-xs text-red-500">{job.failureReason}</span>}
+                  </td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-300">
+                    {job.completedAtUtc ? new Date(job.completedAtUtc).toLocaleString() : 'Probíhá'}
+                  </td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-300">
+                    {job.fileSizeBytes ? `${(job.fileSizeBytes / 1024 / 1024).toFixed(1)} MB` : '—'}
+                  </td>
+                  <td className="px-3 py-2 space-x-2 whitespace-nowrap">
+                    <button
+                      type="button"
+                      className="rounded border border-blue-200 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-200 dark:hover:bg-blue-900/40"
+                      onClick={() => handleRestore(job)}
+                    >
+                      Obnovit
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-500 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => handleTestIntegrity(job)}
+                    >
+                      Test integrity
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Plán automatických záloh</h3>
+        <form className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={handleScheduleSubmit}>
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="schedule-enabled"
+              type="checkbox"
+              checked={scheduleForm.enabled}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, enabled: event.target.checked }))}
+            />
+            <label htmlFor="schedule-enabled">Automatické zálohy povoleny</label>
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Frekvence
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={scheduleForm.frequency}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, frequency: event.target.value }))}
+            >
+              {frequencies.map((frequency) => (
+                <option key={frequency.value} value={frequency.value}>
+                  {frequency.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {scheduleForm.frequency === 'Weekly' && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+              Den v týdnu
+              <select
+                className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={scheduleForm.dayOfWeek ?? ''}
+                onChange={(event) =>
+                  setScheduleForm((prev) => ({ ...prev, dayOfWeek: event.target.value === '' ? null : Number(event.target.value) }))
+                }
+              >
+                <option value="">--</option>
+                {weekDays.map((day) => (
+                  <option key={day.value} value={day.value}>
+                    {day.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {scheduleForm.frequency === 'Monthly' && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+              Den v měsíci
+              <select
+                className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={scheduleForm.dayOfMonth ?? ''}
+                onChange={(event) =>
+                  setScheduleForm((prev) => ({ ...prev, dayOfMonth: event.target.value === '' ? null : Number(event.target.value) }))
+                }
+              >
+                <option value="">--</option>
+                {dayOptions.map((day) => (
+                  <option key={day} value={day}>
+                    {day}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Čas spuštění (UTC)
+            <input
+              type="time"
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={scheduleForm.executionTimeUtc}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, executionTimeUtc: event.target.value }))}
+              required
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Rozsah
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={scheduleForm.scope}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, scope: event.target.value }))}
+            >
+              {scopes.map((scope) => (
+                <option key={scope.value} value={scope.value}>
+                  {scope.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Cesta k úložišti
+            <input
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={scheduleForm.storagePath}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, storagePath: event.target.value }))}
+              required
+            />
+          </label>
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="schedule-encryption"
+              type="checkbox"
+              checked={scheduleForm.encryptionEnabled}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, encryptionEnabled: event.target.checked }))}
+            />
+            <label htmlFor="schedule-encryption">Šifrovat zálohy</label>
+          </div>
+
+          {scheduleForm.encryptionEnabled && (
+            <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <input
+                id="schedule-rotate"
+                type="checkbox"
+                checked={scheduleForm.rotatePassword}
+                onChange={(event) => setScheduleForm((prev) => ({ ...prev, rotatePassword: event.target.checked }))}
+              />
+              <label htmlFor="schedule-rotate">Zadat nové heslo / resetovat uložené heslo</label>
+            </div>
+          )}
+
+          {scheduleForm.encryptionEnabled && scheduleForm.rotatePassword && (
+            <>
+              <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+                Heslo
+                <input
+                  type="password"
+                  className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                  value={scheduleForm.password ?? ''}
+                  onChange={(event) => setScheduleForm((prev) => ({ ...prev, password: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+                Potvrzení hesla
+                <input
+                  type="password"
+                  className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                  value={scheduleForm.passwordConfirmation ?? ''}
+                  onChange={(event) => setScheduleForm((prev) => ({ ...prev, passwordConfirmation: event.target.value }))}
+                  required
+                />
+              </label>
+            </>
+          )}
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="schedule-email"
+              type="checkbox"
+              checked={scheduleForm.sendEmail}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, sendEmail: event.target.checked }))}
+            />
+            <label htmlFor="schedule-email">Odeslat e-mail po dokončení</label>
+          </div>
+
+          {scheduleForm.sendEmail && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+              Příjemci e-mailu
+              <input
+                className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={scheduleForm.emailRecipients ?? ''}
+                onChange={(event) => setScheduleForm((prev) => ({ ...prev, emailRecipients: event.target.value }))}
+              />
+            </label>
+          )}
+
+          <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              id="schedule-integrity"
+              type="checkbox"
+              checked={scheduleForm.integrityCheckEnabled}
+              onChange={(event) => setScheduleForm((prev) => ({ ...prev, integrityCheckEnabled: event.target.checked }))}
+            />
+            <label htmlFor="schedule-integrity">Po záloze provést kontrolu integrity</label>
+          </div>
+
+          {schedule && (
+            <div className="md:col-span-2 text-sm text-slate-600 dark:text-slate-300">
+              <p>
+                Poslední běh: {schedule.lastRunAtUtc ? new Date(schedule.lastRunAtUtc).toLocaleString() : '—'}
+              </p>
+              <p>
+                Další běh: {schedule.nextRunAtUtc ? new Date(schedule.nextRunAtUtc).toLocaleString() : '—'}
+              </p>
+              {schedule.encryptionEnabled && schedule.hasStoredPassword && !scheduleForm.rotatePassword && (
+                <p className="text-xs text-slate-500 dark:text-slate-400">Heslo je uloženo (skryté). Zaškrtněte "resetovat", pokud chcete zadat nové.</p>
+              )}
+            </div>
+          )}
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-700"
+              disabled={loading}
+            >
+              Uložit plán
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/ConnectorsPage.tsx
+++ b/src/web/src/pages/ConnectorsPage.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ConnectorSummary,
+  ConnectorTestRequest,
+  ConnectorTestResponse,
+  fetchConnectors,
+  rotateConnectorSecret,
+  testConnector,
+  toggleConnector
+} from '../api/connectors';
+
+const statusColor = (status?: string | null) => {
+  if (!status) {
+    return 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200';
+  }
+
+  const lowered = status.toLowerCase();
+  if (lowered.includes('healthy')) {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-200';
+  }
+
+  if (lowered.includes('fail') || lowered.includes('down')) {
+    return 'bg-rose-100 text-rose-700 dark:bg-rose-900/50 dark:text-rose-200';
+  }
+
+  if (lowered.includes('degraded') || lowered.includes('warning')) {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200';
+  }
+
+  return 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200';
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) {
+    return '—';
+  }
+
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+};
+
+const canUse = (connector: ConnectorSummary, capability: 'toggle' | 'test' | 'rotate') => {
+  if (!connector.id) {
+    return false;
+  }
+
+  switch (capability) {
+    case 'toggle':
+      return connector.supportsToggle;
+    case 'test':
+      return connector.supportsTest;
+    case 'rotate':
+      return connector.supportsRotateSecret && connector.hasSecret;
+    default:
+      return false;
+  }
+};
+
+const runWithToast = async (
+  action: () => Promise<ConnectorSummary | ConnectorTestResponse>,
+  onSuccess: (result: ConnectorSummary | ConnectorTestResponse) => void,
+  setMessage: (message: string | null) => void
+) => {
+  try {
+    const result = await action();
+    onSuccess(result);
+  } catch (error) {
+    setMessage((error as Error).message);
+  }
+};
+
+export const ConnectorsPage = () => {
+  const [connectors, setConnectors] = useState<ConnectorSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchConnectors();
+      setConnectors(data);
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const updateConnector = (updated?: ConnectorSummary) => {
+    if (!updated || !updated.id) {
+      return load();
+    }
+
+    setConnectors((current) =>
+      current.map((connector) => (connector.id === updated.id ? { ...connector, ...updated } : connector))
+    );
+  };
+
+  const handleToggle = async (connector: ConnectorSummary) => {
+    if (!connector.id) {
+      return;
+    }
+
+    await runWithToast(
+      () => toggleConnector(connector.id!, !connector.enabled),
+      (result) => {
+        setMessage(`Konektor ${result.name} byl ${result.enabled ? 'aktivován' : 'deaktivován'}.`);
+        updateConnector(result as ConnectorSummary);
+      },
+      setMessage
+    );
+  };
+
+  const handleRotate = async (connector: ConnectorSummary) => {
+    if (!connector.id) {
+      return;
+    }
+
+    const confirmed = window.confirm('Opravdu chcete otočit/odstranit tajemství a vyžadovat jeho nové zadání?');
+    if (!confirmed) {
+      return;
+    }
+
+    await runWithToast(
+      () => rotateConnectorSecret(connector.id!),
+      (result) => {
+        setMessage(`Tajný klíč pro konektor ${result.name} byl vymazán. Nakonfigurujte nový.`);
+        updateConnector(result as ConnectorSummary);
+      },
+      setMessage
+    );
+  };
+
+  const handleTest = async (connector: ConnectorSummary) => {
+    if (!connector.id) {
+      return;
+    }
+
+    const payload: ConnectorTestRequest = {};
+    if (connector.type.toUpperCase() === 'SMTP') {
+      const target = window.prompt('Zadejte cílovou e-mailovou adresu pro testovací zprávu:');
+      if (!target) {
+        return;
+      }
+      payload.target = target;
+    } else if (connector.type.toUpperCase() === 'SMS') {
+      const target = window.prompt('Zadejte cílové telefonní číslo pro testovací SMS:');
+      if (!target) {
+        return;
+      }
+      payload.target = target;
+    }
+
+    await runWithToast(
+      () => testConnector(connector.id!, payload),
+      (result) => {
+        const response = result as ConnectorTestResponse;
+        setMessage(response.message);
+        if (response.connector) {
+          updateConnector(response.connector);
+        } else {
+          void load();
+        }
+      },
+      setMessage
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Konektory</h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Přehled všech integračních konektorů. Každý záznam zobrazuje aktuální stav, poslední test a možnosti správy.
+        </p>
+        {message && (
+          <div className="mt-3 rounded border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+            {message}
+          </div>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="rounded border border-dashed border-slate-300 p-12 text-center text-slate-500 dark:border-slate-700 dark:text-slate-400">
+          Načítání konektorů…
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-slate-200 shadow-sm dark:border-slate-800">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50 dark:bg-slate-900/50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Alias</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Typ</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Stav</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Poslední test</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Popis</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Akce</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-950">
+              {connectors.map((connector) => (
+                <tr key={connector.key}>
+                  <td className="px-4 py-4 align-top">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">{connector.name}</div>
+                    <div className="text-xs text-slate-500 dark:text-slate-400">{connector.key}</div>
+                    {connector.requiresConfiguration && (
+                      <span className="mt-2 inline-flex rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-200">
+                        Vyžaduje konfiguraci
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-4 align-top text-sm text-slate-600 dark:text-slate-300">{connector.type}</td>
+                  <td className="px-4 py-4 align-top">
+                    <span className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${statusColor(connector.healthStatus)}`}>
+                      {connector.healthStatus ?? (connector.enabled ? 'Bez testu' : 'Deaktivováno')}
+                    </span>
+                  </td>
+                  <td className="px-4 py-4 align-top text-sm text-slate-600 dark:text-slate-300">{formatDate(connector.lastTestedAtUtc)}</td>
+                  <td className="px-4 py-4 align-top text-sm text-slate-600 dark:text-slate-300">
+                    {connector.description || '—'}
+                  </td>
+                  <td className="px-4 py-4 align-top">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleToggle(connector)}
+                        disabled={!canUse(connector, 'toggle')}
+                        className="rounded border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                      >
+                        {connector.enabled ? 'Vypnout' : 'Zapnout'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleTest(connector)}
+                        disabled={!canUse(connector, 'test')}
+                        className="rounded border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                      >
+                        Test
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRotate(connector)}
+                        disabled={!canUse(connector, 'rotate')}
+                        className="rounded border border-rose-200 px-3 py-1 text-xs font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-800 dark:text-rose-200 dark:hover:bg-rose-900/40"
+                      >
+                        Otočit tajemství
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/web/src/pages/DashboardPage.tsx
+++ b/src/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,29 @@
+export const DashboardPage = () => {
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Quick stats</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Connect the dashboard to /api/dashboard/summary to surface real-time insights across servers, network devices and workstations.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          {['Servers', 'Network devices', 'Workstations'].map((label) => (
+            <div key={label} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <p className="text-sm text-slate-500 dark:text-slate-400">{label}</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">0</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Getting started checklist</h3>
+        <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+          <li>1. Configure SQL Server connection and run the onboarding wizard.</li>
+          <li>2. Enable authentication providers and test 2FA enrollment.</li>
+          <li>3. Sync baseline dictionaries and import inventory data.</li>
+          <li>4. Review scheduled jobs, backup policies, and alerting connectors.</li>
+        </ul>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/DictionariesPage.tsx
+++ b/src/web/src/pages/DictionariesPage.tsx
@@ -1,0 +1,241 @@
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  DictionaryEntry,
+  DictionaryEntryRequest,
+  createDictionaryEntry,
+  deleteDictionaryEntry,
+  getDictionaryEntries,
+  updateDictionaryEntry
+} from '../api/dictionaries';
+
+const supportedTypes = [
+  'Environment',
+  'WsusPriority',
+  'OperatingSystem',
+  'ServerRole',
+  'DeviceType',
+  'Location',
+  'WorkstationType',
+  'Vlan'
+];
+
+const createEmptyForm = (dictType: string): DictionaryEntryRequest => ({
+  dictType,
+  key: '',
+  value: '',
+  description: '',
+  order: 0
+});
+
+export const DictionariesPage = () => {
+  const [selectedType, setSelectedType] = useState(supportedTypes[0]);
+  const [entries, setEntries] = useState<DictionaryEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState(createEmptyForm(selectedType));
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const loadEntries = async (type: string) => {
+    try {
+      setLoading(true);
+      const items = await getDictionaryEntries(type);
+      setEntries(items);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadEntries(selectedType);
+    setForm(createEmptyForm(selectedType));
+    setEditingId(null);
+  }, [selectedType]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      if (editingId) {
+        await updateDictionaryEntry(editingId, form);
+      } else {
+        await createDictionaryEntry(form);
+      }
+      setForm(createEmptyForm(selectedType));
+      setEditingId(null);
+      await loadEntries(selectedType);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleEdit = (entry: DictionaryEntry) => {
+    setEditingId(entry.id);
+    setForm({
+      dictType: entry.dictType,
+      key: entry.key,
+      value: entry.value,
+      description: entry.description ?? '',
+      order: entry.order
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Opravdu chcete záznam smazat?')) {
+      return;
+    }
+    try {
+      await deleteDictionaryEntry(id);
+      await loadEntries(selectedType);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Číselníky</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Správa referenčních dat používaných v celém systému.
+          </p>
+        </div>
+        <select
+          value={selectedType}
+          onChange={(event) => setSelectedType(event.target.value)}
+          className="rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+        >
+          {supportedTypes.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="overflow-x-auto rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Pořadí</th>
+              <th className="px-4 py-3">Klíč</th>
+              <th className="px-4 py-3">Hodnota</th>
+              <th className="px-4 py-3">Popis</th>
+              <th className="px-4 py-3 text-right">Akce</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {entries.map((entry) => (
+              <tr key={entry.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{entry.order}</td>
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{entry.key}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{entry.value}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{entry.description ?? '—'}</td>
+                <td className="flex items-center justify-end gap-2 px-4 py-3">
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleEdit(entry)}
+                  >
+                    Upravit
+                  </button>
+                  <button
+                    className="rounded border border-red-300 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/40"
+                    onClick={() => handleDelete(entry.id)}
+                  >
+                    Smazat
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!loading && entries.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Pro tento typ nejsou k dispozici žádné položky.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {editingId ? 'Upravit položku' : 'Nová položka'} ({selectedType})
+          </h3>
+          {editingId && (
+            <button type="button" onClick={() => { setEditingId(null); setForm(createEmptyForm(selectedType)); }} className="text-sm text-slate-500 underline">
+              Zrušit úpravy
+            </button>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Klíč</span>
+            <input
+              required
+              value={form.key}
+              onChange={(event) => setForm((state) => ({ ...state, key: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Hodnota</span>
+            <input
+              required
+              value={form.value}
+              onChange={(event) => setForm((state) => ({ ...state, value: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm md:col-span-2">
+            <span>Popis</span>
+            <textarea
+              value={form.description ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, description: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+              rows={3}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Pořadí</span>
+            <input
+              type="number"
+              value={form.order}
+              onChange={(event) => setForm((state) => ({ ...state, order: Number(event.target.value) }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => { setEditingId(null); setForm(createEmptyForm(selectedType)); }}
+            className="rounded border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Zrušit
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-teal-500"
+          >
+            {editingId ? 'Uložit změny' : 'Přidat položku'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/web/src/pages/EmailSettingsPage.tsx
+++ b/src/web/src/pages/EmailSettingsPage.tsx
@@ -1,0 +1,347 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  EmailSettings,
+  EmailSettingsUpdate,
+  EmailTestRequest,
+  fetchEmailSettings,
+  saveEmailSettings,
+  sendEmailTest
+} from '../api/email';
+
+type EmailSettingsPageProps = {
+  variant?: 'default' | 'wizard';
+};
+
+const defaultUpdate: EmailSettingsUpdate = {
+  alias: 'Primary SMTP',
+  enabled: true,
+  host: '',
+  port: 587,
+  useTls: true,
+  username: '',
+  fromAddress: '',
+  replyToAddress: '',
+  rotateSecret: false,
+  password: ''
+};
+
+export const EmailSettingsPage = ({ variant = 'default' }: EmailSettingsPageProps) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<EmailSettingsUpdate>(defaultUpdate);
+  const [current, setCurrent] = useState<EmailSettings | null>(null);
+  const [testRequest, setTestRequest] = useState<EmailTestRequest>({
+    recipient: '',
+    subject: 'HW Inventory – SMTP test',
+    body: 'Toto je testovací e-mail odeslaný z administrace HW Inventory.'
+  });
+  const [testResult, setTestResult] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    fetchEmailSettings()
+      .then((settings) => {
+        if (!isMounted) {
+          return;
+        }
+        setCurrent(settings);
+        if (settings) {
+          setState({
+            alias: settings.alias ?? 'Primary SMTP',
+            enabled: settings.enabled,
+            host: settings.host ?? '',
+            port: settings.port ?? 587,
+            useTls: settings.useTls ?? true,
+            username: settings.username ?? '',
+            fromAddress: settings.fromAddress ?? '',
+            replyToAddress: settings.replyToAddress ?? '',
+            rotateSecret: false,
+            password: ''
+          });
+        }
+      })
+      .catch((err: Error) => {
+        if (!isMounted) {
+          return;
+        }
+        setError(err.message);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const payload: EmailSettingsUpdate = {
+        ...state,
+        port: Number(state.port) || 25,
+        rotateSecret: state.rotateSecret || Boolean(state.password)
+      };
+      const result = await saveEmailSettings(payload);
+      setCurrent(result);
+      setState((previous) => ({
+        ...previous,
+        rotateSecret: false,
+        password: ''
+      }));
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    setError(null);
+    try {
+      const result = await sendEmailTest(testRequest);
+      setTestResult(result.message);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const maskMessage = useMemo(() => {
+    if (!current?.hasPassword) {
+      return 'Heslo není nastaveno.';
+    }
+    if (state.rotateSecret || state.password) {
+      return 'Zadáte nové heslo – bude uloženo po uložení formuláře.';
+    }
+    return 'Heslo je nastaveno. Chcete-li jej změnit, zadejte nové nebo zvolte "Vymazat".';
+  }, [current?.hasPassword, state.rotateSecret, state.password]);
+
+  if (loading) {
+    return <div className="text-sm text-slate-600 dark:text-slate-300">Načítám nastavení SMTP…</div>;
+  }
+
+  return (
+    <div className="space-y-8">
+      {variant === 'default' && (
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">E-mail (SMTP)</h1>
+          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-300">
+            Nakonfigurujte připojení k SMTP serveru pro odesílání notifikací, předávacích protokolů a systémových hlášení.
+            Zadané hodnoty se ukládají okamžitě po uložení formuláře a změny se zaznamenávají do auditu.
+          </p>
+        </header>
+      )}
+
+      {error && (
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Připojení</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              Alias
+              <input
+                type="text"
+                value={state.alias}
+                onChange={(event) => setState((previous) => ({ ...previous, alias: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Host
+              <input
+                type="text"
+                required
+                value={state.host}
+                onChange={(event) => setState((previous) => ({ ...previous, host: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Port
+              <input
+                type="number"
+                min={1}
+                max={65535}
+                value={state.port}
+                onChange={(event) => setState((previous) => ({ ...previous, port: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.useTls}
+                onChange={(event) => setState((previous) => ({ ...previous, useTls: event.target.checked }))}
+              />
+              Použít TLS/SSL
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.enabled}
+                onChange={(event) => setState((previous) => ({ ...previous, enabled: event.target.checked }))}
+              />
+              Aktivní konektor
+            </label>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Autentizace</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              Uživatelské jméno
+              <input
+                type="text"
+                value={state.username ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, username: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Heslo
+              <input
+                type="password"
+                placeholder={current?.hasPassword ? '••••••••' : 'Není nastaveno'}
+                value={state.password ?? ''}
+                onChange={(event) =>
+                  setState((previous) => ({ ...previous, password: event.target.value, rotateSecret: true }))
+                }
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+          </div>
+          <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">{maskMessage}</p>
+          {current?.hasPassword && !state.password && (
+            <button
+              type="button"
+              onClick={() => setState((previous) => ({ ...previous, rotateSecret: true }))}
+              className="mt-3 text-sm text-sky-600 hover:underline"
+            >
+              Vymazat uložené heslo při uložení
+            </button>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Adresy</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              From adresa
+              <input
+                type="email"
+                required
+                value={state.fromAddress ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, fromAddress: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex flex-col text-sm">
+              Reply-To adresa (volitelně)
+              <input
+                type="email"
+                value={state.replyToAddress ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, replyToAddress: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+          </div>
+        </section>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? 'Ukládám…' : 'Uložit změny'}
+          </button>
+        </div>
+      </form>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Testovací e-mail</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Ověřte funkčnost SMTP připojení odesláním testovací zprávy. Výsledek testu se uloží do auditu a zdravotního stavu konektoru.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col text-sm">
+            Příjemce
+            <input
+              type="email"
+              required
+              value={testRequest.recipient}
+              onChange={(event) => setTestRequest((previous) => ({ ...previous, recipient: event.target.value }))}
+              className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            Předmět
+            <input
+              type="text"
+              value={testRequest.subject}
+              onChange={(event) => setTestRequest((previous) => ({ ...previous, subject: event.target.value }))}
+              className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+            />
+          </label>
+        </div>
+        <label className="mt-4 flex flex-col text-sm">
+          Text zprávy
+          <textarea
+            rows={4}
+            value={testRequest.body}
+            onChange={(event) => setTestRequest((previous) => ({ ...previous, body: event.target.value }))}
+            className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+          />
+        </label>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleTest}
+            disabled={testing}
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {testing ? 'Odesílám…' : 'Odeslat test'}
+          </button>
+          {testResult && <span className="text-sm text-emerald-600 dark:text-emerald-400">{testResult}</span>}
+        </div>
+
+        {current && (
+          <dl className="mt-6 grid gap-4 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-3">
+            <div>
+              <dt>Zdravotní stav</dt>
+              <dd className="font-medium text-slate-700 dark:text-slate-200">{current.healthStatus ?? 'neznámý'}</dd>
+            </div>
+            <div>
+              <dt>Poslední test</dt>
+              <dd className="font-medium text-slate-700 dark:text-slate-200">
+                {current.lastTestedAtUtc ? new Date(current.lastTestedAtUtc).toLocaleString() : '—'}
+              </dd>
+            </div>
+            <div>
+              <dt>Alias konektoru</dt>
+              <dd className="font-medium text-slate-700 dark:text-slate-200">{current.alias}</dd>
+            </div>
+          </dl>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/ExportJobsPage.tsx
+++ b/src/web/src/pages/ExportJobsPage.tsx
@@ -1,0 +1,574 @@
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  ExportJob,
+  QueueExportPayload,
+  buildExportDownloadUrl,
+  listExportJobs,
+  queueExportJob
+} from '../api/exportJobs';
+import {
+  ImportJob,
+  QueueImportPayload,
+  buildImportLogUrl,
+  listImportJobs,
+  queueImportJob
+} from '../api/importJobs';
+
+const scopes = [
+  { value: 'Servers', label: 'Servery' },
+  { value: 'NetworkDevices', label: 'Síťová zařízení' },
+  { value: 'Workstations', label: 'Pracovní stanice' },
+  { value: 'Dictionaries', label: 'Číselníky' }
+];
+
+const exportFormats = [
+  { value: 'Csv', label: 'CSV' },
+  { value: 'Xlsx', label: 'Excel (XLSX)' }
+];
+
+const importFormats = exportFormats;
+
+const conflictStrategies = [
+  { value: 'Skip', label: 'Přeskočit existující' },
+  { value: 'Update', label: 'Aktualizovat' },
+  { value: 'CreateNew', label: 'Vždy vytvořit nový' }
+];
+
+const defaultExportPayload: QueueExportPayload = {
+  scope: 'Servers',
+  format: 'Csv',
+  storagePath: '',
+  filterJson: '',
+  sendEmail: false,
+  emailRecipients: ''
+};
+
+const defaultImportForm = {
+  scope: 'Servers' as QueueImportPayload['scope'],
+  format: 'Csv' as QueueImportPayload['format'],
+  conflictStrategy: 'Skip' as QueueImportPayload['conflictStrategy'],
+  dryRun: true,
+  storagePath: '',
+  fileName: '',
+  sendEmail: false,
+  emailRecipients: '',
+  mappingJson: ''
+};
+
+const fileToBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Soubor se nepodařilo načíst.'));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === 'string') {
+        const base64 = result.split(',').pop();
+        resolve(base64 ?? '');
+      } else {
+        reject(new Error('Nepodařilo se převést soubor.'));
+      }
+    };
+    reader.readAsDataURL(file);
+  });
+
+export const ExportJobsPage = () => {
+  const [exportHistory, setExportHistory] = useState<ExportJob[]>([]);
+  const [exportLoading, setExportLoading] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportFeedback, setExportFeedback] = useState<string | null>(null);
+  const [exportForm, setExportForm] = useState<QueueExportPayload>({ ...defaultExportPayload });
+
+  const [importHistory, setImportHistory] = useState<ImportJob[]>([]);
+  const [importLoading, setImportLoading] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importFeedback, setImportFeedback] = useState<string | null>(null);
+  const [importForm, setImportForm] = useState({ ...defaultImportForm });
+  const [importFile, setImportFile] = useState<File | null>(null);
+
+  const loadExportHistory = async () => {
+    setExportLoading(true);
+    setExportError(null);
+    try {
+      const data = await listExportJobs(1, 50);
+      setExportHistory(data);
+    } catch (err) {
+      setExportError((err as Error).message);
+    } finally {
+      setExportLoading(false);
+    }
+  };
+
+  const loadImportHistory = async () => {
+    setImportLoading(true);
+    setImportError(null);
+    try {
+      const data = await listImportJobs(1, 50);
+      setImportHistory(data);
+    } catch (err) {
+      setImportError((err as Error).message);
+    } finally {
+      setImportLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadExportHistory();
+    loadImportHistory();
+  }, []);
+
+  const handleExportSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setExportError(null);
+    setExportFeedback(null);
+
+    try {
+      const payload: QueueExportPayload = {
+        ...exportForm,
+        filterJson: exportForm.filterJson ? exportForm.filterJson : undefined,
+        emailRecipients: exportForm.sendEmail ? exportForm.emailRecipients : undefined
+      };
+      await queueExportJob(payload);
+      setExportFeedback('Export byl zařazen do fronty.');
+      await loadExportHistory();
+      setExportForm({ ...defaultExportPayload, storagePath: exportForm.storagePath });
+    } catch (err) {
+      setExportError((err as Error).message);
+    }
+  };
+
+  const handleImportSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setImportError(null);
+    setImportFeedback(null);
+
+    if (!importFile) {
+      setImportError('Vyberte soubor pro import.');
+      return;
+    }
+
+    try {
+      const base64 = await fileToBase64(importFile);
+      const payload: QueueImportPayload = {
+        scope: importForm.scope,
+        format: importForm.format,
+        conflictStrategy: importForm.conflictStrategy,
+        dryRun: importForm.dryRun,
+        storagePath: importForm.storagePath,
+        fileName: importForm.fileName || importFile.name,
+        contentBase64: base64,
+        sendEmail: importForm.sendEmail,
+        emailRecipients: importForm.sendEmail ? importForm.emailRecipients : undefined,
+        mappingJson: importForm.mappingJson || undefined
+      };
+
+      await queueImportJob(payload);
+      setImportFeedback('Import byl zařazen do fronty.');
+      await loadImportHistory();
+      setImportForm({ ...defaultImportForm, storagePath: importForm.storagePath });
+      setImportFile(null);
+    } catch (err) {
+      setImportError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Import/Export</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Správa exportů a importů inventáře, včetně historie zpracovaných úloh.
+        </p>
+      </header>
+
+      {exportError && (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">{exportError}</div>
+      )}
+      {exportFeedback && (
+        <div className="rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+          {exportFeedback}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Nový export</h3>
+        <form className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={handleExportSubmit}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Rozsah
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={exportForm.scope}
+              onChange={(event) => setExportForm((prev) => ({ ...prev, scope: event.target.value }))}
+            >
+              {scopes.map((scope) => (
+                <option key={scope.value} value={scope.value}>
+                  {scope.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Formát
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={exportForm.format}
+              onChange={(event) => setExportForm((prev) => ({ ...prev, format: event.target.value }))}
+            >
+              {exportFormats.map((format) => (
+                <option key={format.value} value={format.value}>
+                  {format.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Cílová složka
+            <input
+              className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={exportForm.storagePath}
+              onChange={(event) => setExportForm((prev) => ({ ...prev, storagePath: event.target.value }))}
+              required
+              placeholder={'např. C\\\Exports'}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Filtr (JSON)
+            <textarea
+              className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={exportForm.filterJson ?? ''}
+              onChange={(event) => setExportForm((prev) => ({ ...prev, filterJson: event.target.value }))}
+              placeholder={'{"field":"status","value":"Active"}'}
+              rows={3}
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            <input
+              type="checkbox"
+              checked={exportForm.sendEmail}
+              onChange={(event) => setExportForm((prev) => ({ ...prev, sendEmail: event.target.checked }))}
+            />
+            Odeslat notifikaci e-mailem po dokončení
+          </label>
+
+          {exportForm.sendEmail && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+              Příjemci (oddělte středníkem)
+              <input
+                className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={exportForm.emailRecipients ?? ''}
+                onChange={(event) => setExportForm((prev) => ({ ...prev, emailRecipients: event.target.value }))}
+              />
+            </label>
+          )}
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700"
+              disabled={exportLoading}
+            >
+              Spustit export
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Historie exportů</h3>
+          <button
+            className="text-sm text-indigo-600 hover:underline dark:text-indigo-300"
+            type="button"
+            onClick={loadExportHistory}
+          >
+            Obnovit
+          </button>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-700">
+            <thead className="bg-slate-50 dark:bg-slate-800">
+              <tr>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Rozsah</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Formát</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Stav</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Vytvořeno</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Dokončeno</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Soubor</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Akce</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+              {exportHistory.map((job) => (
+                <tr key={job.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.scope}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.format}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.status}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">
+                    {new Date(job.createdAtUtc).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">
+                    {job.completedAtUtc ? new Date(job.completedAtUtc).toLocaleString() : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.fileName}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">
+                    {job.artifactPath && job.status === 'Completed' ? (
+                      <a
+                        href={buildExportDownloadUrl(job.id)}
+                        className="text-indigo-600 hover:underline dark:text-indigo-300"
+                      >
+                        Stáhnout
+                      </a>
+                    ) : job.status === 'Failed' ? (
+                      <span className="text-red-600 dark:text-red-300">Selhalo</span>
+                    ) : (
+                      <span className="text-slate-500">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+
+              {exportHistory.length === 0 && !exportLoading && (
+                <tr>
+                  <td className="px-3 py-6 text-center text-slate-500 dark:text-slate-400" colSpan={7}>
+                    Zatím nejsou dostupné žádné exporty.
+                  </td>
+                </tr>
+              )}
+
+              {exportLoading && (
+                <tr>
+                  <td className="px-3 py-6 text-center text-slate-500 dark:text-slate-400" colSpan={7}>
+                    Načítání…
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Nový import</h3>
+        {importError && (
+          <div className="mb-3 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">{importError}</div>
+        )}
+        {importFeedback && (
+          <div className="mb-3 rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+            {importFeedback}
+          </div>
+        )}
+        <form className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={handleImportSubmit}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Rozsah
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.scope}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, scope: event.target.value as QueueImportPayload['scope'] }))}
+            >
+              {scopes.map((scope) => (
+                <option key={scope.value} value={scope.value}>
+                  {scope.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Formát
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.format}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, format: event.target.value as QueueImportPayload['format'] }))}
+            >
+              {importFormats.map((format) => (
+                <option key={format.value} value={format.value}>
+                  {format.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Strategie konfliktů
+            <select
+              className="rounded border border-slate-300 bg-white p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.conflictStrategy}
+              onChange={(event) =>
+                setImportForm((prev) => ({ ...prev, conflictStrategy: event.target.value as QueueImportPayload['conflictStrategy'] }))
+              }
+            >
+              {conflictStrategies.map((strategy) => (
+                <option key={strategy.value} value={strategy.value}>
+                  {strategy.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={importForm.dryRun}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, dryRun: event.target.checked }))}
+            />
+            Pouze dry-run (bez zápisu)
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Cílová složka
+            <input
+              className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.storagePath}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, storagePath: event.target.value }))}
+              required
+              placeholder={'např. C\\\Imports'}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Název souboru
+            <input
+              className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.fileName}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, fileName: event.target.value }))}
+              placeholder="např. import.csv"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Soubor
+            <input
+              type="file"
+              accept=".csv,.xlsx"
+              onChange={(event) => {
+                const file = event.target.files?.[0] ?? null;
+                setImportFile(file);
+                if (file) {
+                  setImportForm((prev) => ({ ...prev, fileName: prev.fileName || file.name }));
+                }
+              }}
+              required
+              className="rounded border border-dashed border-slate-300 p-2 dark:border-slate-700"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            Mapování sloupců (JSON)
+            <textarea
+              className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+              value={importForm.mappingJson}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, mappingJson: event.target.value }))}
+              placeholder={'{"Name":"column_name"}'}
+              rows={3}
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+            <input
+              type="checkbox"
+              checked={importForm.sendEmail}
+              onChange={(event) => setImportForm((prev) => ({ ...prev, sendEmail: event.target.checked }))}
+            />
+            Odeslat souhrn e-mailem
+          </label>
+
+          {importForm.sendEmail && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200 md:col-span-2">
+              Příjemci (oddělte středníkem)
+              <input
+                className="rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+                value={importForm.emailRecipients}
+                onChange={(event) => setImportForm((prev) => ({ ...prev, emailRecipients: event.target.value }))}
+              />
+            </label>
+          )}
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-700"
+              disabled={importLoading}
+            >
+              Spustit import
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Historie importů</h3>
+          <button
+            className="text-sm text-indigo-600 hover:underline dark:text-indigo-300"
+            type="button"
+            onClick={loadImportHistory}
+          >
+            Obnovit
+          </button>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-700">
+            <thead className="bg-slate-50 dark:bg-slate-800">
+              <tr>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Rozsah</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Formát</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Stav</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Dry-run</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Zpracováno</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Soubor</th>
+                <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Log</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+              {importHistory.map((job) => (
+                <tr key={job.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.scope}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.format}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.status}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.dryRun ? 'Ano' : 'Ne'}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.processedRows ?? '—'}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">{job.originalFileName}</td>
+                  <td className="px-3 py-2 text-slate-700 dark:text-slate-200">
+                    {job.resultLog ? (
+                      <a
+                        href={buildImportLogUrl(job.id)}
+                        className="text-indigo-600 hover:underline dark:text-indigo-300"
+                      >
+                        Zobrazit log
+                      </a>
+                    ) : job.status === 'Failed' ? (
+                      <span className="text-red-600 dark:text-red-300">Selhalo</span>
+                    ) : (
+                      <span className="text-slate-500">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+
+              {importHistory.length === 0 && !importLoading && (
+                <tr>
+                  <td className="px-3 py-6 text-center text-slate-500 dark:text-slate-400" colSpan={7}>
+                    Zatím nejsou dostupné žádné importy.
+                  </td>
+                </tr>
+              )}
+
+              {importLoading && (
+                <tr>
+                  <td className="px-3 py-6 text-center text-slate-500 dark:text-slate-400" colSpan={7}>
+                    Načítání…
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/FirstRunWizardPage.tsx
+++ b/src/web/src/pages/FirstRunWizardPage.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { EmailSettingsPage } from './EmailSettingsPage';
+import { SecuritySettingsPage } from './SecuritySettingsPage';
+import { getSecuritySummary } from '../api/security';
+
+const stepDefinitions = [
+  {
+    key: 'intro',
+    title: 'Vítejte v průvodci prvním spuštěním',
+    description:
+      'Před tím, než začnete spravovat inventář, nastavte kritické bezpečnostní integrace. Průvodce je možné kdykoli znovu otevřít v menu Nastavení.',
+    content: (
+      <div className="space-y-4 text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          Tento průvodce vás provede konfigurací externí autentizace, LDAP/AD připojení a self-service resetu hesel. Všechny
+          změny se ukládají okamžitě a zapisují se do auditu.
+        </p>
+        <p>
+          Připravte si přístupové údaje k OIDC providerovi, LDAP/AD serveru, SMTP a případným SMS/CAPTCHA konektorům. Každý krok
+          lze přeskočit a později dokončit v Nastavení.
+        </p>
+      </div>
+    )
+  },
+  {
+    key: 'security',
+    title: 'Bezpečnostní nastavení',
+    description:
+      'Zadejte údaje pro OIDC, LDAP/AD, SSPR, CAPTCHA, SMS a SMTP konektory. Rozhraní níže je shodné s administrací Nastavení → Security/Email.',
+    content: (
+      <div className="space-y-8">
+        <SecuritySettingsPage variant="wizard" />
+        <EmailSettingsPage variant="wizard" />
+      </div>
+    )
+  },
+  {
+    key: 'summary',
+    title: 'Hotovo',
+    description: 'Základní bezpečnostní integrace jsou připraveny. Doporučujeme pokračovat konfigurací zbylých modulů aplikace.',
+    content: (
+      <div className="space-y-4 text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          Konfigurace byla dokončena. V Nastavení můžete kdykoli upravit jednotlivé konektory, přidat další mapování AD skupin
+          nebo sledovat auditní záznamy.
+        </p>
+        <p>
+          Pokračujte na dashboard, kde najdete souhrn aktivovaných modulů a další kroky pro nasazení platformy HW Inventory.
+        </p>
+      </div>
+    )
+  }
+];
+
+export const FirstRunWizardPage = () => {
+  const navigate = useNavigate();
+  const [activeStep, setActiveStep] = useState(0);
+  const summaryQuery = useQuery({
+    queryKey: ['security', 'summary', 'wizard'],
+    queryFn: getSecuritySummary,
+    refetchInterval: 30000
+  });
+
+  const clampedStep = useMemo(() => Math.min(Math.max(activeStep, 0), stepDefinitions.length - 1), [activeStep]);
+  const step = stepDefinitions[clampedStep];
+  const securityReady = summaryQuery.data?.criticalReady ?? false;
+  const securityBlocked = step.key === 'security' && !securityReady && !summaryQuery.isError;
+
+  const goNext = () => {
+    if (clampedStep < stepDefinitions.length - 1) {
+      setActiveStep((current) => current + 1);
+    }
+  };
+
+  const goPrevious = () => {
+    if (clampedStep > 0) {
+      setActiveStep((current) => current - 1);
+    }
+  };
+
+  const finish = () => {
+    navigate('/');
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Průvodce prvním spuštěním</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Krok {clampedStep + 1} z {stepDefinitions.length} – {step.title}
+        </p>
+        <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
+      </header>
+
+      <nav className="flex flex-wrap gap-3">
+        {stepDefinitions.map((definition, index) => (
+          <button
+            key={definition.key}
+            type="button"
+            onClick={() => setActiveStep(index)}
+            className={`rounded px-3 py-1 text-sm transition ${
+              index === clampedStep
+                ? 'bg-sky-600 text-white shadow'
+                : 'border border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800'
+            }`}
+          >
+            {index + 1}. {definition.title}
+          </button>
+        ))}
+      </nav>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        {step.content}
+      </section>
+
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={goPrevious}
+          disabled={clampedStep === 0}
+          className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+        >
+          Zpět
+        </button>
+        {clampedStep < stepDefinitions.length - 1 ? (
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={securityBlocked}
+            className={`rounded px-4 py-2 text-sm font-semibold text-white shadow-sm transition ${
+              securityBlocked
+                ? 'cursor-not-allowed bg-slate-400 dark:bg-slate-600'
+                : 'bg-sky-600 hover:bg-sky-700'
+            }`}
+          >
+            {securityBlocked ? 'Dokončete konfiguraci' : 'Pokračovat'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={finish}
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+          >
+            Dokončit
+          </button>
+        )}
+      </div>
+      {step.key === 'security' && securityBlocked && (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          Pro pokračování je potřeba dokončit konfiguraci všech požadovaných bezpečnostních komponent (OIDC/LDAP, 2FA/SSPR,
+          CAPTCHA, SMS a politika hesel).
+        </p>
+      )}
+      {step.key === 'security' && summaryQuery.isError && (
+        <p className="text-xs text-rose-500 dark:text-rose-400">
+          Nepodařilo se ověřit stav zabezpečení. Zkuste stránku obnovit po dokončení konfigurace nebo zkontrolujte připojení k
+          API.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/web/src/pages/LabelsPage.tsx
+++ b/src/web/src/pages/LabelsPage.tsx
@@ -1,0 +1,274 @@
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  LabelPrintJob,
+  LabelTemplate,
+  createLabelTemplate,
+  deleteLabelTemplate,
+  getLabelPrintJobs,
+  getLabelTemplates,
+  renderLabelPdf,
+  renderLabelZpl,
+  updateLabelTemplate
+} from '../api/labels';
+
+const createEmptyTemplate = (): LabelTemplate => ({
+  id: '',
+  name: '',
+  code: '',
+  format: 'A7',
+  payload: '{\n  "elements": []\n}',
+  description: ''
+});
+
+export const LabelsPage = () => {
+  const [templates, setTemplates] = useState<LabelTemplate[]>([]);
+  const [jobs, setJobs] = useState<LabelPrintJob[]>([]);
+  const [form, setForm] = useState(createEmptyTemplate());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewZpl, setPreviewZpl] = useState('');
+
+  const loadTemplates = async () => {
+    try {
+      setLoading(true);
+      const [templateData, jobsData] = await Promise.all([getLabelTemplates(), getLabelPrintJobs()]);
+      setTemplates(templateData);
+      setJobs(jobsData);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadTemplates();
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      if (editingId) {
+        await updateLabelTemplate(editingId, { ...form, id: editingId });
+      } else {
+        await createLabelTemplate({ ...form, id: crypto.randomUUID() });
+      }
+      setForm(createEmptyTemplate());
+      setEditingId(null);
+      await loadTemplates();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleEdit = (template: LabelTemplate) => {
+    setEditingId(template.id);
+    setForm(template);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Opravdu chcete šablonu smazat?')) {
+      return;
+    }
+    try {
+      await deleteLabelTemplate(id);
+      await loadTemplates();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRenderZpl = async (id: string) => {
+    try {
+      const zpl = await renderLabelZpl(id, {});
+      setPreviewZpl(zpl);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRenderPdf = async (id: string) => {
+    try {
+      const pdfBlob = await renderLabelPdf(id, {});
+      const url = URL.createObjectURL(pdfBlob);
+      window.open(url, '_blank');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Štítky a tisk</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Správa šablon, generování náhledů a kontrola tiskových úloh.
+        </p>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Šablony</h3>
+          <div className="rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <ul className="divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              {templates.map((template) => (
+                <li key={template.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-slate-100">{template.name}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{template.code} · {template.format}</p>
+                  </div>
+                  <div className="flex gap-2 text-xs">
+                    <button
+                      className="rounded border border-slate-200 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => handleEdit(template)}
+                    >
+                      Upravit
+                    </button>
+                    <button
+                      className="rounded border border-slate-200 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => handleRenderZpl(template.id)}
+                    >
+                      Náhled ZPL
+                    </button>
+                    <button
+                      className="rounded border border-slate-200 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => handleRenderPdf(template.id)}
+                    >
+                      PDF
+                    </button>
+                    <button
+                      className="rounded border border-red-300 px-3 py-1 font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/40"
+                      onClick={() => handleDelete(template.id)}
+                    >
+                      Smazat
+                    </button>
+                  </div>
+                </li>
+              ))}
+              {!loading && templates.length === 0 && (
+                <li className="px-4 py-6 text-sm text-slate-500 dark:text-slate-400">Nejsou definované žádné šablony.</li>
+              )}
+              {loading && (
+                <li className="px-4 py-6 text-sm text-slate-500 dark:text-slate-400">Načítám data…</li>
+              )}
+            </ul>
+          </div>
+
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Tiskové úlohy</h3>
+          <div className="rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <ul className="divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              {jobs.map((job) => (
+                <li key={job.id} className="flex flex-col gap-1 px-4 py-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-slate-900 dark:text-slate-100">{job.target}</span>
+                    <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{job.jobStatus}</span>
+                  </div>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {new Date(job.createdAtUtc).toLocaleString()} · {job.format}
+                  </span>
+                </li>
+              ))}
+              {!loading && jobs.length === 0 && (
+                <li className="px-4 py-6 text-sm text-slate-500 dark:text-slate-400">Zatím nebyly vytvořeny žádné tiskové úlohy.</li>
+              )}
+            </ul>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 rounded border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {editingId ? 'Upravit šablonu' : 'Nová šablona'}
+            </h3>
+            {editingId && (
+              <button
+                type="button"
+                onClick={() => { setEditingId(null); setForm(createEmptyTemplate()); }}
+                className="text-sm text-slate-500 underline"
+              >
+                Zrušit úpravy
+              </button>
+            )}
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Název</span>
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((state) => ({ ...state, name: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Kód</span>
+            <input
+              required
+              value={form.code}
+              onChange={(event) => setForm((state) => ({ ...state, code: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Formát / rozměr</span>
+            <input
+              value={form.format}
+              onChange={(event) => setForm((state) => ({ ...state, format: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Popis</span>
+            <textarea
+              value={form.description ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, description: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+              rows={3}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Payload (JSON)</span>
+            <textarea
+              required
+              value={form.payload}
+              onChange={(event) => setForm((state) => ({ ...state, payload: event.target.value }))}
+              className="h-48 rounded border border-slate-300 px-3 py-2 font-mono text-xs dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+
+          {previewZpl && (
+            <div className="rounded border border-slate-200 bg-slate-50 p-3 text-xs font-mono text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+              <div className="mb-2 flex items-center justify-between">
+                <strong>ZPL náhled</strong>
+                <button type="button" className="text-xs text-slate-500 underline" onClick={() => setPreviewZpl('')}>
+                  Zavřít
+                </button>
+              </div>
+              <pre className="whitespace-pre-wrap break-all">{previewZpl}</pre>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => { setEditingId(null); setForm(createEmptyTemplate()); }}
+              className="rounded border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              Zrušit
+            </button>
+            <button
+              type="submit"
+              className="rounded bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-500"
+            >
+              {editingId ? 'Uložit změny' : 'Přidat šablonu'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/web/src/pages/ModulesPage.tsx
+++ b/src/web/src/pages/ModulesPage.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { FeatureModule, getFeatureModules, toggleFeatureModule } from '../api/modules';
+
+export const ModulesPage = () => {
+  const [modules, setModules] = useState<FeatureModule[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadModules = async () => {
+    try {
+      setLoading(true);
+      const data = await getFeatureModules();
+      setModules(data);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadModules();
+  }, []);
+
+  const handleToggle = async (module: FeatureModule) => {
+    try {
+      await toggleFeatureModule(module.key, !module.enabled);
+      await loadModules();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Moduly</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Zapnutí a vypnutí jednotlivých funkčních celků platformy.
+        </p>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Modul</th>
+              <th className="px-4 py-3">Popis</th>
+              <th className="px-4 py-3">Stav</th>
+              <th className="px-4 py-3 text-right">Akce</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {modules.map((module) => (
+              <tr key={module.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{module.name}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{module.description ?? '—'}</td>
+                <td className="px-4 py-3">
+                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${module.enabled ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-700'}`}>
+                    {module.enabled ? 'Zapnuto' : 'Vypnuto'}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleToggle(module)}
+                  >
+                    {module.enabled ? 'Vypnout' : 'Zapnout'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!loading && modules.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Nebyly nalezeny žádné moduly.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/web/src/pages/NetworkDevicesPage.tsx
+++ b/src/web/src/pages/NetworkDevicesPage.tsx
@@ -1,0 +1,430 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  NetworkDevice,
+  NetworkDeviceRequest,
+  createNetworkDevice,
+  deleteNetworkDevice,
+  getNetworkDevices,
+  retireNetworkDevice,
+  restoreNetworkDevice,
+  updateNetworkDevice
+} from '../api/networkDevices';
+import { DictionaryEntry, getDictionaryEntries } from '../api/dictionaries';
+
+const dictionaryTypes = ['DeviceType', 'Location', 'Vlan'];
+
+const createEmptyForm = (): NetworkDeviceRequest => ({
+  name: '',
+  inventoryNumber: '',
+  deviceTypeId: '',
+  manufacturer: '',
+  model: '',
+  locationId: '',
+  rackPosition: '',
+  primaryAdministratorId: null,
+  secondaryAdministratorId: null,
+  supportUntil: '',
+  notes: '',
+  networkAssignments: [
+    { label: 'VLAN1', vlanId: null, ipAddress: '' },
+    { label: 'VLAN2', vlanId: null, ipAddress: '' },
+    { label: 'VLAN3', vlanId: null, ipAddress: '' }
+  ]
+});
+
+export const NetworkDevicesPage = () => {
+  const [devices, setDevices] = useState<NetworkDevice[]>([]);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(25);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<NetworkDeviceRequest>(() => createEmptyForm());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [dictionaries, setDictionaries] = useState<Record<string, DictionaryEntry[]>>({});
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(totalCount / pageSize)), [totalCount, pageSize]);
+
+  const loadDevices = async (pageIndex = page) => {
+    try {
+      setLoading(true);
+      const response = await getNetworkDevices(pageIndex, pageSize);
+      setDevices(response.items);
+      setTotalCount(response.totalCount);
+      setPage(response.page);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadDictionaries = async () => {
+    const map: Record<string, DictionaryEntry[]> = {};
+    await Promise.all(
+      dictionaryTypes.map(async (type) => {
+        map[type] = await getDictionaryEntries(type);
+      })
+    );
+    setDictionaries(map);
+  };
+
+  useEffect(() => {
+    void loadDevices(1);
+    void loadDictionaries();
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload: NetworkDeviceRequest = {
+      ...form,
+      rackPosition: form.rackPosition || null,
+      primaryAdministratorId: form.primaryAdministratorId || null,
+      secondaryAdministratorId: form.secondaryAdministratorId || null,
+      supportUntil: form.supportUntil ? new Date(form.supportUntil).toISOString() : null,
+      notes: form.notes || null,
+      networkAssignments: form.networkAssignments
+        .filter((assignment) => assignment.vlanId || assignment.ipAddress)
+        .map((assignment) => ({
+          label: assignment.label,
+          vlanId: assignment.vlanId || null,
+          ipAddress: assignment.ipAddress || null
+        }))
+    };
+
+    try {
+      if (editingId) {
+        await updateNetworkDevice(editingId, payload);
+      } else {
+        await createNetworkDevice(payload);
+      }
+      setForm(createEmptyForm());
+      setEditingId(null);
+      await loadDevices(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleEdit = (device: NetworkDevice) => {
+    setEditingId(device.id);
+    setForm({
+      name: device.name,
+      inventoryNumber: device.inventoryNumber,
+      deviceTypeId: device.deviceTypeId,
+      manufacturer: device.manufacturer,
+      model: device.model,
+      locationId: device.locationId,
+      rackPosition: device.rackPosition ?? '',
+      primaryAdministratorId: device.primaryAdministratorId ?? null,
+      secondaryAdministratorId: device.secondaryAdministratorId ?? null,
+      supportUntil: device.supportUntil ? device.supportUntil.substring(0, 10) : '',
+      notes: device.notes ?? '',
+      networkAssignments: [
+        { label: 'VLAN1', vlanId: device.networkAssignments[0]?.vlanId ?? null, ipAddress: device.networkAssignments[0]?.ipAddress ?? '' },
+        { label: 'VLAN2', vlanId: device.networkAssignments[1]?.vlanId ?? null, ipAddress: device.networkAssignments[1]?.ipAddress ?? '' },
+        { label: 'VLAN3', vlanId: device.networkAssignments[2]?.vlanId ?? null, ipAddress: device.networkAssignments[2]?.ipAddress ?? '' }
+      ]
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Opravdu chcete zařízení smazat?')) {
+      return;
+    }
+    try {
+      await deleteNetworkDevice(id);
+      await loadDevices(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRetireToggle = async (device: NetworkDevice) => {
+    try {
+      if (device.status === 'Retired') {
+        await restoreNetworkDevice(device.id);
+      } else {
+        await retireNetworkDevice(device.id);
+      }
+      await loadDevices(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleResetForm = () => {
+    setForm(createEmptyForm());
+    setEditingId(null);
+  };
+
+  const options = (type: string) => dictionaries[type] ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Síťová zařízení</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Evidence switchů, routerů, firewallů a dalších síťových prvků.
+        </p>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="overflow-x-auto rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Název</th>
+              <th className="px-4 py-3">Typ</th>
+              <th className="px-4 py-3">Lokalita</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3 text-right">Akce</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {devices.map((device) => (
+              <tr key={device.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{device.name}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{device.deviceTypeId}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{device.locationId}</td>
+                <td className="px-4 py-3">
+                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${device.status === 'Retired' ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-700'}`}>
+                    {device.status}
+                  </span>
+                </td>
+                <td className="flex items-center justify-end gap-2 px-4 py-3">
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleEdit(device)}
+                  >
+                    Upravit
+                  </button>
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleRetireToggle(device)}
+                  >
+                    {device.status === 'Retired' ? 'Obnovit' : 'Vyřadit'}
+                  </button>
+                  <button
+                    className="rounded border border-red-300 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/40"
+                    onClick={() => handleDelete(device.id)}
+                  >
+                    Smazat
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!loading && devices.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Nebyla nalezena žádná síťová zařízení.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
+        <span>
+          Stránka {page} / {totalPages} · {totalCount} záznamů
+        </span>
+        <div className="space-x-2">
+          <button
+            disabled={page <= 1}
+            onClick={() => void loadDevices(page - 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Předchozí
+          </button>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => void loadDevices(page + 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Další
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{editingId ? 'Upravit zařízení' : 'Nové zařízení'}</h3>
+          {editingId && (
+            <button type="button" onClick={handleResetForm} className="text-sm text-slate-500 underline">
+              Zrušit úpravy
+            </button>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Název</span>
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((state) => ({ ...state, name: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Inventární číslo</span>
+            <input
+              required
+              value={form.inventoryNumber}
+              onChange={(event) => setForm((state) => ({ ...state, inventoryNumber: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Výrobce</span>
+            <input
+              required
+              value={form.manufacturer}
+              onChange={(event) => setForm((state) => ({ ...state, manufacturer: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Model</span>
+            <input
+              required
+              value={form.model}
+              onChange={(event) => setForm((state) => ({ ...state, model: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Typ zařízení</span>
+            <select
+              required
+              value={form.deviceTypeId}
+              onChange={(event) => setForm((state) => ({ ...state, deviceTypeId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {options('DeviceType').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Lokalita</span>
+            <select
+              required
+              value={form.locationId}
+              onChange={(event) => setForm((state) => ({ ...state, locationId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {options('Location').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Rack pozice</span>
+            <input
+              value={form.rackPosition ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, rackPosition: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Podpora do</span>
+            <input
+              type="date"
+              value={form.supportUntil ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, supportUntil: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          {form.networkAssignments.map((assignment, index) => (
+            <div key={assignment.label} className="rounded border border-slate-200 p-3 dark:border-slate-700">
+              <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">{assignment.label}</h4>
+              <label className="mb-2 flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                VLAN
+                <select
+                  value={assignment.vlanId ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value || null;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], vlanId: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                >
+                  <option value="">—</option>
+                  {options('Vlan').map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                IP adresa
+                <input
+                  value={assignment.ipAddress ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], ipAddress: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span>Poznámka</span>
+          <textarea
+            value={form.notes ?? ''}
+            onChange={(event) => setForm((state) => ({ ...state, notes: event.target.value }))}
+            className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            rows={3}
+          />
+        </label>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleResetForm}
+            className="rounded border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Zrušit
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
+          >
+            {editingId ? 'Uložit změny' : 'Přidat zařízení'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/web/src/pages/ObservabilitySettingsPage.tsx
+++ b/src/web/src/pages/ObservabilitySettingsPage.tsx
@@ -1,0 +1,351 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  ObservabilityConfiguration,
+  ObservabilityConfigurationUpdate,
+  fetchMetricsPreview,
+  fetchObservabilityConfiguration,
+  saveObservabilityConfiguration
+} from '../api/observability';
+
+const logLevels = ['Trace', 'Debug', 'Information', 'Warning', 'Error', 'Critical', 'None'];
+
+const defaultState: ObservabilityConfigurationUpdate = {
+  logLevel: 'Information',
+  healthEndpointEnabled: true,
+  metricsEndpointEnabled: false,
+  correlationIdsEnabled: true,
+  includeTraceIdentifier: true,
+  otelExporterEnabled: false,
+  otelEndpoint: '',
+  otelAuthToken: '',
+  rotateOtelAuthToken: false,
+  resourceAttributes: ''
+};
+
+export const ObservabilitySettingsPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [state, setState] = useState<ObservabilityConfigurationUpdate>(defaultState);
+  const [current, setCurrent] = useState<ObservabilityConfiguration | null>(null);
+  const [metricsPreview, setMetricsPreview] = useState<string>('');
+  const [previewTimestamp, setPreviewTimestamp] = useState<string>('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const refreshMetrics = async () => {
+      try {
+        setPreviewLoading(true);
+        const snapshot = await fetchMetricsPreview();
+        if (!mounted) {
+          return;
+        }
+        setMetricsPreview(snapshot);
+        setPreviewTimestamp(new Date().toLocaleString());
+      } catch (err) {
+        if (mounted) {
+          setMetricsPreview('Náhled metrik se nepodařilo načíst.');
+        }
+      } finally {
+        if (mounted) {
+          setPreviewLoading(false);
+        }
+      }
+    };
+
+    const load = async () => {
+      try {
+        const configuration = await fetchObservabilityConfiguration();
+        if (!mounted) {
+          return;
+        }
+        setCurrent(configuration);
+        setState({
+          logLevel: configuration.logLevel,
+          healthEndpointEnabled: configuration.healthEndpointEnabled,
+          metricsEndpointEnabled: configuration.metricsEndpointEnabled,
+          correlationIdsEnabled: configuration.correlationIdsEnabled,
+          includeTraceIdentifier: configuration.includeTraceIdentifier,
+          otelExporterEnabled: configuration.otelExporterEnabled,
+          otelEndpoint: configuration.otelEndpoint ?? '',
+          otelAuthToken: '',
+          rotateOtelAuthToken: false,
+          resourceAttributes: configuration.resourceAttributes ?? ''
+        });
+        await refreshMetrics();
+      } catch (err) {
+        if (mounted) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleRefreshMetrics = async () => {
+    setError(null);
+    setPreviewLoading(true);
+    try {
+      const snapshot = await fetchMetricsPreview();
+      setMetricsPreview(snapshot);
+      setPreviewTimestamp(new Date().toLocaleString());
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const tokenMessage = useMemo(() => {
+    if (!current?.hasOtelAuthToken) {
+      return 'Token není nastaven.';
+    }
+    if (state.rotateOtelAuthToken || state.otelAuthToken) {
+      return 'Zadáte nový token – bude uložen po uložení formuláře.';
+    }
+    return 'Token je nastaven. Chcete-li jej odstranit, zaškrtněte „Vymazat token“ nebo zadejte nový.';
+  }, [current?.hasOtelAuthToken, state.rotateOtelAuthToken, state.otelAuthToken]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload: ObservabilityConfigurationUpdate = {
+        ...state,
+        otelEndpoint: state.otelEndpoint?.trim() || undefined,
+        otelAuthToken: state.otelAuthToken?.trim() || undefined,
+        rotateOtelAuthToken: state.rotateOtelAuthToken || Boolean(state.otelAuthToken && state.otelAuthToken.trim()),
+        resourceAttributes: state.resourceAttributes?.trim() || undefined
+      };
+
+      const updated = await saveObservabilityConfiguration(payload);
+      setCurrent(updated);
+      setState((previous) => ({
+        ...previous,
+        rotateOtelAuthToken: false,
+        otelAuthToken: ''
+      }));
+      setSuccess('Nastavení bylo uloženo.');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-sm text-slate-600 dark:text-slate-300">Načítám observability nastavení…</div>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Observabilita</h1>
+        <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-300">
+          Spravujte logovací úroveň, dostupnost koncových bodů /health a /metrics a konfiguraci OpenTelemetry exporteru. Změny
+          se ukládají okamžitě a zapisují do auditu.
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="rounded border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200">
+          {success}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Logování a telemetry</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm">
+              Log level
+              <select
+                value={state.logLevel}
+                onChange={(event) => setState((previous) => ({ ...previous, logLevel: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              >
+                {logLevels.map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.healthEndpointEnabled}
+                onChange={(event) => setState((previous) => ({ ...previous, healthEndpointEnabled: event.target.checked }))}
+              />
+              Povolit /health
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.metricsEndpointEnabled}
+                onChange={(event) => setState((previous) => ({ ...previous, metricsEndpointEnabled: event.target.checked }))}
+              />
+              Povolit /metrics
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.correlationIdsEnabled}
+                onChange={(event) => setState((previous) => ({ ...previous, correlationIdsEnabled: event.target.checked }))}
+              />
+              Přidávat X-Correlation-Id
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={state.includeTraceIdentifier}
+                onChange={(event) => setState((previous) => ({ ...previous, includeTraceIdentifier: event.target.checked }))}
+              />
+              Přidat trace-id do odpovědi
+            </label>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">OpenTelemetry Exporter</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm md:col-span-2">
+              <input
+                type="checkbox"
+                checked={state.otelExporterEnabled}
+                onChange={(event) => setState((previous) => ({ ...previous, otelExporterEnabled: event.target.checked }))}
+              />
+              Povolit odesílání do OTLP endpointu
+            </label>
+            <label className="flex flex-col text-sm md:col-span-2">
+              Endpoint
+              <input
+                type="url"
+                placeholder="https://otel.example.com:4318/v1/traces"
+                value={state.otelEndpoint ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, otelEndpoint: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+            <label className="flex flex-col text-sm md:col-span-2">
+              Token
+              <input
+                type="password"
+                value={state.otelAuthToken ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, otelAuthToken: event.target.value }))}
+                placeholder="••••••"
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+              <span className="mt-1 text-xs text-slate-500 dark:text-slate-400">{tokenMessage}</span>
+              <div className="mt-2 flex items-center gap-2">
+                <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={state.rotateOtelAuthToken}
+                    onChange={(event) =>
+                      setState((previous) => ({ ...previous, rotateOtelAuthToken: event.target.checked }))
+                    }
+                  />
+                  Vymazat aktuální token
+                </label>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setState((previous) => ({
+                      ...previous,
+                      otelAuthToken: '',
+                      rotateOtelAuthToken: true
+                    }))
+                  }
+                  className="text-xs font-semibold text-red-600 hover:underline"
+                >
+                  Vymazat
+                </button>
+              </div>
+            </label>
+            <label className="flex flex-col text-sm md:col-span-2">
+              Resource attributes (např. <code>service.name=hw-inventory,environment=prod</code>)
+              <textarea
+                rows={3}
+                value={state.resourceAttributes ?? ''}
+                onChange={(event) => setState((previous) => ({ ...previous, resourceAttributes: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Náhled metrik</h2>
+          <div className="mt-4 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+            <span>{previewTimestamp ? `Poslední aktualizace: ${previewTimestamp}` : 'Náhled zatím nebyl načten.'}</span>
+            <button
+              type="button"
+              onClick={handleRefreshMetrics}
+              className="rounded border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+            >
+              Obnovit náhled
+            </button>
+          </div>
+          <pre className="mt-3 max-h-64 overflow-auto rounded bg-slate-900 p-4 text-xs text-slate-100">
+            {previewLoading ? 'Načítám…' : metricsPreview || 'Žádná data.'}
+          </pre>
+        </section>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              if (!current) {
+                return;
+              }
+              setState({
+                logLevel: current.logLevel,
+                healthEndpointEnabled: current.healthEndpointEnabled,
+                metricsEndpointEnabled: current.metricsEndpointEnabled,
+                correlationIdsEnabled: current.correlationIdsEnabled,
+                includeTraceIdentifier: current.includeTraceIdentifier,
+                otelExporterEnabled: current.otelExporterEnabled,
+                otelEndpoint: current.otelEndpoint ?? '',
+                otelAuthToken: '',
+                rotateOtelAuthToken: false,
+                resourceAttributes: current.resourceAttributes ?? ''
+              });
+              setError(null);
+              setSuccess(null);
+            }}
+            className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+          >
+            Zrušit změny
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-60"
+          >
+            {saving ? 'Ukládám…' : 'Uložit' }
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/web/src/pages/PlaceholderPage.tsx
+++ b/src/web/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type PlaceholderPageProps = {
+  title: string;
+  description: string;
+};
+
+export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title, description }) => (
+  <div className="space-y-4 rounded-lg border border-dashed border-slate-300 bg-white p-6 text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+    <h2 className="text-xl font-semibold">{title}</h2>
+    <p>{description}</p>
+    <p className="text-sm text-slate-500 dark:text-slate-400">
+      Scaffold API clients with React Query to fetch data from the secured ASP.NET Core backend. This shell ensures the dark/light
+      theme toggle and navigation system are ready for the upcoming modules.
+    </p>
+  </div>
+);

--- a/src/web/src/pages/SecuritySettingsPage.tsx
+++ b/src/web/src/pages/SecuritySettingsPage.tsx
@@ -1,0 +1,1810 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  CaptchaConfiguration,
+  CaptchaConfigurationRequest,
+  LdapConfiguration,
+  LdapConfigurationRequest,
+  LdapConnectionTestResult,
+  LdapRoleMapping,
+  OidcConfiguration,
+  SmsConnectorConfiguration,
+  SmsConnectorRequest,
+  SsprConfiguration,
+  PasswordPolicyConfiguration,
+  UserSummary,
+  UserSession,
+  createLdapRoleMapping,
+  deleteLdapRoleMapping,
+  dryRunLdap,
+  getCaptchaConfiguration,
+  getLdapConfiguration,
+  getLdapRoleMappings,
+  getOidcConfiguration,
+  getSmsConfiguration,
+  getSsprConfiguration,
+  getPasswordPolicyConfiguration,
+  getSecuritySummary,
+  testLdapConnection,
+  getUserSessions,
+  updateCaptchaConfiguration,
+  updateLdapConfiguration,
+  updateLdapRoleMapping,
+  updateOidcConfiguration,
+  updateSmsConfiguration,
+  updateSsprConfiguration,
+  updatePasswordPolicyConfiguration,
+  searchSecurityUsers,
+  revokeSession,
+  revokeAllSessions,
+  SecuritySummary
+} from '../api/security';
+import { AuditLogEntry, getAuditLogs } from '../api/audit';
+
+interface FlashMessage {
+  type: 'success' | 'error';
+  message: string;
+}
+
+const parseClaimMappings = (input: string): Record<string, string> => {
+  const mappings: Record<string, string> = {};
+  input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [key, value] = line.split('=', 2);
+      if (key && value) {
+        mappings[key.trim()] = value.trim();
+      }
+    });
+  return mappings;
+};
+
+const stringifyClaimMappings = (mappings: Record<string, string>): string =>
+  Object.entries(mappings)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+const parseList = (input: string): string[] =>
+  input
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const stringifyList = (items: string[]): string => items.join('\n');
+
+const SECURITY_AUDIT_TYPES = [
+  'Security.OIDC',
+  'Security.LDAP',
+  'Security.SSPR',
+  'Security.Captcha',
+  'Security.SMS',
+  'Security.PasswordPolicy',
+  'Security.Session',
+  'Security.LdapRoleMapping',
+  'Security.DataScopes'
+];
+
+const ROLE_OPTIONS = [
+  { value: 'SuperAdmin', label: 'Super Admin' },
+  { value: 'SRV Administrator', label: 'SRV Administrator' },
+  { value: 'NET Administrator', label: 'NET Administrator' },
+  { value: 'Aplikační admin', label: 'Aplikační admin' },
+  { value: 'Helpdesk', label: 'Helpdesk' },
+  { value: 'Helpdesk Read', label: 'Helpdesk Read' }
+];
+
+interface SecuritySettingsPageProps {
+  variant?: 'full' | 'wizard';
+}
+
+export const SecuritySettingsPage = ({ variant = 'full' }: SecuritySettingsPageProps) => {
+  const queryClient = useQueryClient();
+  const [flash, setFlash] = useState<FlashMessage | null>(null);
+  const headerDescription =
+    variant === 'wizard'
+      ? 'V rámci průvodce prvním spuštěním nastavte klíčové bezpečnostní integrace. Změny se uloží okamžitě.'
+      : 'Spravujte externí identity, připojení k LDAP/AD a pravidla self-service resetu hesel. Změny se okamžitě zapisují do auditu.';
+
+  const [oidcState, setOidcState] = useState<OidcConfiguration>({
+    enabled: false,
+    authority: '',
+    clientId: '',
+    clientSecret: '',
+    responseType: 'code',
+    scopes: ['openid', 'profile', 'email'],
+    claimMappings: { name: 'name', email: 'email' },
+    usePkce: true
+  });
+  const [scopesInput, setScopesInput] = useState('openid profile email');
+  const [claimMappingsInput, setClaimMappingsInput] = useState('name=name\nemail=email');
+
+  const [ldapState, setLdapState] = useState<{
+    form: LdapConfigurationRequest;
+    hasPassword: boolean;
+  }>({
+    form: {
+      enabled: false,
+      host: '',
+      port: 389,
+      useSsl: false,
+      bindDn: '',
+      password: '',
+      resetPassword: false,
+      ignoreCertificateErrors: false,
+      usersBaseDn: '',
+      usersFilter: '',
+      attributeMap: []
+    },
+    hasPassword: false
+  });
+  const [ldapTestResult, setLdapTestResult] = useState<LdapConnectionTestResult | null>(null);
+  const [ldapDryRunResult, setLdapDryRunResult] = useState<{
+    resultCount: number;
+    truncated: boolean;
+    notes?: string | null;
+    users: Array<{ distinguishedName: string; attributes: Record<string, string | null> }>;
+  } | null>(null);
+  const [ldapAttributeMapInput, setLdapAttributeMapInput] = useState('');
+
+  const [ssprState, setSsprState] = useState<SsprConfiguration>({
+    enabled: false,
+    requireTwoFactor: true,
+    requireCaptcha: true,
+    requireSmsOtp: false,
+    tokenExpiryMinutes: 30,
+    throttleWindowMinutes: 15,
+    maxRequestsPerWindow: 3,
+    smsConnectorKey: ''
+  });
+
+  const [captchaState, setCaptchaState] = useState<CaptchaConfiguration>({
+    enabled: false,
+    siteKey: '',
+    hasSecret: false,
+    verificationEndpoint: '',
+    bypassToken: ''
+  });
+  const [captchaSecretInput, setCaptchaSecretInput] = useState('');
+  const [captchaRotateSecret, setCaptchaRotateSecret] = useState(false);
+
+  const [smsState, setSmsState] = useState<SmsConnectorConfiguration>({
+    id: null,
+    alias: 'Primary SMS',
+    enabled: false,
+    endpoint: '',
+    sender: '',
+    region: '',
+    hasSecret: false,
+    healthStatus: undefined,
+    lastTestedAtUtc: undefined
+  });
+  const [smsSecretInput, setSmsSecretInput] = useState('');
+  const [smsRotateSecret, setSmsRotateSecret] = useState(false);
+
+  const [passwordPolicyState, setPasswordPolicyState] = useState<PasswordPolicyConfiguration>({
+    enabled: true,
+    minimumLength: 12,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireDigit: true,
+    requireNonAlphanumeric: false,
+    expirationDays: 90,
+    historyCount: 5,
+    lockoutAttempts: 5,
+    lockoutDurationMinutes: 15
+  });
+
+  const [sessionSearchTerm, setSessionSearchTerm] = useState('');
+  const [selectedUser, setSelectedUser] = useState<UserSummary | null>(null);
+  const [revokeReason, setRevokeReason] = useState('');
+
+  const [roleMappings, setRoleMappings] = useState<LdapRoleMapping[]>([]);
+  const [mappingDrafts, setMappingDrafts] = useState<Record<string, { groupName: string; roleName: string }>>({});
+  const [newMapping, setNewMapping] = useState<{ groupName: string; roleName: string }>({
+    groupName: '',
+    roleName: ROLE_OPTIONS[0].value
+  });
+
+  const [auditExpanded, setAuditExpanded] = useState<string | null>(null);
+
+  const oidcQuery = useQuery({
+    queryKey: ['security', 'oidc'],
+    queryFn: getOidcConfiguration,
+    onSuccess: (data) => {
+      if (data) {
+        setOidcState(data);
+        setScopesInput(data.scopes.join(' '));
+        setClaimMappingsInput(stringifyClaimMappings(data.claimMappings));
+      }
+    }
+  });
+
+  const ldapQuery = useQuery({
+    queryKey: ['security', 'ldap'],
+    queryFn: getLdapConfiguration,
+    onSuccess: (data: LdapConfiguration) => {
+      setLdapState({
+        form: {
+          enabled: data.enabled,
+          host: data.host,
+          port: data.port,
+          useSsl: data.useSsl,
+          bindDn: data.bindDn,
+          password: '',
+          resetPassword: false,
+          ignoreCertificateErrors: data.ignoreCertificateErrors,
+          usersBaseDn: data.usersBaseDn,
+          usersFilter: data.usersFilter ?? '',
+          attributeMap: data.attributeMap
+        },
+        hasPassword: data.hasPassword
+      });
+      setLdapAttributeMapInput(stringifyList(data.attributeMap));
+    }
+  });
+
+  const ssprQuery = useQuery({
+    queryKey: ['security', 'sspr'],
+    queryFn: getSsprConfiguration,
+    onSuccess: (data) => {
+      setSsprState(data);
+    }
+  });
+
+  const captchaQuery = useQuery({
+    queryKey: ['security', 'captcha'],
+    queryFn: getCaptchaConfiguration,
+    onSuccess: (data: CaptchaConfiguration) => {
+      setCaptchaState(data);
+      setCaptchaSecretInput('');
+      setCaptchaRotateSecret(false);
+    }
+  });
+
+  const smsQuery = useQuery({
+    queryKey: ['security', 'sms'],
+    queryFn: getSmsConfiguration,
+    onSuccess: (data: SmsConnectorConfiguration | null) => {
+      if (data) {
+        setSmsState({ ...data });
+      } else {
+        setSmsState({
+          id: null,
+          alias: 'Primary SMS',
+          enabled: false,
+          endpoint: '',
+          sender: '',
+          region: '',
+          hasSecret: false,
+          healthStatus: undefined,
+          lastTestedAtUtc: undefined
+        });
+      }
+      setSmsSecretInput('');
+      setSmsRotateSecret(false);
+    }
+  });
+
+  const passwordPolicyQuery = useQuery({
+    queryKey: ['security', 'password-policy'],
+    queryFn: getPasswordPolicyConfiguration,
+    onSuccess: (data: PasswordPolicyConfiguration) => {
+      setPasswordPolicyState(data);
+    }
+  });
+
+  const normalizedSearchTerm = sessionSearchTerm.trim();
+
+  const userSearchQuery = useQuery({
+    queryKey: ['security', 'user-search', normalizedSearchTerm],
+    queryFn: () => searchSecurityUsers(normalizedSearchTerm),
+    enabled: normalizedSearchTerm.length === 0 || normalizedSearchTerm.length >= 2
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['security', 'sessions', selectedUser?.id ?? 'none'],
+    queryFn: async () => {
+      if (!selectedUser) {
+        return [] as UserSession[];
+      }
+      return getUserSessions(selectedUser.id);
+    },
+    enabled: Boolean(selectedUser?.id)
+  });
+
+  const roleMappingQuery = useQuery({
+    queryKey: ['security', 'ldap-role-mappings'],
+    queryFn: getLdapRoleMappings,
+    onSuccess: (data: LdapRoleMapping[]) => {
+      setRoleMappings(data);
+      const drafts = data.reduce<Record<string, { groupName: string; roleName: string }>>((acc, mapping) => {
+        acc[mapping.id] = { groupName: mapping.groupName, roleName: mapping.roleName };
+        return acc;
+      }, {});
+      setMappingDrafts(drafts);
+    }
+  });
+
+  const auditQuery = useQuery({
+    queryKey: ['audit', 'security'],
+    queryFn: async () => {
+      const responses = await Promise.all(SECURITY_AUDIT_TYPES.map((type) => getAuditLogs(type)));
+      return responses.flat().sort((a, b) => new Date(b.performedAtUtc).getTime() - new Date(a.performedAtUtc).getTime());
+    }
+  });
+
+  const summaryQuery = useQuery({
+    queryKey: ['security', 'summary'],
+    queryFn: getSecuritySummary,
+    refetchInterval: 60000
+  });
+  const summary = summaryQuery.data;
+
+  const renderStatusPill = (label: string, active: boolean) => (
+    <span
+      key={label}
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+        active
+          ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-100'
+          : 'bg-amber-100 text-amber-800 dark:bg-amber-900/60 dark:text-amber-100'
+      }`}
+    >
+      <span aria-hidden>{active ? '✅' : '⚠️'}</span>
+      {label}
+    </span>
+  );
+
+  const formatChange = (change?: SecuritySummary['oidcLastChange']) => {
+    if (!change || !change.timestampUtc) {
+      return '—';
+    }
+    const date = new Date(change.timestampUtc);
+    return `${date.toLocaleString()} • ${change.actor ?? 'neznámý uživatel'}`;
+  };
+
+  const showFlash = (message: FlashMessage) => {
+    setFlash(message);
+    window.setTimeout(() => setFlash(null), 5000);
+  };
+
+  const oidcMutation = useMutation({
+    mutationFn: updateOidcConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'oidc'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'OIDC konfigurace byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit OIDC konfiguraci.' });
+    }
+  });
+
+  const ldapMutation = useMutation({
+    mutationFn: updateLdapConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'LDAP konfigurace byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit LDAP konfiguraci.' });
+    }
+  });
+
+  const ssprMutation = useMutation({
+    mutationFn: updateSsprConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'sspr'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'SSPR nastavení byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit SSPR nastavení.' });
+    }
+  });
+
+  const captchaMutation = useMutation({
+    mutationFn: updateCaptchaConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'captcha'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'CAPTCHA nastavení bylo uloženo.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit CAPTCHA nastavení.' });
+    }
+  });
+
+  const smsMutation = useMutation({
+    mutationFn: updateSmsConfiguration,
+    onSuccess: (data: SmsConnectorConfiguration) => {
+      setSmsState(data);
+      setSmsSecretInput('');
+      setSmsRotateSecret(false);
+      queryClient.invalidateQueries({ queryKey: ['security', 'sms'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'SMS konektor byl uložen.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit SMS konektor.' });
+    }
+  });
+
+  const passwordPolicyMutation = useMutation({
+    mutationFn: updatePasswordPolicyConfiguration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'password-policy'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      queryClient.invalidateQueries({ queryKey: ['security', 'summary'] });
+      showFlash({ type: 'success', message: 'Politika hesel byla uložena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se uložit politiku hesel.' });
+    }
+  });
+
+  const revokeSessionMutation = useMutation({
+    mutationFn: ({ sessionId, reason }: { sessionId: string; reason?: string }) => revokeSession(sessionId, reason),
+    onSuccess: () => {
+      if (selectedUser?.id) {
+        queryClient.invalidateQueries({ queryKey: ['security', 'sessions', selectedUser.id] });
+      }
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Sezení bylo odhlášeno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odhlásit sezení.' });
+    }
+  });
+
+  const revokeAllSessionsMutation = useMutation({
+    mutationFn: revokeAllSessions,
+    onSuccess: () => {
+      if (selectedUser?.id) {
+        queryClient.invalidateQueries({ queryKey: ['security', 'sessions', selectedUser.id] });
+      }
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Všechna sezení byla odhlášena.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odhlásit všechna sezení.' });
+    }
+  });
+
+  const createMappingMutation = useMutation({
+    mutationFn: createLdapRoleMapping,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo přidáno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se přidat mapování.' });
+    }
+  });
+
+  const updateMappingMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { groupName: string; roleName: string } }) =>
+      updateLdapRoleMapping(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo aktualizováno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se aktualizovat mapování.' });
+    }
+  });
+
+  const deleteMappingMutation = useMutation({
+    mutationFn: deleteLdapRoleMapping,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['security', 'ldap-role-mappings'] });
+      queryClient.invalidateQueries({ queryKey: ['audit', 'security'] });
+      showFlash({ type: 'success', message: 'Mapování bylo odstraněno.' });
+    },
+    onError: (error: unknown) => {
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'Nepodařilo se odstranit mapování.' });
+    }
+  });
+
+  const ldapTestMutation = useMutation({
+    mutationFn: testLdapConnection,
+    onSuccess: (data) => {
+      setLdapTestResult(data);
+      showFlash({ type: 'success', message: 'Test LDAP připojení dokončen.' });
+    },
+    onError: (error: unknown) => {
+      setLdapTestResult(null);
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'LDAP test selhal.' });
+    }
+  });
+
+  const ldapDryRunMutation = useMutation({
+    mutationFn: dryRunLdap,
+    onSuccess: (data) => {
+      setLdapDryRunResult(data);
+      showFlash({ type: 'success', message: 'LDAP dry-run byl úspěšný.' });
+    },
+    onError: (error: unknown) => {
+      setLdapDryRunResult(null);
+      showFlash({ type: 'error', message: error instanceof Error ? error.message : 'LDAP dry-run selhal.' });
+    }
+  });
+
+  const handleOidcSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const payload: OidcConfiguration = {
+      ...oidcState,
+      scopes: scopesInput.split(/\s+/).map((scope) => scope.trim()).filter(Boolean),
+      claimMappings: parseClaimMappings(claimMappingsInput)
+    };
+    oidcMutation.mutate(payload);
+  };
+
+  const handleLdapSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmedFilter = ldapState.form.usersFilter?.trim();
+    const payload: LdapConfigurationRequest = {
+      ...ldapState.form,
+      usersBaseDn: ldapState.form.usersBaseDn.trim(),
+      usersFilter: trimmedFilter ? trimmedFilter : undefined,
+      attributeMap: parseList(ldapAttributeMapInput),
+      password: ldapState.form.password ? ldapState.form.password : undefined
+    };
+    ldapMutation.mutate(payload);
+  };
+
+  const handleSsprSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const payload: SsprConfiguration = {
+      ...ssprState,
+      smsConnectorKey: ssprState.smsConnectorKey?.trim() ? ssprState.smsConnectorKey.trim() : undefined
+    };
+    ssprMutation.mutate(payload);
+  };
+
+  const handlePasswordPolicySubmit = (event: FormEvent) => {
+    event.preventDefault();
+    passwordPolicyMutation.mutate({ ...passwordPolicyState });
+  };
+
+  const handleCaptchaSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const secret = captchaSecretInput.trim();
+    const payload: CaptchaConfigurationRequest = {
+      enabled: captchaState.enabled,
+      siteKey: captchaState.siteKey.trim(),
+      verificationEndpoint: captchaState.verificationEndpoint.trim(),
+      secret: secret ? secret : undefined,
+      rotateSecret: captchaRotateSecret || (!!secret && !captchaState.hasSecret),
+      bypassToken: captchaState.bypassToken?.trim() ? captchaState.bypassToken.trim() : undefined
+    };
+    captchaMutation.mutate(payload);
+  };
+
+  const handleSmsSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const secret = smsSecretInput.trim();
+    const payload: SmsConnectorRequest = {
+      alias: smsState.alias?.trim() ? smsState.alias.trim() : 'Primary SMS',
+      enabled: smsState.enabled,
+      endpoint: smsState.endpoint.trim(),
+      sender: smsState.sender && smsState.sender.toString().trim() ? smsState.sender.toString().trim() : undefined,
+      region: smsState.region && smsState.region.toString().trim() ? smsState.region.toString().trim() : undefined,
+      secret: secret ? secret : undefined,
+      rotateSecret: smsRotateSecret || (!!secret && !smsState.hasSecret)
+    };
+    smsMutation.mutate(payload);
+  };
+
+  const handleAddMapping = (event: FormEvent) => {
+    event.preventDefault();
+    const groupName = newMapping.groupName.trim();
+    if (!groupName) {
+      showFlash({ type: 'error', message: 'Zadejte název AD skupiny.' });
+      return;
+    }
+    createMappingMutation.mutate({ groupName, roleName: newMapping.roleName });
+    setNewMapping({ groupName: '', roleName: ROLE_OPTIONS[0].value });
+  };
+
+  const handleMappingDraftChange = (id: string, field: 'groupName' | 'roleName', value: string) => {
+    setMappingDrafts((current) => ({
+      ...current,
+      [id]: {
+        ...(current[id] ?? { groupName: '', roleName: ROLE_OPTIONS[0].value }),
+        [field]: value
+      }
+    }));
+  };
+
+  const handleSaveMapping = (id: string) => {
+    const draft = mappingDrafts[id];
+    if (!draft) {
+      return;
+    }
+    const groupName = draft.groupName.trim();
+    if (!groupName) {
+      showFlash({ type: 'error', message: 'Zadejte název AD skupiny.' });
+      return;
+    }
+    updateMappingMutation.mutate({ id, data: { groupName, roleName: draft.roleName } });
+  };
+
+  const handleDeleteMapping = (id: string) => {
+    deleteMappingMutation.mutate(id);
+  };
+
+  useEffect(() => {
+    if (ldapMutation.isSuccess) {
+      setLdapState((current) => ({
+        form: { ...current.form, password: '', resetPassword: false },
+        hasPassword: current.form.password ? true : current.hasPassword
+      }));
+    }
+  }, [ldapMutation.isSuccess]);
+
+  const securityAuditEntries = useMemo(() => auditQuery.data ?? [], [auditQuery.data]);
+
+  const renderAuditDetails = (entry: AuditLogEntry) => {
+    if (!entry.changedFieldsJson) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(entry.changedFieldsJson);
+      return <pre className="mt-2 whitespace-pre-wrap rounded bg-slate-900/80 p-3 text-xs text-slate-100">{JSON.stringify(parsed, null, 2)}</pre>;
+    } catch (error) {
+      return <pre className="mt-2 whitespace-pre-wrap rounded bg-slate-900/80 p-3 text-xs text-slate-100">{entry.changedFieldsJson}</pre>;
+    }
+  };
+
+  const handleSelectUser = (user: UserSummary) => {
+    setSelectedUser(user);
+    setRevokeReason('');
+    queryClient.invalidateQueries({ queryKey: ['security', 'sessions', user.id] });
+  };
+
+  const handleRevokeSession = (sessionId: string) => {
+    revokeSessionMutation.mutate({ sessionId, reason: revokeReason.trim() ? revokeReason.trim() : undefined });
+  };
+
+  const handleRevokeAllSessions = () => {
+    if (selectedUser) {
+      revokeAllSessionsMutation.mutate(selectedUser.id);
+    }
+  };
+
+  const userResults = userSearchQuery.data ?? [];
+  const sessions = sessionsQuery.data ?? [];
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Bezpečnostní nastavení</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{headerDescription}</p>
+      </header>
+
+      {flash && (
+        <div
+          className={`rounded-md border px-4 py-3 text-sm ${
+            flash.type === 'success'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-100'
+              : 'border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-100'
+          }`}
+        >
+          {flash.message}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Bezpečnostní přehled</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Shrnutí stavu kritických integrací a připravenosti prostředí. Data se každou minutu automaticky aktualizují.
+            </p>
+          </div>
+          <div
+            className={`rounded-full px-4 py-2 text-sm font-semibold ${summary?.criticalReady ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-100' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/60 dark:text-amber-100'}`}
+          >
+            {summary?.criticalReady ? 'Průvodce splněn' : 'Ještě zbývá dokončit'}
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {renderStatusPill('OIDC', !!summary?.oidcEnabled)}
+          {renderStatusPill('LDAP', !!summary?.ldapEnabled)}
+          {renderStatusPill('SSPR', !!summary?.ssprEnabled)}
+          {renderStatusPill('CAPTCHA', !!summary?.captchaEnabled)}
+          {renderStatusPill('SMS konektor', !!summary?.smsEnabled)}
+          {renderStatusPill('Password policy', !!summary?.passwordPolicyEnabled)}
+        </div>
+        <dl className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Uživatelé s 2FA</dt>
+            <dd className="text-lg font-semibold text-slate-900 dark:text-white">
+              {summary ? `${summary.twoFactorUsers} / ${summary.totalUsers}` : '…'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Uzamčené účty</dt>
+            <dd className="text-lg font-semibold text-slate-900 dark:text-white">{summary ? summary.lockedOutUsers : '…'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Poslední změna OIDC</dt>
+            <dd className="text-sm text-slate-600 dark:text-slate-300">{formatChange(summary?.oidcLastChange)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Poslední změna LDAP</dt>
+            <dd className="text-sm text-slate-600 dark:text-slate-300">{formatChange(summary?.ldapLastChange)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Poslední změna SSPR</dt>
+            <dd className="text-sm text-slate-600 dark:text-slate-300">{formatChange(summary?.ssprLastChange)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Poslední změna policy</dt>
+            <dd className="text-sm text-slate-600 dark:text-slate-300">{formatChange(summary?.passwordPolicyLastChange)}</dd>
+          </div>
+        </dl>
+        {summaryQuery.isLoading && (
+          <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">Načítání bezpečnostního přehledu…</p>
+        )}
+        {summaryQuery.isError && (
+          <p className="mt-4 text-xs text-rose-500">Nepodařilo se načíst bezpečnostní přehled.</p>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleOidcSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">SSO / OIDC</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Konfigurace OpenID Connect přihlášení.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={oidcState.enabled}
+                onChange={(event) => setOidcState((state) => ({ ...state, enabled: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit OIDC
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Authority URL
+              <input
+                value={oidcState.authority}
+                onChange={(event) => setOidcState((state) => ({ ...state, authority: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://login.example.com"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Client ID
+              <input
+                value={oidcState.clientId}
+                onChange={(event) => setOidcState((state) => ({ ...state, clientId: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="hw-inventory"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Client secret
+              <input
+                value={oidcState.clientSecret ?? ''}
+                onChange={(event) => setOidcState((state) => ({ ...state, clientSecret: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="••••••"
+                type="password"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Response type
+              <input
+                value={oidcState.responseType ?? 'code'}
+                onChange={(event) => setOidcState((state) => ({ ...state, responseType: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="code"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Scope hodnoty
+              <input
+                value={scopesInput}
+                onChange={(event) => setScopesInput(event.target.value)}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="openid profile email"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Claim mapování (key=value)
+              <textarea
+                value={claimMappingsInput}
+                onChange={(event) => setClaimMappingsInput(event.target.value)}
+                className="mt-1 h-24 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+          </div>
+
+          <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={oidcState.usePkce}
+              onChange={(event) => setOidcState((state) => ({ ...state, usePkce: event.target.checked }))}
+              className="h-4 w-4"
+            />
+            Použít PKCE
+          </label>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={oidcMutation.isPending}
+            >
+              {oidcMutation.isPending ? 'Ukládám…' : 'Uložit OIDC' }
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleLdapSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">LDAP / AD</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Základní připojení a mapování atributů.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.enabled}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, enabled: event.target.checked }
+                  }))
+                }
+                className="h-4 w-4"
+              />
+              Povolit LDAP synchronizaci
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Host
+              <input
+                value={ldapState.form.host}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, host: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="ldap.example.com"
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Port
+              <input
+                type="number"
+                value={ldapState.form.port}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, port: Number(event.target.value) }
+                  }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Bind DN
+              <input
+                value={ldapState.form.bindDn}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, bindDn: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="CN=Service,OU=Accounts,DC=example,DC=com"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Heslo
+              <input
+                type="password"
+                value={ldapState.form.password ?? ''}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, password: event.target.value }
+                  }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder={ldapState.hasPassword ? '••••••' : 'Zadejte heslo'}
+              />
+              <label className="mt-2 inline-flex items-center gap-2 text-xs font-normal text-slate-500 dark:text-slate-400">
+                <input
+                  type="checkbox"
+                  checked={ldapState.form.resetPassword}
+                  onChange={(event) =>
+                    setLdapState((state) => ({
+                      ...state,
+                      form: { ...state.form, resetPassword: event.target.checked }
+                    }))
+                  }
+                  className="h-4 w-4"
+                />
+                Resetovat uložené heslo (ponechá prázdné)
+              </label>
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.useSsl}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, useSsl: event.target.checked } }))}
+                className="h-4 w-4"
+              />
+              Použít LDAPS / SSL
+            </label>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ldapState.form.ignoreCertificateErrors}
+                onChange={(event) =>
+                  setLdapState((state) => ({
+                    ...state,
+                    form: { ...state.form, ignoreCertificateErrors: event.target.checked }
+                  }))
+                }
+                className="h-4 w-4"
+              />
+              Ignorovat chyby certifikátu
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Base DN pro uživatele
+              <input
+                value={ldapState.form.usersBaseDn}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, usersBaseDn: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="OU=Users,DC=example,DC=com"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Filtr uživatelů
+              <input
+                value={ldapState.form.usersFilter ?? ''}
+                onChange={(event) => setLdapState((state) => ({ ...state, form: { ...state.form, usersFilter: event.target.value } }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="(objectClass=person)"
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+            Mapování atributů (každý řádek: attribute)
+            <textarea
+              value={ldapAttributeMapInput}
+              onChange={(event) => setLdapAttributeMapInput(event.target.value)}
+              className="mt-1 h-28 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder={'displayName\nmail\ndepartment'}
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={ldapMutation.isPending}
+            >
+              {ldapMutation.isPending ? 'Ukládám…' : 'Uložit LDAP'}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+              onClick={() =>
+                ldapTestMutation.mutate({
+                  host: ldapState.form.host,
+                  port: ldapState.form.port,
+                  useSsl: ldapState.form.useSsl,
+                  bindDn: ldapState.form.bindDn,
+                  password: ldapState.form.password || undefined,
+                  ignoreCertificateErrors: ldapState.form.ignoreCertificateErrors
+                })
+              }
+              disabled={ldapTestMutation.isPending}
+            >
+              {ldapTestMutation.isPending ? 'Testuji…' : 'Test připojení'}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+              onClick={() =>
+                ldapDryRunMutation.mutate({
+                  connection: {
+                    host: ldapState.form.host,
+                    port: ldapState.form.port,
+                    useSsl: ldapState.form.useSsl,
+                    bindDn: ldapState.form.bindDn,
+                    password: ldapState.form.password || undefined,
+                    ignoreCertificateErrors: ldapState.form.ignoreCertificateErrors
+                  },
+                  usersBaseDn: ldapState.form.usersBaseDn,
+                  usersFilter: ldapState.form.usersFilter || undefined,
+                  attributeMap: parseList(ldapAttributeMapInput),
+                  resultLimit: 20
+                })
+              }
+              disabled={ldapDryRunMutation.isPending}
+            >
+              {ldapDryRunMutation.isPending ? 'Spouštím…' : 'Dry-run náhled'}
+            </button>
+          </div>
+
+          {ldapTestResult && (
+            <div className={`rounded-md border px-4 py-3 text-sm ${ldapTestResult.success ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-100' : 'border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-100'}`}>
+              <p className="font-medium">Výsledek testu: {ldapTestResult.message}</p>
+              {ldapTestResult.diagnostics && (
+                <pre className="mt-2 whitespace-pre-wrap text-xs text-slate-600 dark:text-slate-300">
+                  {JSON.stringify(ldapTestResult.diagnostics, null, 2)}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {ldapDryRunResult && (
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100">
+              <p className="font-medium">
+                Dry-run: {ldapDryRunResult.resultCount} záznamů{ldapDryRunResult.truncated ? ' (výsledek zkrácen)' : ''}
+              </p>
+              {ldapDryRunResult.notes && <p className="mt-1 text-xs text-slate-500">{ldapDryRunResult.notes}</p>}
+              <div className="mt-3 space-y-3">
+                {ldapDryRunResult.users.map((user) => (
+                  <div key={user.distinguishedName} className="rounded border border-slate-200 bg-white p-3 text-xs dark:border-slate-700 dark:bg-slate-900">
+                    <p className="font-semibold text-slate-700 dark:text-slate-200">{user.distinguishedName}</p>
+                    <pre className="mt-2 whitespace-pre-wrap text-[11px] text-slate-600 dark:text-slate-300">
+                      {JSON.stringify(user.attributes, null, 2)}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleSsprSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Self-service reset hesla (SSPR)</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Ovládá proces obnovy hesla pro lokální účty.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.enabled}
+                onChange={(event) => setSsprState((state) => ({ ...state, enabled: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit SSPR
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireTwoFactor}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireTwoFactor: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Vyžadovat 2FA před odesláním resetu
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireCaptcha}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireCaptcha: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Vyžadovat CAPTCHA
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={ssprState.requireSmsOtp}
+                onChange={(event) => setSsprState((state) => ({ ...state, requireSmsOtp: event.target.checked }))}
+                className="h-4 w-4"
+              />
+              Povolit SMS OTP
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Expirace tokenu (minuty)
+              <input
+                type="number"
+                value={ssprState.tokenExpiryMinutes}
+                onChange={(event) => setSsprState((state) => ({ ...state, tokenExpiryMinutes: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={5}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Okno throttlingu (minuty)
+              <input
+                type="number"
+                value={ssprState.throttleWindowMinutes}
+                onChange={(event) => setSsprState((state) => ({ ...state, throttleWindowMinutes: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Max. požadavků v okně
+              <input
+                type="number"
+                value={ssprState.maxRequestsPerWindow}
+                onChange={(event) => setSsprState((state) => ({ ...state, maxRequestsPerWindow: Number(event.target.value) }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                min={1}
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+            SMS konektor (alias)
+            <input
+              value={ssprState.smsConnectorKey ?? ''}
+              onChange={(event) => setSsprState((state) => ({ ...state, smsConnectorKey: event.target.value }))}
+              className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="sms-primary"
+            />
+          </label>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={ssprMutation.isPending}
+            >
+              {ssprMutation.isPending ? 'Ukládám…' : 'Uložit SSPR'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handlePasswordPolicySubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Politika hesel a uzamykání účtů</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Spravujte minimální požadavky na hesla, expiraci a reakci na opakované neúspěšné pokusy.
+              </p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.enabled}
+                onChange={(event) => setPasswordPolicyState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              Vynucovat politiku hesel
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Minimální délka hesla
+              <input
+                type="number"
+                min={6}
+                value={passwordPolicyState.minimumLength}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, minimumLength: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Expirace hesla (dny, 0 = bez expirace)
+              <input
+                type="number"
+                min={0}
+                value={passwordPolicyState.expirationDays}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, expirationDays: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Historie hesel (počet uchovaných)
+              <input
+                type="number"
+                min={0}
+                value={passwordPolicyState.historyCount}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, historyCount: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Uzamknout po (počet pokusů)
+              <input
+                type="number"
+                min={1}
+                value={passwordPolicyState.lockoutAttempts}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, lockoutAttempts: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Doba uzamčení (minuty)
+              <input
+                type="number"
+                min={1}
+                value={passwordPolicyState.lockoutDurationMinutes}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, lockoutDurationMinutes: Number(event.target.value) }))
+                }
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireUppercase}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireUppercase: event.target.checked }))
+                }
+              />
+              Vyžadovat velká písmena
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireLowercase}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireLowercase: event.target.checked }))
+                }
+              />
+              Vyžadovat malá písmena
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireDigit}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireDigit: event.target.checked }))
+                }
+              />
+              Vyžadovat číslice
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={passwordPolicyState.requireNonAlphanumeric}
+                onChange={(event) =>
+                  setPasswordPolicyState((state) => ({ ...state, requireNonAlphanumeric: event.target.checked }))
+                }
+              />
+              Vyžadovat speciální znak
+            </label>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={passwordPolicyMutation.isPending}
+            >
+              {passwordPolicyMutation.isPending ? 'Ukládám…' : 'Uložit politiku hesel'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleCaptchaSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">CAPTCHA a ochrana formulářů</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Definujte CAPTCHA konektor použitý pro přihlášení a SSPR.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={captchaState.enabled}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              CAPTCHA povolena
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Site key
+              <input
+                value={captchaState.siteKey}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, siteKey: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="public-site-key"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Verifikační endpoint
+              <input
+                value={captchaState.verificationEndpoint}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, verificationEndpoint: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://captcha.example.com/verify"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Bypass token (pro podporu)
+              <input
+                value={captchaState.bypassToken ?? ''}
+                onChange={(event) => setCaptchaState((state) => ({ ...state, bypassToken: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="DEV-BYPASS"
+              />
+            </label>
+            <div className="space-y-2">
+              <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={captchaRotateSecret}
+                  onChange={(event) => setCaptchaRotateSecret(event.target.checked)}
+                />
+                Obnovit tajný klíč (aktuálně {captchaState.hasSecret ? 'nastaven' : 'není nastaven'})
+              </label>
+              <input
+                type="password"
+                value={captchaSecretInput}
+                onChange={(event) => setCaptchaSecretInput(event.target.value)}
+                disabled={!captchaRotateSecret && captchaState.hasSecret}
+                className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:disabled:bg-slate-800/60"
+                placeholder="Nový tajný klíč"
+              />
+            </div>
+          </div>
+
+          {captchaQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst aktuální nastavení CAPTCHA.</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={captchaMutation.isPending || captchaQuery.isLoading}
+            >
+              {captchaMutation.isPending ? 'Ukládám…' : 'Uložit CAPTCHA'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form onSubmit={handleSmsSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">SMS konektor</h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">Používá se pro zasílání OTP a notifikací.</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={smsState.enabled}
+                onChange={(event) => setSmsState((state) => ({ ...state, enabled: event.target.checked }))}
+              />
+              Aktivní konektor
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Alias konektoru
+              <input
+                value={smsState.alias ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, alias: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="primary-sms"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Endpoint URL
+              <input
+                value={smsState.endpoint}
+                onChange={(event) => setSmsState((state) => ({ ...state, endpoint: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="https://sms-gateway.example.com/send"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Sender ID
+              <input
+                value={smsState.sender ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, sender: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="HWINVENTORY"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Region / poznámka
+              <input
+                value={smsState.region ?? ''}
+                onChange={(event) => setSmsState((state) => ({ ...state, region: event.target.value }))}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="EU"
+              />
+            </label>
+          </div>
+
+          <div className="space-y-2">
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={smsRotateSecret}
+                onChange={(event) => setSmsRotateSecret(event.target.checked)}
+              />
+              Obnovit API token (aktuálně {smsState.hasSecret ? 'nastaven' : 'není nastaven'})
+            </label>
+            <input
+              type="password"
+              value={smsSecretInput}
+              onChange={(event) => setSmsSecretInput(event.target.value)}
+              disabled={!smsRotateSecret && smsState.hasSecret}
+              className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:disabled:bg-slate-800/60"
+              placeholder="Nový API token"
+            />
+          </div>
+
+          {smsQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst konfiguraci SMS konektoru.</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+              disabled={smsMutation.isPending || smsQuery.isLoading}
+            >
+              {smsMutation.isPending ? 'Ukládám…' : 'Uložit SMS konektor'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {variant === 'full' && (
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Správa aktivních relací</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Vyhledejte uživatele, zobrazte jeho aktivní relace a případně je ukončete. Všechny zásahy se zapisují do auditu.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
+          <div className="space-y-3">
+            <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+              Vyhledat uživatele (jméno, e-mail nebo login)
+              <input
+                value={sessionSearchTerm}
+                onChange={(event) => setSessionSearchTerm(event.target.value)}
+                className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                placeholder="např. jana.novakova"
+              />
+            </label>
+            {normalizedSearchTerm.length === 1 && (
+              <p className="text-xs text-slate-500 dark:text-slate-400">Pro vyhledávání zadejte alespoň 2 znaky.</p>
+            )}
+            <div className="max-h-60 space-y-2 overflow-y-auto rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+              {userSearchQuery.isLoading ? (
+                <p className="text-sm text-slate-500 dark:text-slate-400">Načítám uživatele…</p>
+              ) : userResults.length === 0 ? (
+                <p className="text-sm text-slate-500 dark:text-slate-400">Žádný uživatel neodpovídá zadaným kritériím.</p>
+              ) : (
+                userResults.map((user) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => handleSelectUser(user)}
+                    className={`flex w-full flex-col rounded border px-3 py-2 text-left text-sm transition ${
+                      selectedUser?.id === user.id
+                        ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-500 dark:bg-sky-900/40 dark:text-sky-100'
+                        : 'border-slate-200 hover:border-sky-400 hover:bg-slate-50 dark:border-slate-700 dark:hover:border-sky-500 dark:hover:bg-slate-800'
+                    }`}
+                  >
+                    <span className="font-semibold">{user.displayName}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{user.email || 'bez e-mailu'}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{user.userName}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="rounded border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+            {selectedUser ? (
+              <div className="space-y-2">
+                <p className="font-semibold text-slate-900 dark:text-slate-100">Vybraný uživatel</p>
+                <p>
+                  {selectedUser.displayName}
+                  <br />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{selectedUser.email || 'bez e-mailu'}</span>
+                  <br />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{selectedUser.userName}</span>
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setSelectedUser(null)}
+                  className="rounded border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+                >
+                  Zrušit výběr
+                </button>
+              </div>
+            ) : (
+              <p className="text-slate-500 dark:text-slate-400">Zvolte uživatele ze seznamu vlevo.</p>
+            )}
+          </div>
+        </div>
+
+        {selectedUser && (
+          <div className="mt-6 space-y-4">
+            <div className="grid gap-4 md:grid-cols-[2fr,1fr]">
+              <label className="flex flex-col text-sm font-medium text-slate-700 dark:text-slate-200">
+                Důvod odhlášení (uloží se do auditu)
+                <input
+                  value={revokeReason}
+                  onChange={(event) => setRevokeReason(event.target.value)}
+                  className="mt-1 rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                  placeholder="např. porušení politiky"
+                />
+              </label>
+              <div className="flex items-end justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleRevokeAllSessions}
+                  disabled={revokeAllSessionsMutation.isPending || sessions.length === 0}
+                  className="rounded border border-rose-400 px-3 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-600 dark:text-rose-300 dark:hover:bg-rose-900/40"
+                >
+                  {revokeAllSessionsMutation.isPending ? 'Odhlasuji…' : 'Odhlásit všechna sezení'}
+                </button>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto rounded border border-slate-200 dark:border-slate-700">
+              <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+                <thead className="bg-slate-50 dark:bg-slate-800">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Sezení</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Poslední aktivita</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">IP</th>
+                    <th className="px-3 py-2 text-left font-semibold text-slate-600 dark:text-slate-300">Akce</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                  {sessions.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-3 py-4 text-center text-slate-500 dark:text-slate-400">
+                        Uživatel nemá žádná aktivní sezení.
+                      </td>
+                    </tr>
+                  ) : (
+                    sessions.map((session) => (
+                      <tr key={session.id} className="bg-white text-slate-700 dark:bg-slate-900 dark:text-slate-200">
+                        <td className="px-3 py-2">
+                          <p className="font-mono text-xs">{session.sessionIdentifier}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">Vytvořeno: {new Date(session.issuedAtUtc).toLocaleString()}</p>
+                        </td>
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-300">{new Date(session.lastSeenAtUtc).toLocaleString()}</td>
+                        <td className="px-3 py-2 text-xs text-slate-600 dark:text-slate-300">{session.ipAddress ?? 'N/A'}</td>
+                        <td className="px-3 py-2 text-right">
+                          <button
+                            type="button"
+                            onClick={() => handleRevokeSession(session.id)}
+                            disabled={revokeSessionMutation.isPending}
+                            className="rounded border border-rose-400 px-3 py-1 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-600 dark:text-rose-300 dark:hover:bg-rose-900/40"
+                          >
+                            {revokeSessionMutation.isPending ? 'Odhlasuji…' : 'Odhlásit'}
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+        </section>
+      )}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Mapování AD skupin na role</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Každé mapování přiřadí uživatelům z konkrétní skupiny odpovídající roli v aplikaci. Všechny změny jsou auditovány.
+          </p>
+        </div>
+
+        <form onSubmit={handleAddMapping} className="mb-6 grid gap-4 md:grid-cols-[2fr,1fr,auto]">
+          <input
+            value={newMapping.groupName}
+            onChange={(event) => setNewMapping((state) => ({ ...state, groupName: event.target.value }))}
+            placeholder="CN=SRV-ADMINS,OU=Groups,DC=example,DC=com"
+            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          />
+          <select
+            value={newMapping.roleName}
+            onChange={(event) => setNewMapping((state) => ({ ...state, roleName: event.target.value }))}
+            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
+            disabled={createMappingMutation.isPending}
+          >
+            {createMappingMutation.isPending ? 'Přidávám…' : 'Přidat mapování'}
+          </button>
+        </form>
+
+        <div className="space-y-4">
+          {roleMappingQuery.isLoading && <p className="text-sm text-slate-500 dark:text-slate-400">Načítám mapování…</p>}
+          {roleMappingQuery.isError && (
+            <p className="text-sm text-rose-600">Nepodařilo se načíst mapování AD skupin.</p>
+          )}
+          {!roleMappingQuery.isLoading && roleMappings.length === 0 && (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Zatím není definováno žádné mapování.</p>
+          )}
+
+          {roleMappings.map((mapping) => {
+            const draft = mappingDrafts[mapping.id] ?? { groupName: mapping.groupName, roleName: mapping.roleName };
+            return (
+              <div
+                key={mapping.id}
+                className="rounded border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <div className="grid gap-4 md:grid-cols-[2fr,1fr]">
+                  <input
+                    value={draft.groupName}
+                    onChange={(event) => handleMappingDraftChange(mapping.id, 'groupName', event.target.value)}
+                    className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  />
+                  <select
+                    value={draft.roleName}
+                    onChange={(event) => handleMappingDraftChange(mapping.id, 'roleName', event.target.value)}
+                    className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  >
+                    {ROLE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mt-3 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleSaveMapping(mapping.id)}
+                    className="rounded bg-sky-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-sky-700 disabled:opacity-50"
+                    disabled={updateMappingMutation.isPending}
+                  >
+                    {updateMappingMutation.isPending ? 'Ukládám…' : 'Uložit'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteMapping(mapping.id)}
+                    className="rounded bg-rose-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-50"
+                    disabled={deleteMappingMutation.isPending}
+                  >
+                    {deleteMappingMutation.isPending ? 'Mažu…' : 'Odstranit'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Audit bezpečnostních změn</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Poslední operace na nastaveních OIDC, LDAP, SSPR, CAPTCHA, SMS a mapování rolí.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => queryClient.invalidateQueries({ queryKey: ['audit', 'security'] })}
+            className="rounded border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800"
+          >
+            Obnovit
+          </button>
+        </div>
+
+        {auditQuery.isLoading && <p className="text-sm text-slate-500 dark:text-slate-400">Načítám audit…</p>}
+        {auditQuery.isError && <p className="text-sm text-rose-600">Nepodařilo se načíst auditní záznamy.</p>}
+
+        <div className="divide-y divide-slate-200 dark:divide-slate-700">
+          {securityAuditEntries.map((entry) => (
+            <div key={entry.id} className="py-3">
+              <button
+                type="button"
+                onClick={() => setAuditExpanded((current) => (current === entry.id ? null : entry.id))}
+                className="flex w-full items-start justify-between gap-3 text-left"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    {entry.entityType} – {entry.action}
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    {new Date(entry.performedAtUtc).toLocaleString()} • {entry.performedBy}
+                  </p>
+                  {entry.changeSummary && (
+                    <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">{entry.changeSummary}</p>
+                  )}
+                </div>
+                <span className="text-xs text-slate-500 dark:text-slate-400">{auditExpanded === entry.id ? '▲' : '▼'}</span>
+              </button>
+              {auditExpanded === entry.id && renderAuditDetails(entry)}
+            </div>
+          ))}
+
+          {securityAuditEntries.length === 0 && !auditQuery.isLoading && (
+            <p className="py-4 text-sm text-slate-500 dark:text-slate-400">Zatím nejsou k dispozici žádné záznamy.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/web/src/pages/ServersPage.tsx
+++ b/src/web/src/pages/ServersPage.tsx
@@ -1,0 +1,526 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  Server,
+  ServerRequest,
+  createServer,
+  deleteServer,
+  getServers,
+  retireServer,
+  restoreServer,
+  updateServer
+} from '../api/servers';
+import { DictionaryEntry, getDictionaryEntries } from '../api/dictionaries';
+
+interface ServerFormState extends Omit<ServerRequest, 'networkAssignments'> {
+  networkAssignments: {
+    label: string;
+    vlanId?: string | null;
+    ipAddress?: string | null;
+  }[];
+}
+
+const createEmptyForm = (): ServerFormState => ({
+  name: '',
+  inventoryNumber: '',
+  manufacturer: '',
+  model: '',
+  environmentId: '',
+  wsusPriorityId: '',
+  operatingSystemId: '',
+  serverRoleId: '',
+  primaryAdministratorId: null,
+  secondaryAdministratorId: null,
+  locationId: '',
+  rackPosition: '',
+  purchasedAt: '',
+  supportUntil: '',
+  notes: '',
+  networkAssignments: [
+    { label: 'VLAN1', vlanId: null, ipAddress: '' },
+    { label: 'VLAN2', vlanId: null, ipAddress: '' },
+    { label: 'VLAN3', vlanId: null, ipAddress: '' }
+  ]
+});
+
+interface OptionGroup {
+  type: string;
+  entries: DictionaryEntry[];
+}
+
+const dictionaryTypes = [
+  'Environment',
+  'WsusPriority',
+  'OperatingSystem',
+  'ServerRole',
+  'Location',
+  'Vlan'
+];
+
+const formatDateValue = (value?: string | null) => (value ? value.substring(0, 10) : '');
+
+export const ServersPage = () => {
+  const [servers, setServers] = useState<Server[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [pageSize] = useState(25);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<ServerFormState>(() => createEmptyForm());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [dicts, setDicts] = useState<OptionGroup[]>([]);
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(totalCount / pageSize)), [totalCount, pageSize]);
+
+  const loadServers = async (pageIndex = page) => {
+    try {
+      setLoading(true);
+      const response = await getServers(pageIndex, pageSize);
+      setServers(response.items);
+      setTotalCount(response.totalCount);
+      setPage(response.page);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadDictionaries = async () => {
+    const results = await Promise.all(dictionaryTypes.map((type) => getDictionaryEntries(type)));
+    const groups = results.map((entries, index) => ({ type: dictionaryTypes[index], entries }));
+    setDicts(groups);
+  };
+
+  useEffect(() => {
+    void loadServers(1);
+    void loadDictionaries();
+  }, []);
+
+  const dictionary = (type: string) => dicts.find((x) => x.type.toLowerCase() === type.toLowerCase())?.entries ?? [];
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload: ServerRequest = {
+      ...form,
+      primaryAdministratorId: form.primaryAdministratorId || null,
+      secondaryAdministratorId: form.secondaryAdministratorId || null,
+      rackPosition: form.rackPosition || null,
+      notes: form.notes || null,
+      purchasedAt: form.purchasedAt ? new Date(form.purchasedAt).toISOString() : null,
+      supportUntil: form.supportUntil ? new Date(form.supportUntil).toISOString() : null,
+      networkAssignments: form.networkAssignments
+        .filter((assignment) => assignment.vlanId || assignment.ipAddress)
+        .map((assignment) => ({
+          label: assignment.label,
+          vlanId: assignment.vlanId || null,
+          ipAddress: assignment.ipAddress || null
+        }))
+    };
+
+    try {
+      if (editingId) {
+        await updateServer(editingId, payload);
+      } else {
+        await createServer(payload);
+      }
+      setForm(createEmptyForm());
+      setEditingId(null);
+      await loadServers(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleEdit = (server: Server) => {
+    setEditingId(server.id);
+    setForm({
+      name: server.name,
+      inventoryNumber: server.inventoryNumber,
+      manufacturer: server.manufacturer,
+      model: server.model,
+      environmentId: server.environmentId,
+      wsusPriorityId: server.wsusPriorityId,
+      operatingSystemId: server.operatingSystemId,
+      serverRoleId: server.serverRoleId,
+      primaryAdministratorId: server.primaryAdministratorId ?? null,
+      secondaryAdministratorId: server.secondaryAdministratorId ?? null,
+      locationId: server.locationId,
+      rackPosition: server.rackPosition ?? '',
+      purchasedAt: formatDateValue(server.purchasedAt),
+      supportUntil: formatDateValue(server.supportUntil),
+      notes: server.notes ?? '',
+      networkAssignments: [
+        { label: 'VLAN1', vlanId: server.networkAssignments[0]?.vlanId ?? null, ipAddress: server.networkAssignments[0]?.ipAddress ?? '' },
+        { label: 'VLAN2', vlanId: server.networkAssignments[1]?.vlanId ?? null, ipAddress: server.networkAssignments[1]?.ipAddress ?? '' },
+        { label: 'VLAN3', vlanId: server.networkAssignments[2]?.vlanId ?? null, ipAddress: server.networkAssignments[2]?.ipAddress ?? '' }
+      ]
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Opravdu chcete server smazat?')) {
+      return;
+    }
+    try {
+      await deleteServer(id);
+      await loadServers(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRetireToggle = async (server: Server) => {
+    try {
+      if (server.status === 'Retired') {
+        await restoreServer(server.id);
+      } else {
+        await retireServer(server.id);
+      }
+      await loadServers(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleResetForm = () => {
+    setForm(createEmptyForm());
+    setEditingId(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Servery</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Kompletní evidence serverů včetně vazeb na číselníky a VLAN konfiguraci.
+        </p>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="overflow-x-auto rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Název</th>
+              <th className="px-4 py-3">Inventární číslo</th>
+              <th className="px-4 py-3">Prostředí</th>
+              <th className="px-4 py-3">Lokalita</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3 text-right">Akce</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {servers.map((server) => (
+              <tr key={server.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{server.name}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{server.inventoryNumber}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{server.environmentId}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{server.locationId}</td>
+                <td className="px-4 py-3">
+                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${server.status === 'Retired' ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-700'}`}>
+                    {server.status}
+                  </span>
+                </td>
+                <td className="flex items-center justify-end gap-2 px-4 py-3">
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleEdit(server)}
+                  >
+                    Upravit
+                  </button>
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleRetireToggle(server)}
+                  >
+                    {server.status === 'Retired' ? 'Obnovit' : 'Vyřadit'}
+                  </button>
+                  <button
+                    className="rounded border border-red-300 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/40"
+                    onClick={() => handleDelete(server.id)}
+                  >
+                    Smazat
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!loading && servers.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Nebyly nalezeny žádné servery.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
+        <span>
+          Stránka {page} / {totalPages} · {totalCount} záznamů
+        </span>
+        <div className="space-x-2">
+          <button
+            disabled={page <= 1}
+            onClick={() => void loadServers(page - 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Předchozí
+          </button>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => void loadServers(page + 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Další
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {editingId ? 'Upravit server' : 'Nový server'}
+          </h3>
+          {editingId && (
+            <button type="button" onClick={handleResetForm} className="text-sm text-slate-500 underline">
+              Zrušit úpravy
+            </button>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Název</span>
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((state) => ({ ...state, name: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Inventární číslo</span>
+            <input
+              required
+              value={form.inventoryNumber}
+              onChange={(event) => setForm((state) => ({ ...state, inventoryNumber: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Výrobce</span>
+            <input
+              required
+              value={form.manufacturer}
+              onChange={(event) => setForm((state) => ({ ...state, manufacturer: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Model</span>
+            <input
+              required
+              value={form.model}
+              onChange={(event) => setForm((state) => ({ ...state, model: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Prostředí</span>
+            <select
+              required
+              value={form.environmentId}
+              onChange={(event) => setForm((state) => ({ ...state, environmentId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {dictionary('Environment').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>WSUS priorita</span>
+            <select
+              required
+              value={form.wsusPriorityId}
+              onChange={(event) => setForm((state) => ({ ...state, wsusPriorityId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {dictionary('WsusPriority').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Operační systém</span>
+            <select
+              required
+              value={form.operatingSystemId}
+              onChange={(event) => setForm((state) => ({ ...state, operatingSystemId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {dictionary('OperatingSystem').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Role/typ serveru</span>
+            <select
+              required
+              value={form.serverRoleId}
+              onChange={(event) => setForm((state) => ({ ...state, serverRoleId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {dictionary('ServerRole').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Lokalita</span>
+            <select
+              required
+              value={form.locationId}
+              onChange={(event) => setForm((state) => ({ ...state, locationId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {dictionary('Location').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Rack pozice</span>
+            <input
+              value={form.rackPosition ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, rackPosition: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Datum zakoupení</span>
+            <input
+              type="date"
+              value={form.purchasedAt ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, purchasedAt: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Podpora do</span>
+            <input
+              type="date"
+              value={form.supportUntil ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, supportUntil: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          {form.networkAssignments.map((assignment, index) => (
+            <div key={assignment.label} className="rounded border border-slate-200 p-3 dark:border-slate-700">
+              <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">{assignment.label}</h4>
+              <label className="mb-2 flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                VLAN
+                <select
+                  value={assignment.vlanId ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value || null;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], vlanId: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                >
+                  <option value="">—</option>
+                  {dictionary('Vlan').map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                IP adresa
+                <input
+                  value={assignment.ipAddress ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], ipAddress: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span>Poznámka</span>
+          <textarea
+            value={form.notes ?? ''}
+            onChange={(event) => setForm((state) => ({ ...state, notes: event.target.value }))}
+            className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            rows={3}
+          />
+        </label>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleResetForm}
+            className="rounded border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Zrušit
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+          >
+            {editingId ? 'Uložit změny' : 'Přidat server'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/web/src/pages/UpdatesPage.tsx
+++ b/src/web/src/pages/UpdatesPage.tsx
@@ -1,0 +1,268 @@
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import { downloadUpdateLog, listUpdateHistory, UpdatePackageResponse, uploadUpdatePackage } from '../api/updates';
+
+type FormState = {
+  file?: File;
+  version?: string;
+  preserveDb: boolean;
+  createBackup: boolean;
+  backupPath?: string;
+  integrityCheck: boolean;
+  confirmedBackup: boolean;
+  notes?: string;
+};
+
+const defaultState: FormState = {
+  preserveDb: true,
+  createBackup: true,
+  integrityCheck: true,
+  confirmedBackup: false
+};
+
+export function UpdatesPage() {
+  const [history, setHistory] = useState<UpdatePackageResponse[]>([]);
+  const [form, setForm] = useState<FormState>(defaultState);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [success, setSuccess] = useState<string | undefined>();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const items = await listUpdateHistory();
+        setHistory(items);
+      } catch (err) {
+        console.error(err);
+        setError('Nepodařilo se načíst historii aktualizací.');
+      }
+    })();
+  }, []);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      setForm((prev) => ({ ...prev, file: event.target.files![0] }));
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(undefined);
+    setSuccess(undefined);
+
+    if (!form.file) {
+      setError('Vyberte soubor s aktualizací.');
+      return;
+    }
+
+    if (!form.confirmedBackup && !form.createBackup) {
+      setError('Potvrďte existenci zálohy nebo zapněte vytvoření zálohy před aktualizací.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const result = await uploadUpdatePackage({
+        file: form.file,
+        version: form.version,
+        preserveDatabaseConfiguration: form.preserveDb,
+        createBackupBeforeInstall: form.createBackup,
+        backupStoragePath: form.backupPath,
+        performIntegrityCheck: form.integrityCheck,
+        confirmedBackupAvailable: form.confirmedBackup,
+        notes: form.notes
+      });
+
+      setHistory((prev) => [result, ...prev]);
+      setSuccess('Aktualizační balíček byl zařazen do fronty.');
+      setForm(defaultState);
+    } catch (err: any) {
+      console.error(err);
+      const detail = err?.response?.data?.detail ?? 'Nahrání selhalo.';
+      setError(detail);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const downloadLog = async (item: UpdatePackageResponse) => {
+    try {
+      const blob = await downloadUpdateLog(item.id);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `update-${item.version || item.id}.log`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      setError('Stažení logu selhalo.');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Aktualizace aplikace</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Nahrajte balíček ZIP/PKG s novou verzí aplikace. Systém jej uloží, ověří hash a připraví staging adresář pro následné nasazení.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-md border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Soubor aktualizace</label>
+          <input type="file" accept=".zip,.pkg" onChange={handleFileChange} className="mt-1 block w-full text-sm text-slate-700 dark:text-slate-200" required />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Verze (volitelné)</label>
+            <input
+              type="text"
+              value={form.version ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, version: e.target.value }))}
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="v1.2.3"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Cesta pro zálohu (volitelné)</label>
+            <input
+              type="text"
+              value={form.backupPath ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, backupPath: e.target.value }))}
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="C:\\Backups\\HWInventory"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Poznámka</label>
+          <textarea
+            value={form.notes ?? ''}
+            onChange={(e) => setForm((prev) => ({ ...prev, notes: e.target.value }))}
+            rows={3}
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            placeholder="Poznámky k vydání nebo postup aktualizace"
+          />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={form.preserveDb}
+              onChange={(e) => setForm((prev) => ({ ...prev, preserveDb: e.target.checked }))}
+              className="h-4 w-4"
+            />
+            Zachovat stávající DB konfiguraci
+          </label>
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={form.integrityCheck}
+              onChange={(e) => setForm((prev) => ({ ...prev, integrityCheck: e.target.checked }))}
+              className="h-4 w-4"
+            />
+            Ověřit integritu balíčku (SHA256)
+          </label>
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={form.createBackup}
+              onChange={(e) => setForm((prev) => ({ ...prev, createBackup: e.target.checked }))}
+              className="h-4 w-4"
+            />
+            Vytvořit zálohu před nasazením
+          </label>
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={form.confirmedBackup}
+              onChange={(e) => setForm((prev) => ({ ...prev, confirmedBackup: e.target.checked }))}
+              className="h-4 w-4"
+            />
+            Potvrzuji, že mám aktuální zálohu
+          </label>
+        </div>
+        {error && <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">{error}</div>}
+        {success && <div className="rounded-md border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700 dark:border-green-700 dark:bg-green-900/30 dark:text-green-200">{success}</div>}
+        <div className="flex justify-end gap-3">
+          <button
+            type="submit"
+            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white"
+            disabled={loading}
+          >
+            {loading ? 'Nahrávám…' : 'Nahrát aktualizaci'}
+          </button>
+        </div>
+      </form>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Historie aktualizačních balíčků</h3>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Přehled nahraných balíčků, včetně výsledku ověření a odkazu na log.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+            <thead className="bg-slate-50 dark:bg-slate-800">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Verze</th>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Soubor</th>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Stav</th>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Vytvořil</th>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Čas</th>
+                <th className="px-4 py-2 text-left font-medium text-slate-700 dark:text-slate-200">Akce</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              {history.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-6 text-center text-slate-500 dark:text-slate-400">
+                    Zatím nebyly nahrány žádné aktualizační balíčky.
+                  </td>
+                </tr>
+              )}
+              {history.map((item) => (
+                <tr key={item.id}>
+                  <td className="px-4 py-2 text-slate-900 dark:text-slate-100">{item.version}</td>
+                  <td className="px-4 py-2 text-slate-600 dark:text-slate-300">{item.fileName}</td>
+                  <td className="px-4 py-2">
+                    <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                      {item.status}
+                    </span>
+                    {item.failureReason && (
+                      <p className="mt-1 text-xs text-red-500">{item.failureReason}</p>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-slate-600 dark:text-slate-300">{item.createdBy}</td>
+                  <td className="px-4 py-2 text-slate-600 dark:text-slate-300">
+                    {new Date(item.createdAtUtc).toLocaleString()}
+                    {item.completedAtUtc && <div className="text-xs text-slate-500 dark:text-slate-400">Dokončeno: {new Date(item.completedAtUtc).toLocaleString()}</div>}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => downloadLog(item)}
+                        className="rounded-md border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+                      >
+                        Log
+                      </button>
+                      {item.manifestJson && (
+                        <details className="rounded-md border border-slate-200 px-3 py-1 text-xs dark:border-slate-600">
+                          <summary className="cursor-pointer text-slate-700 dark:text-slate-200">Manifest</summary>
+                          <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap text-[10px] text-slate-600 dark:text-slate-300">
+                            {item.manifestJson}
+                          </pre>
+                        </details>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/web/src/pages/WorkstationsPage.tsx
+++ b/src/web/src/pages/WorkstationsPage.tsx
@@ -1,0 +1,508 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  Workstation,
+  WorkstationRequest,
+  createWorkstation,
+  deleteWorkstation,
+  getWorkstations,
+  retireWorkstation,
+  restoreWorkstation,
+  updateWorkstation
+} from '../api/workstations';
+import { DictionaryEntry, getDictionaryEntries } from '../api/dictionaries';
+
+const dictionaryTypes = ['OperatingSystem', 'WorkstationType', 'Location', 'Vlan'];
+
+const createEmptyForm = (): WorkstationRequest => ({
+  name: '',
+  inventoryNumber: '',
+  operatingSystemId: '',
+  workstationTypeId: '',
+  ownerId: null,
+  ownerDisplayName: '',
+  ownerDepartment: '',
+  locationId: '',
+  locationNote: '',
+  cpu: '',
+  ram: '',
+  storage: '',
+  macAddress: '',
+  purchasedAt: '',
+  supportUntil: '',
+  primaryAdministratorId: null,
+  secondaryAdministratorId: null,
+  notes: '',
+  networkAssignments: [
+    { label: 'VLAN1', vlanId: null, ipAddress: '' },
+    { label: 'VLAN2', vlanId: null, ipAddress: '' },
+    { label: 'VLAN3', vlanId: null, ipAddress: '' }
+  ]
+});
+
+export const WorkstationsPage = () => {
+  const [workstations, setWorkstations] = useState<Workstation[]>([]);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(25);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<WorkstationRequest>(() => createEmptyForm());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [dictionaries, setDictionaries] = useState<Record<string, DictionaryEntry[]>>({});
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(totalCount / pageSize)), [totalCount, pageSize]);
+
+  const loadWorkstations = async (pageIndex = page) => {
+    try {
+      setLoading(true);
+      const response = await getWorkstations(pageIndex, pageSize);
+      setWorkstations(response.items);
+      setTotalCount(response.totalCount);
+      setPage(response.page);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadDictionaries = async () => {
+    const map: Record<string, DictionaryEntry[]> = {};
+    await Promise.all(
+      dictionaryTypes.map(async (type) => {
+        map[type] = await getDictionaryEntries(type);
+      })
+    );
+    setDictionaries(map);
+  };
+
+  useEffect(() => {
+    void loadWorkstations(1);
+    void loadDictionaries();
+  }, []);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const payload: WorkstationRequest = {
+      ...form,
+      ownerId: form.ownerId || null,
+      ownerDisplayName: form.ownerDisplayName || null,
+      ownerDepartment: form.ownerDepartment || null,
+      locationNote: form.locationNote || null,
+      primaryAdministratorId: form.primaryAdministratorId || null,
+      secondaryAdministratorId: form.secondaryAdministratorId || null,
+      notes: form.notes || null,
+      purchasedAt: form.purchasedAt ? new Date(form.purchasedAt).toISOString() : null,
+      supportUntil: form.supportUntil ? new Date(form.supportUntil).toISOString() : null,
+      networkAssignments: form.networkAssignments
+        .filter((assignment) => assignment.vlanId || assignment.ipAddress)
+        .map((assignment) => ({
+          label: assignment.label,
+          vlanId: assignment.vlanId || null,
+          ipAddress: assignment.ipAddress || null
+        }))
+    };
+
+    try {
+      if (editingId) {
+        await updateWorkstation(editingId, payload);
+      } else {
+        await createWorkstation(payload);
+      }
+      setForm(createEmptyForm());
+      setEditingId(null);
+      await loadWorkstations(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleEdit = (workstation: Workstation) => {
+    setEditingId(workstation.id);
+    setForm({
+      name: workstation.name,
+      inventoryNumber: workstation.inventoryNumber,
+      operatingSystemId: workstation.operatingSystemId,
+      workstationTypeId: workstation.workstationTypeId,
+      ownerId: workstation.ownerId ?? null,
+      ownerDisplayName: workstation.ownerDisplayName ?? '',
+      ownerDepartment: workstation.ownerDepartment ?? '',
+      locationId: workstation.locationId,
+      locationNote: workstation.locationNote ?? '',
+      cpu: workstation.cpu,
+      ram: workstation.ram,
+      storage: workstation.storage,
+      macAddress: workstation.macAddress,
+      purchasedAt: workstation.purchasedAt ? workstation.purchasedAt.substring(0, 10) : '',
+      supportUntil: workstation.supportUntil ? workstation.supportUntil.substring(0, 10) : '',
+      primaryAdministratorId: workstation.primaryAdministratorId ?? null,
+      secondaryAdministratorId: workstation.secondaryAdministratorId ?? null,
+      notes: workstation.notes ?? '',
+      networkAssignments: [
+        { label: 'VLAN1', vlanId: workstation.networkAssignments[0]?.vlanId ?? null, ipAddress: workstation.networkAssignments[0]?.ipAddress ?? '' },
+        { label: 'VLAN2', vlanId: workstation.networkAssignments[1]?.vlanId ?? null, ipAddress: workstation.networkAssignments[1]?.ipAddress ?? '' },
+        { label: 'VLAN3', vlanId: workstation.networkAssignments[2]?.vlanId ?? null, ipAddress: workstation.networkAssignments[2]?.ipAddress ?? '' }
+      ]
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Opravdu chcete pracovní stanici smazat?')) {
+      return;
+    }
+    try {
+      await deleteWorkstation(id);
+      await loadWorkstations(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleRetireToggle = async (workstation: Workstation) => {
+    try {
+      if (workstation.status === 'Retired') {
+        await restoreWorkstation(workstation.id);
+      } else {
+        await retireWorkstation(workstation.id);
+      }
+      await loadWorkstations(page);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleResetForm = () => {
+    setForm(createEmptyForm());
+    setEditingId(null);
+  };
+
+  const options = (type: string) => dictionaries[type] ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Pracovní stanice</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Evidence pracovních stanic, notebooků a thin klientů včetně handover agendy.
+        </p>
+      </div>
+
+      {error && <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="overflow-x-auto rounded border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 text-left font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="px-4 py-3">Název</th>
+              <th className="px-4 py-3">Inventární číslo</th>
+              <th className="px-4 py-3">Uživatel</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3 text-right">Akce</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {workstations.map((workstation) => (
+              <tr key={workstation.id} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{workstation.name}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{workstation.inventoryNumber}</td>
+                <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{workstation.ownerDisplayName ?? '—'}</td>
+                <td className="px-4 py-3">
+                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${workstation.status === 'Retired' ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-700'}`}>
+                    {workstation.status}
+                  </span>
+                </td>
+                <td className="flex items-center justify-end gap-2 px-4 py-3">
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleEdit(workstation)}
+                  >
+                    Upravit
+                  </button>
+                  <button
+                    className="rounded border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    onClick={() => handleRetireToggle(workstation)}
+                  >
+                    {workstation.status === 'Retired' ? 'Obnovit' : 'Vyřadit'}
+                  </button>
+                  <button
+                    className="rounded border border-red-300 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/40"
+                    onClick={() => handleDelete(workstation.id)}
+                  >
+                    Smazat
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!loading && workstations.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Nebyly nalezeny žádné pracovní stanice.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                  Načítám data…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-400">
+        <span>
+          Stránka {page} / {totalPages} · {totalCount} záznamů
+        </span>
+        <div className="space-x-2">
+          <button
+            disabled={page <= 1}
+            onClick={() => void loadWorkstations(page - 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Předchozí
+          </button>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => void loadWorkstations(page + 1)}
+            className="rounded border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            Další
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{editingId ? 'Upravit stanici' : 'Nová stanice'}</h3>
+          {editingId && (
+            <button type="button" onClick={handleResetForm} className="text-sm text-slate-500 underline">
+              Zrušit úpravy
+            </button>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Název</span>
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm((state) => ({ ...state, name: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Inventární číslo</span>
+            <input
+              required
+              value={form.inventoryNumber}
+              onChange={(event) => setForm((state) => ({ ...state, inventoryNumber: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Operační systém</span>
+            <select
+              required
+              value={form.operatingSystemId}
+              onChange={(event) => setForm((state) => ({ ...state, operatingSystemId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {options('OperatingSystem').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Typ stanice</span>
+            <select
+              required
+              value={form.workstationTypeId}
+              onChange={(event) => setForm((state) => ({ ...state, workstationTypeId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {options('WorkstationType').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Uživatel / vlastník</span>
+            <input
+              value={form.ownerDisplayName ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, ownerDisplayName: event.target.value }))}
+              placeholder="Jméno uživatele"
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Oddělení</span>
+            <input
+              value={form.ownerDepartment ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, ownerDepartment: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Lokalita</span>
+            <select
+              required
+              value={form.locationId}
+              onChange={(event) => setForm((state) => ({ ...state, locationId: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <option value="">Vyberte…</option>
+              {options('Location').map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Poznámka k lokaci</span>
+            <input
+              value={form.locationNote ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, locationNote: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>CPU</span>
+            <input
+              required
+              value={form.cpu}
+              onChange={(event) => setForm((state) => ({ ...state, cpu: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>RAM</span>
+            <input
+              required
+              value={form.ram}
+              onChange={(event) => setForm((state) => ({ ...state, ram: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Úložiště</span>
+            <input
+              required
+              value={form.storage}
+              onChange={(event) => setForm((state) => ({ ...state, storage: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>MAC adresa</span>
+            <input
+              required
+              value={form.macAddress}
+              onChange={(event) => setForm((state) => ({ ...state, macAddress: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 uppercase tracking-wider dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Datum zakoupení</span>
+            <input
+              type="date"
+              value={form.purchasedAt ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, purchasedAt: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Podpora do</span>
+            <input
+              type="date"
+              value={form.supportUntil ?? ''}
+              onChange={(event) => setForm((state) => ({ ...state, supportUntil: event.target.value }))}
+              className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          {form.networkAssignments.map((assignment, index) => (
+            <div key={assignment.label} className="rounded border border-slate-200 p-3 dark:border-slate-700">
+              <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">{assignment.label}</h4>
+              <label className="mb-2 flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                VLAN
+                <select
+                  value={assignment.vlanId ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value || null;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], vlanId: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                >
+                  <option value="">—</option>
+                  {options('Vlan').map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                IP adresa
+                <input
+                  value={assignment.ipAddress ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setForm((state) => {
+                      const updated = [...state.networkAssignments];
+                      updated[index] = { ...updated[index], ipAddress: value };
+                      return { ...state, networkAssignments: updated };
+                    });
+                  }}
+                  className="rounded border border-slate-300 px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800"
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span>Poznámka</span>
+          <textarea
+            value={form.notes ?? ''}
+            onChange={(event) => setForm((state) => ({ ...state, notes: event.target.value }))}
+            className="rounded border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-slate-800"
+            rows={3}
+          />
+        </label>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleResetForm}
+            className="rounded border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            Zrušit
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
+          >
+            {editingId ? 'Uložit změny' : 'Přidat stanici'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/web/src/styles.css
+++ b/src/web/src/styles.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 transition-colors duration-200;
+}
+
+[data-theme='dark'] body {
+  @apply bg-slate-900 text-slate-100;
+}

--- a/src/web/src/theme/ThemeProvider.tsx
+++ b/src/web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => undefined
+});
+
+const STORAGE_KEY = 'hw-inventory:theme';
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/src/web/tailwind.config.cjs
+++ b/src/web/tailwind.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          dark: '#1d4ed8'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/web/tsconfig.node.json
+++ b/src/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: false
+  },
+  preview: {
+    port: 4173
+  }
+});


### PR DESCRIPTION
## Summary
- add React/Vite pages for servers, network devices, and workstations with CRUD forms, VLAN/IP helpers, pagination, and integration with dictionary lookups
- surface audit, dictionary, label, and module management UIs, including label template previews, print job history, and connector-aware settings navigation updates
- document the expanded admin experience in the README, status report, and implementation plan with refreshed next-step guidance

## Testing
- not run (dotnet SDK unavailable)
- not run (node tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e519d659008324a7e28854833a88fb